### PR TITLE
fix: Grant contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     name: Build and Release
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## What

Adds `permissions: contents: write` to the release workflow job.

## Why

GitHub's default `GITHUB_TOKEN` is now read-only for new repositories. The `softprops/action-gh-release` action needs `contents: write` to create a GitHub Release and upload binary assets. Without it, every upload attempt fails with a `403`, even when the build and test steps complete successfully — which is exactly what happened on the `v0.0.2` run.

## Gotchas

- The `v0.0.2` release on GitHub may have been partially created (tag exists, release draft with no assets). Once this is merged, we'll need to either delete and re-push the `v0.0.2` tag to re-trigger the workflow, or push a new `v0.0.3` tag.
- Scoping `permissions` at the job level (rather than workflow level) keeps the blast radius minimal — only the build job gets elevated permissions, not any future jobs added to this workflow.