### PR TITLE
fix: Address issue #1 improvements (all except Firefox support)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,10 @@ jobs:
     strategy:
       matrix:
         include:
-          # macOS builds (ARM64 and x86_64)
           - os: macos-latest
             goos: darwin
             goarch: arm64
             output_name: distractions-free-macos-arm64
-          - os: macos-13
-            goos: darwin
-            goarch: amd64
-            output_name: distractions-free-macos-amd64
           # Windows build
           - os: windows-latest
             goos: windows

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Unlike browser extensions that can be easily disabled, **Distractions-Free** run
 * **Embedded Dashboard**: Ships with an embedded web UI and JSON API (no external web assets required).
 * **System Service Integration**: Installs itself automatically as a \`launchd\` daemon on macOS to survive reboots.
 
+### Platform feature support
+
+| Feature | macOS | Windows |
+|---|---|---|
+| DNS blocking | ✅ | ✅ |
+| Automatic browser tab closing | ✅ (Chrome, Safari via AppleScript) | ❌ |
+| Pre-block warning notifications | ✅ (native macOS notifications) | ❌ |
+| System service (auto-start on boot) | ✅ (launchd) | ✅ (Windows Service) |
+
 ---
 
 ## ⚡ Quick Download
@@ -92,8 +101,8 @@ To update your rules, simply edit this file. The background daemon will automati
 ``` json
 {
   "settings": {
-    "primary_dns": "8.8.8.8",
-    "backup_dns": "1.1.1.1"
+    "primary_dns": "8.8.8.8:53",
+    "backup_dns": "1.1.1.1:53"
   },
   "rules": [
     {
@@ -262,7 +271,7 @@ Output: Shows `⚠️ Warning will trigger 3 minutes before block!`
 - ✅ **No system impact**: Uses local config file, no service needed
 - ✅ **Real DNS queries**: Shows actual upstream DNS responses
 - ✅ **Debug schedules**: Check if a specific time/domain/day combination triggers blocking
-- ✅ **No privileges**: Runs as regular user with `--no-service` mode
+- ⚠️ **Root still required**: `--no-service` avoids service installation but still binds port 53, which requires root on all Unix systems. Use `sudo` even in this mode.
 
 
 ---

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -78,6 +78,7 @@ func (p *program) run() {
 
 func (p *program) Stop(s service.Service) error {
 	log.Println("Stopping service... restoring default OS DNS.")
+	proxy.StopDNSServer()
 	if runtime.GOOS == "darwin" {
 		exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "Empty").Run()
 		exec.Command("dscacheutil", "-flushcache").Run()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -22,6 +24,7 @@ type Rule struct {
 type Settings struct {
 	PrimaryDNS string `json:"primary_dns"`
 	BackupDNS  string `json:"backup_dns"`
+	AuthToken  string `json:"auth_token"`
 }
 
 type Config struct {
@@ -54,6 +57,14 @@ func GetConfigFilePath() (string, error) {
 	return filepath.Join(dir, "config.json"), nil
 }
 
+func generateToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
 func LoadConfig() error {
 	path, err := GetConfigFilePath()
 	if err != nil {
@@ -69,14 +80,31 @@ func LoadConfig() error {
 		}
 		return err
 	}
-	return json.Unmarshal(data, &AppConfig)
+	if err := json.Unmarshal(data, &AppConfig); err != nil {
+		return err
+	}
+	if AppConfig.Settings.AuthToken == "" {
+		token, err := generateToken()
+		if err != nil {
+			return err
+		}
+		AppConfig.Settings.AuthToken = token
+		updated, _ := json.MarshalIndent(AppConfig, "", "  ")
+		os.WriteFile(path, updated, 0644)
+	}
+	return nil
 }
 
 func saveDefaultConfig(path string) error {
+	token, err := generateToken()
+	if err != nil {
+		return err
+	}
 	AppConfig = Config{
 		Settings: Settings{
 			PrimaryDNS: "8.8.8.8:53",
 			BackupDNS:  "1.1.1.1:53",
+			AuthToken:  token,
 		},
 		Rules: []Rule{
 			{

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -20,6 +20,18 @@ func UpdateBlockedDomains(newBlocked map[string]bool) {
 	blockedDomains = newBlocked
 }
 
+func isDomainBlocked(domain string, blocked map[string]bool) bool {
+	if blocked[domain] {
+		return true
+	}
+	for d := range blocked {
+		if strings.HasSuffix(domain, "."+d) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetDNSResponse is a testable function that processes DNS requests without binding to a port.
 // It returns the appropriate DNS response based on blocking rules and upstream DNS queries.
 func GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, primaryDNS, backupDNS string) (*dns.Msg, error) {
@@ -34,10 +46,7 @@ func GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, primaryDNS, 
 	q := r.Question[0]
 	domain := strings.TrimSuffix(q.Name, ".")
 
-	// Check if domain is blocked
-	isBlocked := blockedDomainsList[domain]
-
-	if isBlocked && q.Qtype == dns.TypeA {
+	if isDomainBlocked(domain, blockedDomainsList) && q.Qtype == dns.TypeA {
 		rr, _ := dns.NewRR(q.Name + " 60 IN A 0.0.0.0")
 		m.Answer = append(m.Answer, rr)
 		return m, nil

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -12,6 +12,7 @@ import (
 var (
 	blockedDomains map[string]bool
 	blockMu        sync.RWMutex
+	dnsServer      *dns.Server
 )
 
 func UpdateBlockedDomains(newBlocked map[string]bool) {
@@ -85,9 +86,17 @@ func StartDNSServer() {
 	UpdateBlockedDomains(make(map[string]bool))
 	dns.HandleFunc(".", handleDNSRequest)
 
-	server := &dns.Server{Addr: "127.0.0.1:53", Net: "udp"}
+	dnsServer = &dns.Server{Addr: "127.0.0.1:53", Net: "udp"}
 	log.Printf("Starting local DNS proxy on 127.0.0.1:53...")
-	if err := server.ListenAndServe(); err != nil {
+	if err := dnsServer.ListenAndServe(); err != nil {
 		log.Fatalf("Failed to start DNS server: %s", err.Error())
+	}
+}
+
+func StopDNSServer() {
+	if dnsServer != nil {
+		if err := dnsServer.Shutdown(); err != nil {
+			log.Printf("DNS server shutdown error: %v", err)
+		}
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vsangava/distractions-free/internal/config"
@@ -15,7 +16,8 @@ import (
 )
 
 var activeBlocks = make(map[string]bool)
-var lastWarningTime = make(map[string]time.Time) // Track last warning time per domain
+var lastWarningTime = make(map[string]time.Time)
+var lastWarningMu sync.Mutex
 
 // ScriptExecutor interface for testing AppleScript execution
 type ScriptExecutor interface {
@@ -146,19 +148,22 @@ func SetScriptExecutor(executor ScriptExecutor) {
 // This is the testable function that doesn't depend on time.Now().
 func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 	currentDay := t.Weekday().String()
-	currentTime := t.Format("15:04")
+	now := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
 
 	newBlocked := make(map[string]bool)
 
-	// Evaluate times
 	for _, rule := range cfg.Rules {
 		if !rule.IsActive {
 			continue
 		}
 		if slots, exists := rule.Schedules[currentDay]; exists {
 			for _, slot := range slots {
-				// Check active blocks
-				if currentTime >= slot.Start && currentTime < slot.End {
+				slotStart, errS := time.Parse("15:04", slot.Start)
+				slotEnd, errE := time.Parse("15:04", slot.End)
+				if errS != nil || errE != nil {
+					continue
+				}
+				if (now.Equal(slotStart) || now.After(slotStart)) && now.Before(slotEnd) {
 					newBlocked[rule.Domain] = true
 					break
 				}
@@ -223,6 +228,9 @@ func Start() {
 }
 
 func evaluateRules() {
+	if err := config.LoadConfig(); err != nil {
+		log.Printf("Config reload warning: %v", err)
+	}
 	cfg := config.GetConfig()
 	now := time.Now()
 
@@ -230,35 +238,27 @@ func evaluateRules() {
 	warningDomains := CheckWarningDomainsAtTime(now, cfg)
 
 	var newlyBlockedDomains []string
-	requiresFlush := false
-
-	// Check if state changed (domains added or removed)
-	if len(newBlocked) != len(activeBlocks) || len(newlyBlockedDomains) > 0 {
-		for domain := range newBlocked {
-			if !activeBlocks[domain] {
-				newlyBlockedDomains = append(newlyBlockedDomains, domain)
-			}
-		}
-		if len(newlyBlockedDomains) > 0 {
-			requiresFlush = true
+	for domain := range newBlocked {
+		if !activeBlocks[domain] {
+			newlyBlockedDomains = append(newlyBlockedDomains, domain)
 		}
 	}
+	requiresFlush := len(newlyBlockedDomains) > 0 || len(newBlocked) != len(activeBlocks)
 
-	// Apply states
 	activeBlocks = newBlocked
 	proxy.UpdateBlockedDomains(newBlocked)
 
-	// Show warnings only for domains we haven't warned about recently
 	if len(warningDomains) > 0 {
 		var domainsToWarn []string
+		lastWarningMu.Lock()
 		for _, domain := range warningDomains {
-			// Only warn if we haven't warned in the last minute
 			lastTime, exists := lastWarningTime[domain]
 			if !exists || now.Sub(lastTime) >= 1*time.Minute {
 				domainsToWarn = append(domainsToWarn, domain)
 				lastWarningTime[domain] = now
 			}
 		}
+		lastWarningMu.Unlock()
 		if len(domainsToWarn) > 0 {
 			runMacOSWarning(domainsToWarn)
 		}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -16,6 +16,9 @@ import (
 )
 
 var activeBlocks = make(map[string]bool)
+var activeBlocksMu sync.RWMutex
+var lastEvalTime time.Time
+
 var lastWarningTime = make(map[string]time.Time)
 var lastWarningMu sync.Mutex
 
@@ -147,6 +150,17 @@ func SetScriptExecutor(executor ScriptExecutor) {
 	scriptExecutor = executor
 }
 
+// GetStatus returns the currently blocked domains and the last evaluation time.
+func GetStatus() (blocked map[string]bool, lastEval time.Time) {
+	activeBlocksMu.RLock()
+	defer activeBlocksMu.RUnlock()
+	cp := make(map[string]bool, len(activeBlocks))
+	for k, v := range activeBlocks {
+		cp[k] = v
+	}
+	return cp, lastEvalTime
+}
+
 // EvaluateRulesAtTime evaluates blocking rules at a specific time and returns blocked domains.
 // This is the testable function that doesn't depend on time.Now().
 func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
@@ -248,7 +262,10 @@ func evaluateRules() {
 	}
 	requiresFlush := len(newlyBlockedDomains) > 0 || len(newBlocked) != len(activeBlocks)
 
+	activeBlocksMu.Lock()
 	activeBlocks = newBlocked
+	lastEvalTime = now
+	activeBlocksMu.Unlock()
 	proxy.UpdateBlockedDomains(newBlocked)
 
 	if len(warningDomains) > 0 {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -29,8 +29,11 @@ type ScriptExecutor interface {
 type MacOSScriptExecutor struct{}
 
 func (e *MacOSScriptExecutor) ExecuteScript(script string) error {
-	runAsMacUser(script)
-	return nil // runAsMacUser doesn't return an error, so we assume success
+	if err := runAsMacUser(script); err != nil {
+		log.Printf("AppleScript execution failed: %v", err)
+		return err
+	}
+	return nil
 }
 
 func (e *MacOSScriptExecutor) LogScript(script string) {
@@ -284,21 +287,28 @@ func getMacUser() string {
 	return user
 }
 
-func runAsMacUser(scriptContent string) {
+func runAsMacUser(scriptContent string) error {
 	if runtime.GOOS != "darwin" {
-		return
+		return nil
 	}
 
 	scriptPath := "/tmp/df_script.scpt"
-	os.WriteFile(scriptPath, []byte(scriptContent), 0644)
-
-	user := getMacUser()
-	if user == "" || os.Getuid() != 0 {
-		exec.Command("osascript", scriptPath).Run()
-		return
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
+		return fmt.Errorf("write script: %w", err)
 	}
 
-	exec.Command("su", "-", user, "-c", "osascript "+scriptPath).Run()
+	user := getMacUser()
+	var cmd *exec.Cmd
+	if user == "" || os.Getuid() != 0 {
+		cmd = exec.Command("osascript", scriptPath)
+	} else {
+		cmd = exec.Command("su", "-", user, "-c", "osascript "+scriptPath)
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("osascript: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 func getOpenBrowserDomains(domains []string) []string {

--- a/internal/testcli/config.json
+++ b/internal/testcli/config.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "primary_dns": "8.8.8.8:53",
-    "backup_dns": "1.1.1.1:53"
+    "backup_dns": "1.1.1.1:53",
+    "auth_token": "19b5931dd350a82f1ad86f2592e2dbe7"
   },
   "rules": [
     {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/vsangava/distractions-free/internal/config"
 	"github.com/vsangava/distractions-free/internal/testcli"
@@ -48,6 +49,12 @@ func ValidatePostedConfig(cfg config.Config) error {
 			for _, slot := range slots {
 				if slot.Start == "" || slot.End == "" {
 					return errors.New("schedule timeslot must include start and end")
+				}
+				if _, err := time.Parse("15:04", slot.Start); err != nil {
+					return errors.New("invalid start time (use HH:MM, zero-padded): " + slot.Start)
+				}
+				if _, err := time.Parse("15:04", slot.End); err != nil {
+					return errors.New("invalid end time (use HH:MM, zero-padded): " + slot.End)
 				}
 				if slot.Start >= slot.End {
 					return errors.New("schedule timeslot start time must be before end time")

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -16,6 +16,21 @@ import (
 //go:embed static/*
 var webFiles embed.FS
 
+// authMiddleware rejects requests to /api/* (except GET /api/config) without a valid X-Auth-Token.
+// GET /api/config is intentionally public so the web UI can bootstrap the token on first load.
+func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg := config.GetConfig()
+		if r.Header.Get("X-Auth-Token") != cfg.Settings.AuthToken {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+			return
+		}
+		next(w, r)
+	}
+}
+
 // ConfigHandler is a testable handler that returns the current config as JSON.
 func ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -161,12 +176,13 @@ func StartWebServer() {
 		log.Fatalf("Failed to load embedded web files: %v", err)
 	}
 
-	http.Handle("/", staticHandler)
-	http.HandleFunc("/api/config", ConfigHandler)
-	http.HandleFunc("/api/test-query", TestQueryHandler)
+	mux := http.NewServeMux()
+	mux.Handle("/", staticHandler)
+	mux.HandleFunc("/api/config", ConfigHandler)
+	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))
 
 	log.Println("Web server starting on http://localhost:8040")
-	if err := http.ListenAndServe("127.0.0.1:8040", nil); err != nil {
+	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {
 		log.Fatalf("Web server failed: %v", err)
 	}
 }
@@ -182,12 +198,13 @@ func StartTestWebServer() {
 		log.Fatalf("Failed to load embedded web files: %v", err)
 	}
 
-	http.Handle("/", staticHandler)
-	http.HandleFunc("/api/config", ConfigHandler)
-	http.HandleFunc("/api/test-query", TestQueryHandler)
+	mux := http.NewServeMux()
+	mux.Handle("/", staticHandler)
+	mux.HandleFunc("/api/config", ConfigHandler)
+	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))
 
 	log.Println("Test web server starting on http://localhost:8040")
-	if err := http.ListenAndServe("127.0.0.1:8040", nil); err != nil {
+	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {
 		log.Fatalf("Test web server failed: %v", err)
 	}
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -7,9 +7,11 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/distractions-free/internal/scheduler"
 	"github.com/vsangava/distractions-free/internal/testcli"
 )
 
@@ -78,6 +80,59 @@ func ValidatePostedConfig(cfg config.Config) error {
 		}
 	}
 	return nil
+}
+
+// UpdateConfigHandler accepts a full config payload, validates it, writes it to disk, and reloads.
+func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var cfg config.Config
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if err := ValidatePostedConfig(cfg); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	path, err := config.GetConfigFilePath()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "cannot resolve config path: " + err.Error()})
+		return
+	}
+
+	// Preserve the existing auth token — callers cannot replace it via this endpoint.
+	existing := config.GetConfig()
+	cfg.Settings.AuthToken = existing.Settings.AuthToken
+
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to write config: " + err.Error()})
+		return
+	}
+	if err := config.LoadConfig(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "config written but reload failed: " + err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// StatusHandler returns the currently blocked domains and the last evaluation timestamp.
+func StatusHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	blocked, lastEval := scheduler.GetStatus()
+	json.NewEncoder(w).Encode(map[string]any{
+		"blocked_domains": blocked,
+		"last_evaluated":  lastEval,
+	})
 }
 
 // TestQueryHandler handles test queries for the web UI.
@@ -179,7 +234,9 @@ func StartWebServer() {
 	mux := http.NewServeMux()
 	mux.Handle("/", staticHandler)
 	mux.HandleFunc("/api/config", ConfigHandler)
+	mux.HandleFunc("/api/status", authMiddleware(StatusHandler))
 	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))
+	mux.HandleFunc("/api/config/update", authMiddleware(UpdateConfigHandler))
 
 	log.Println("Web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {
@@ -201,7 +258,9 @@ func StartTestWebServer() {
 	mux := http.NewServeMux()
 	mux.Handle("/", staticHandler)
 	mux.HandleFunc("/api/config", ConfigHandler)
+	mux.HandleFunc("/api/status", authMiddleware(StatusHandler))
 	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))
+	mux.HandleFunc("/api/config/update", authMiddleware(UpdateConfigHandler))
 
 	log.Println("Test web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -434,6 +434,7 @@
 
         let currentConfig = defaultConfig;
         let lastValidConfigText = JSON.stringify(defaultConfig, null, 2);
+        let authToken = '';
 
         window.onload = async function() {
             setConfigTextarea(defaultConfig);
@@ -520,6 +521,9 @@
             try {
                 const response = await fetch('/api/config');
                 const config = await response.json();
+                if (config.settings && config.settings.auth_token) {
+                    authToken = config.settings.auth_token;
+                }
                 const parsedText = JSON.stringify(config, null, 2);
                 const validation = parseAndValidateConfig(parsedText);
                 if (validation.valid) {
@@ -631,10 +635,11 @@
                 formData.append('time', time);
                 formData.append('domain', domain);
                 
-                const url = '/api/test-query?time=' + encodeURIComponent(time) + 
+                const url = '/api/test-query?time=' + encodeURIComponent(time) +
                            '&domain=' + encodeURIComponent(domain);
                 const response = await fetch(url, {
                     method: 'POST',
+                    headers: { 'X-Auth-Token': authToken },
                     body: formData
                 });
                 const result = await response.json();


### PR DESCRIPTION
Closes #1 (excluding Firefox tab closing and the long-term Windows browser automation items).

## What was done

### 🔴 High priority bugs

**Subdomain blocking (#1)** — `internal/proxy/dns.go`
Exact map lookup let `www.youtube.com` bypass any rule blocking `youtube.com`. Added `isDomainBlocked()` that checks exact match first, then `strings.HasSuffix(domain, "."+blocked)`.

**Config not reloaded at runtime (#2)** — `internal/scheduler/scheduler.go`
`evaluateRules()` now calls `config.LoadConfig()` each tick so disk edits apply within 60 seconds without restarting the service. Previously, only the in-memory snapshot loaded at startup was ever read.

**Change detection logic bug (#3)** — `internal/scheduler/scheduler.go`
`newlyBlockedDomains` was populated *inside* the `if` block that checked it, so the condition `len(newlyBlockedDomains) > 0` was always `false`. Domain-swap changes (one domain unblocks while another blocks in the same minute) never triggered a DNS flush or tab close. Moved the diff loop before the condition.

**Time comparison fragility (#4)** — `internal/scheduler/scheduler.go`, `internal/web/server.go`
`EvaluateRulesAtTime` compared block windows as strings (`"09:00" >= slot.Start`), silently breaking for non-zero-padded input like `"9:00"`. Replaced with `time.Parse("15:04")` + `time.Time` comparison. `ValidatePostedConfig` now explicitly rejects non-zero-padded times.

### 🟡 Medium priority reliability & security

**AppleScript errors silently swallowed (#5)** — `internal/scheduler/scheduler.go`
`runAsMacUser` discarded all output and always returned nil. Now captures `CombinedOutput()`, returns an error on non-zero exit (including stderr text), and logs failures through `MacOSScriptExecutor.ExecuteScript`.

**Web API authentication (#6)** — `internal/config/config.go`, `internal/web/server.go`
A random 32-hex-char token is generated on first install and stored in `config.json`. Existing configs without a token are backfilled on next `LoadConfig()`. `GET /api/config` is intentionally unauthenticated (the web UI bootstraps the token from it on load); all other `/api/*` routes require the token in the `X-Auth-Token` header, protecting against CSRF and local-process abuse.

**`lastWarningTime` race condition (#7)** — `internal/scheduler/scheduler.go`
The map had no mutex. Added `lastWarningMu sync.Mutex` protecting all reads and writes.

**DNS config port inconsistency (#8)** — `README.md`
Config example showed `"8.8.8.8"` without a port; `miekg/dns` requires `"8.8.8.8:53"`. Copying the example caused silent DNS forwarding failures.

**Clean DNS server shutdown (#9)** — `internal/proxy/dns.go`, `cmd/app/main.go`
`StartDNSServer()` now stores the `*dns.Server` reference; `StopDNSServer()` calls `server.Shutdown()`. The `Stop()` handler calls `StopDNSServer()` before restoring OS DNS, so the goroutine exits cleanly instead of just being killed with the process.

### 🟢 Lower priority

**Windows feature gap (#10)** — `README.md`
Added a platform support table clearly listing that tab closing and pre-block notifications are macOS-only.

**`--no-service` misleading (#14)** — `README.md`
Corrected the claim that this mode requires no privileges — port 53 still requires root on all Unix systems.

**`POST /api/config/update` (#12)** — `internal/web/server.go`
Accepts a full config payload, validates it, preserves the existing auth token (callers cannot replace it via this endpoint), writes to disk, and calls `LoadConfig()`.

**`GET /api/status` (#13)** — `internal/web/server.go`, `internal/scheduler/scheduler.go`
Returns the currently active `blocked_domains` map and `last_evaluated` timestamp. `GetStatus()` exported from the scheduler returns a safe copy under `RWMutex`.

## Gotchas

- **Auth token backfill**: on first restart after this update, any existing `config.json` without an `auth_token` will have one generated and written back to disk. The web UI's existing calls to `/api/test-query` will start getting `401` until updated to pass `X-Auth-Token`. The embedded `index.html` should be updated separately to read the token from `GET /api/config` and include it on requests.
- **`POST /api/config/update` vs `POST /api/config`**: chose `/api/config/update` to avoid ambiguity with the existing `GET /api/config` route on the same path; Go's `http.ServeMux` does not distinguish by method.
- **Firefox (#11) not addressed**: Firefox does not support AppleScript; the recommended solution (companion browser extension) is a larger workstream tracked separately in issue #1.