### PR TITLE
fix: Status tab shows empty when running in --test-web mode

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -126,9 +126,15 @@ func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // StatusHandler returns the currently blocked domains and the last evaluation timestamp.
+// When the scheduler is not running (e.g. --test-web mode), it evaluates rules at
+// time.Now() directly from config so the result is always meaningful.
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	blocked, lastEval := scheduler.GetStatus()
+	if lastEval.IsZero() {
+		blocked = scheduler.EvaluateRulesAtTime(time.Now(), config.GetConfig())
+		lastEval = time.Now()
+	}
 	json.NewEncoder(w).Encode(map[string]any{
 		"blocked_domains": blocked,
 		"last_evaluated":  lastEval,


### PR DESCRIPTION
## What

`GET /api/status` always returned an empty blocked-domains list in `--test-web` mode.

## Why

The endpoint read from `scheduler.activeBlocks`, which is a cache populated by the 1-minute ticker in `scheduler.Start()`. In `--test-web` mode the scheduler is intentionally not started (it would try to close browser tabs and fire notifications), so `activeBlocks` was always the zero-value empty map.

The test query worked fine because it calls `EvaluateRulesAtTime` directly — it never touches the scheduler cache.

## Fix

In `StatusHandler`, check whether `lastEvalTime` is zero. If it is, the scheduler hasn't run, so fall back to calling `EvaluateRulesAtTime(time.Now(), cfg)` on the fly. When the full service is running normally, the scheduler-populated value is used as before — keeping the status consistent with what the DNS proxy is actually enforcing.

## Gotcha

In `--test-web` mode the status now reflects *what would be blocked right now according to config*, not the live DNS proxy state (since the proxy isn't running either). This is the most useful thing to show in that mode.