### PR TITLE
fix: Status tab shows stale results in --test-web mode

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -33,9 +33,13 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// ConfigHandler is a testable handler that returns the current config as JSON.
+// ConfigHandler returns the current config as JSON, reloading from disk first so the
+// browser always sees the latest file state rather than the startup snapshot.
 func ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	if err := config.LoadConfig(); err != nil {
+		log.Printf("config reload warning: %v", err)
+	}
 	cfg := config.GetConfig()
 	json.NewEncoder(w).Encode(cfg)
 }
@@ -127,18 +131,35 @@ func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 // StatusHandler returns the currently blocked domains and the last evaluation timestamp.
 // When the scheduler is not running (e.g. --test-web mode), it evaluates rules at
-// time.Now() directly from config so the result is always meaningful.
+// time.Now() using whichever config the caller POSTs (same as test-query), falling
+// back to a fresh disk reload if no body is provided.
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	blocked, lastEval := scheduler.GetStatus()
 	if lastEval.IsZero() {
-		blocked = scheduler.EvaluateRulesAtTime(time.Now(), config.GetConfig())
+		cfg := resolveConfig(r)
+		blocked = scheduler.EvaluateRulesAtTime(time.Now(), cfg)
 		lastEval = time.Now()
 	}
 	json.NewEncoder(w).Encode(map[string]any{
 		"blocked_domains": blocked,
 		"last_evaluated":  lastEval,
 	})
+}
+
+// resolveConfig extracts a config from the request body if present, otherwise reloads
+// from disk. Used by endpoints that need the "current" config in --test-web mode.
+func resolveConfig(r *http.Request) config.Config {
+	if r.Body != nil && r.Header.Get("Content-Type") == "application/json" {
+		var posted config.Config
+		if err := json.NewDecoder(r.Body).Decode(&posted); err == nil {
+			return posted
+		}
+	}
+	if err := config.LoadConfig(); err != nil {
+		log.Printf("config reload warning: %v", err)
+	}
+	return config.GetConfig()
 }
 
 // TestQueryHandler handles test queries for the web UI.

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,10 +1,12 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/vsangava/distractions-free/internal/config"
 )
@@ -338,6 +340,95 @@ func TestConfigHandler_ValidJSONAfterMarshal(t *testing.T) {
 	_, err = json.Marshal(cfg)
 	if err != nil {
 		t.Errorf("failed to marshal config back to JSON: %v", err)
+	}
+}
+
+// TestStatusHandler_UsesPostedConfig verifies that StatusHandler evaluates blocking
+// using a config POSTed in the request body when the scheduler hasn't run (lastEvalTime
+// zero). This is the --test-web mode scenario: the user edits config in the browser
+// textarea and expects Status to reflect the same config as test-query.
+func TestStatusHandler_UsesPostedConfig(t *testing.T) {
+	now := time.Now()
+	day := now.Weekday().String()
+	start := now.Add(-1 * time.Hour).Format("15:04")
+	end := now.Add(1 * time.Hour).Format("15:04")
+
+	blocked := config.Config{
+		Settings: config.Settings{PrimaryDNS: "8.8.8.8:53", BackupDNS: "1.1.1.1:53"},
+		Rules: []config.Rule{
+			{
+				Domain:   "youtube.com",
+				IsActive: true,
+				Schedules: map[string][]config.TimeSlot{
+					day: {{Start: start, End: end}},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(blocked)
+	req, _ := http.NewRequest("POST", "/api/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	StatusHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	domains, ok := result["blocked_domains"].(map[string]any)
+	if !ok {
+		t.Fatalf("blocked_domains missing or wrong type: %v", result)
+	}
+	if domains["youtube.com"] != true {
+		t.Errorf("expected youtube.com to be blocked, got blocked_domains=%v", domains)
+	}
+}
+
+// TestStatusHandler_EmptyWhenNotBlocked verifies that a domain outside its schedule
+// window is not reported as blocked.
+func TestStatusHandler_EmptyWhenNotBlocked(t *testing.T) {
+	notBlocked := config.Config{
+		Settings: config.Settings{PrimaryDNS: "8.8.8.8:53", BackupDNS: "1.1.1.1:53"},
+		Rules: []config.Rule{
+			{
+				Domain:   "youtube.com",
+				IsActive: true,
+				Schedules: map[string][]config.TimeSlot{
+					// Window in the past — never active now
+					"Monday": {{Start: "01:00", End: "01:01"}},
+					"Tuesday": {{Start: "01:00", End: "01:01"}},
+					"Wednesday": {{Start: "01:00", End: "01:01"}},
+					"Thursday": {{Start: "01:00", End: "01:01"}},
+					"Friday": {{Start: "01:00", End: "01:01"}},
+					"Saturday": {{Start: "01:00", End: "01:01"}},
+					"Sunday": {{Start: "01:00", End: "01:01"}},
+				},
+			},
+		},
+	}
+
+	body, _ := json.Marshal(notBlocked)
+	req, _ := http.NewRequest("POST", "/api/status", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	StatusHandler(rr, req)
+
+	var result map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	domains := result["blocked_domains"].(map[string]any)
+	if domains["youtube.com"] == true {
+		t.Errorf("expected youtube.com not to be blocked outside its window")
 	}
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -519,7 +519,12 @@
             metaEl.textContent = '';
             try {
                 const response = await fetch('/api/status', {
-                    headers: { 'X-Auth-Token': authToken }
+                    method: 'POST',
+                    headers: {
+                        'X-Auth-Token': authToken,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(currentConfig)
                 });
                 if (!response.ok) {
                     contentEl.innerHTML = '<div class="error-banner">Failed to load status (is the service running?)</div>';


### PR DESCRIPTION
## Root cause

Two config staleness issues caused status to always appear empty while test query correctly showed domains as blocked.

**Issue 1 — ConfigHandler never reloaded from disk**
`config.LoadConfig()` was called once at `StartTestWebServer()` startup. `ConfigHandler` returned `config.GetConfig()` (the startup snapshot) on every subsequent call. This meant the browser textarea was frozen at startup state — editing `config.json` after starting `--test-web` was completely invisible to the web UI, even on page refresh.

**Issue 2 — StatusHandler evaluated the wrong config**
The previous fix (PR #10) made `StatusHandler` call `config.GetConfig()` when the scheduler hadn't run. This is the same stale snapshot. Meanwhile, `TestQueryHandler` uses the config POSTed in the form body (whatever's in the browser textarea). So if the user edited the Config tab textarea, test query used that edit but status did not — two different configs, inconsistent results.

## Fix

- `ConfigHandler`: calls `config.LoadConfig()` on each request, so the browser always serves the latest file state.
- `StatusHandler`: accepts the current config as a JSON POST body (same pattern as `TestQueryHandler`). The JS now POSTs `currentConfig` on every status refresh. Falls back to a fresh disk reload if no body is provided.
- Added `resolveConfig(r)` helper shared by both status and any future handlers that need the "current config" in test mode.

## Tests added

- `TestStatusHandler_UsesPostedConfig` — domain within active time window in posted config → `blocked_domains["youtube.com"] == true`
- `TestStatusHandler_EmptyWhenNotBlocked` — domain outside all schedule windows → not blocked

Both tests run without requiring the scheduler, port 53, or any system config — they test the exact code path that was broken.

## Gotcha

The status and test query are now consistent: both use whatever config is in the browser textarea. If the user edits the textarea without saving to disk via `POST /api/config/update`, status reflects the textarea state, not the disk state. This is the expected behaviour — status answers "what would be blocked right now with this config?"