### PR TITLE
Implement pause and resume for blocking rules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 )
 
 type TimeSlot struct {
@@ -40,9 +41,20 @@ func (s Settings) GetEnforcementMode() string {
 	}
 }
 
+// PauseWindow represents a temporary suspension of all blocking rules.
+type PauseWindow struct {
+	Until time.Time `json:"until"`
+}
+
 type Config struct {
-	Settings Settings `json:"settings"`
-	Rules    []Rule   `json:"rules"`
+	Settings Settings     `json:"settings"`
+	Rules    []Rule       `json:"rules"`
+	Pause    *PauseWindow `json:"pause,omitempty"`
+}
+
+// IsPaused reports whether all blocking rules are suspended at time t.
+func (c Config) IsPaused(t time.Time) bool {
+	return c.Pause != nil && t.Before(c.Pause.Until)
 }
 
 var (
@@ -114,6 +126,22 @@ func SetEnforcementMode(mode string) {
 	mu.Lock()
 	defer mu.Unlock()
 	AppConfig.Settings.EnforcementMode = mode
+}
+
+// SetPause sets a pause window that suppresses all blocking until until.
+// Call SaveConfig to persist the change to disk.
+func SetPause(until time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	AppConfig.Pause = &PauseWindow{Until: until}
+}
+
+// ClearPause removes any active pause window.
+// Call SaveConfig to persist the change to disk.
+func ClearPause() {
+	mu.Lock()
+	defer mu.Unlock()
+	AppConfig.Pause = nil
 }
 
 // SaveConfig writes the current in-memory config to disk.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -170,8 +170,13 @@ func GetStatus() (blocked map[string]bool, lastEval time.Time) {
 }
 
 // EvaluateRulesAtTime evaluates blocking rules at a specific time and returns blocked domains.
+// Returns an empty map immediately if the config has an active pause window.
 // This is the testable function that doesn't depend on time.Now().
 func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
+	if cfg.IsPaused(t) {
+		return make(map[string]bool)
+	}
+
 	currentDay := t.Weekday().String()
 	now := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
 
@@ -200,9 +205,13 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 }
 
 // CheckWarningDomainsAtTime checks if any domains should trigger warnings within 3 minutes of block start.
-// Warnings are triggered for any time within 3 minutes before a scheduled block.
+// Returns nil immediately if the config has an active pause window.
 // This is the testable function that doesn't depend on time.Now().
 func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string {
+	if cfg.IsPaused(t) {
+		return nil
+	}
+
 	currentDay := t.Weekday().String()
 
 	var warningDomains []string
@@ -258,6 +267,15 @@ func evaluateRules() {
 	}
 	cfg := config.GetConfig()
 	now := time.Now()
+
+	// Remove an expired pause so config.json stays clean.
+	if cfg.Pause != nil && !now.Before(cfg.Pause.Until) {
+		config.ClearPause()
+		if err := config.SaveConfig(); err != nil {
+			log.Printf("scheduler: clear expired pause: %v", err)
+		}
+		cfg = config.GetConfig()
+	}
 
 	newBlocked := EvaluateRulesAtTime(now, cfg)
 	warningDomains := CheckWarningDomainsAtTime(now, cfg)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -17,6 +17,8 @@ import (
 	"github.com/vsangava/distractions-free/internal/testcli"
 )
 
+const maxPauseMinutes = 240 // 4 hours
+
 //go:embed static/*
 var webFiles embed.FS
 
@@ -151,11 +153,64 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		blocked = scheduler.EvaluateRulesAtTime(time.Now(), cfg)
 		lastEval = time.Now()
 	}
-	json.NewEncoder(w).Encode(map[string]any{
+	cfg := config.GetConfig()
+	resp := map[string]any{
 		"blocked_domains":  blocked,
 		"last_evaluated":   lastEval,
-		"enforcement_mode": config.GetConfig().Settings.GetEnforcementMode(),
+		"enforcement_mode": cfg.Settings.GetEnforcementMode(),
+		"paused":           cfg.IsPaused(time.Now()),
+	}
+	if cfg.Pause != nil {
+		resp["paused_until"] = cfg.Pause.Until.Format(time.RFC3339)
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+// PauseHandler handles POST /api/pause.
+// Body: {"minutes": N} where N must be between 1 and maxPauseMinutes.
+func PauseHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var body struct {
+		Minutes int `json:"minutes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if body.Minutes <= 0 || body.Minutes > maxPauseMinutes {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "minutes must be between 1 and 240"})
+		return
+	}
+
+	until := time.Now().Add(time.Duration(body.Minutes) * time.Minute)
+	config.SetPause(until)
+	if err := config.SaveConfig(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to save config: " + err.Error()})
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":      "ok",
+		"paused_until": until.Format(time.RFC3339),
 	})
+}
+
+// ResumeHandler handles DELETE /api/pause, clearing any active pause immediately.
+func ResumeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	config.ClearPause()
+	if err := config.SaveConfig(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to save config: " + err.Error()})
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // resolveConfig extracts a config from the request body if present, otherwise reloads
@@ -329,6 +384,16 @@ func StartWebServer() {
 	mux.HandleFunc("/api/config/update", authMiddleware(UpdateConfigHandler))
 	mux.HandleFunc("/api/hosts-preview", authMiddleware(HostsPreviewHandler))
 	mux.HandleFunc("/api/pf-preview", authMiddleware(PFPreviewHandler))
+	mux.HandleFunc("/api/pause", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			PauseHandler(w, r)
+		case http.MethodDelete:
+			ResumeHandler(w, r)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
 
 	log.Println("Web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {
@@ -355,6 +420,16 @@ func StartTestWebServer() {
 	mux.HandleFunc("/api/config/update", authMiddleware(UpdateConfigHandler))
 	mux.HandleFunc("/api/hosts-preview", authMiddleware(HostsPreviewHandler))
 	mux.HandleFunc("/api/pf-preview", authMiddleware(PFPreviewHandler))
+	mux.HandleFunc("/api/pause", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			PauseHandler(w, r)
+		case http.MethodDelete:
+			ResumeHandler(w, r)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
 
 	log.Println("Test web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -292,6 +292,42 @@
             font-size: 13px;
             padding: 8px 18px;
         }
+        .pause-panel {
+            margin-top: 20px;
+            padding: 16px;
+            border-radius: 8px;
+            border: 2px solid #e0e0e0;
+            background: #fafafa;
+        }
+        .pause-panel h3 {
+            font-size: 14px;
+            font-weight: 600;
+            color: #333;
+            margin-bottom: 12px;
+        }
+        .pause-active {
+            border-color: #ffc107;
+            background: #fff8e1;
+        }
+        .pause-active h3 {
+            color: #856404;
+        }
+        .pause-until {
+            font-size: 14px;
+            color: #856404;
+            margin-bottom: 12px;
+            font-weight: 600;
+        }
+        .button-pause {
+            background: linear-gradient(135deg, #fd7e14 0%, #e55a00 100%);
+            font-size: 13px;
+            padding: 8px 16px;
+        }
+        .button-resume {
+            background: linear-gradient(135deg, #28a745 0%, #1e7e34 100%);
+            font-size: 13px;
+            padding: 8px 18px;
+        }
     </style>
 </head>
 <body>
@@ -429,6 +465,22 @@
             <div id="statusContent" style="margin-top: 16px;">
                 <p style="color: #999;">Loading...</p>
             </div>
+            <div id="pausePanel" class="pause-panel" style="display:none;">
+                <h3 id="pausePanelTitle">⏸ Pause Blocking</h3>
+                <div id="pauseActive" style="display:none;">
+                    <div class="pause-until" id="pauseUntilText"></div>
+                    <button class="button-resume" onclick="resumeBlocking()">▶ Resume Now</button>
+                </div>
+                <div id="pauseInactive">
+                    <div class="button-group" style="margin-bottom:0;">
+                        <button class="button-pause" onclick="pauseBlocking(15)">15 min</button>
+                        <button class="button-pause" onclick="pauseBlocking(30)">30 min</button>
+                        <button class="button-pause" onclick="pauseBlocking(60)">1 hour</button>
+                        <button class="button-pause" onclick="pauseBlocking(120)">2 hours</button>
+                    </div>
+                </div>
+            </div>
+            <div id="pauseMessage" style="margin-top:10px;"></div>
         </div>
     </div>
     
@@ -582,8 +634,67 @@
                     const items = domains.map(d => '<li>' + d + '</li>').join('');
                     contentEl.innerHTML = '<ul class="blocked-list">' + items + '</ul>';
                 }
+
+                // Render pause panel.
+                const panel = document.getElementById('pausePanel');
+                panel.style.display = 'block';
+                if (data.paused && data.paused_until) {
+                    const until = new Date(data.paused_until);
+                    panel.classList.add('pause-active');
+                    document.getElementById('pausePanelTitle').textContent = '⏸ Blocking Paused';
+                    document.getElementById('pauseUntilText').textContent =
+                        'Blocking paused until ' + until.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+                    document.getElementById('pauseActive').style.display = 'block';
+                    document.getElementById('pauseInactive').style.display = 'none';
+                } else {
+                    panel.classList.remove('pause-active');
+                    document.getElementById('pausePanelTitle').textContent = '⏸ Pause Blocking';
+                    document.getElementById('pauseActive').style.display = 'none';
+                    document.getElementById('pauseInactive').style.display = 'block';
+                }
             } catch (err) {
                 contentEl.innerHTML = '<div class="error-banner">Error fetching status: ' + err.message + '</div>';
+            }
+        }
+
+        async function pauseBlocking(minutes) {
+            const msgEl = document.getElementById('pauseMessage');
+            try {
+                const res = await fetch('/api/pause', {
+                    method: 'POST',
+                    headers: { 'X-Auth-Token': authToken, 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ minutes })
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    msgEl.innerHTML = '<div class="error-banner">' + (data.error || 'Failed to pause') + '</div>';
+                    return;
+                }
+                const until = new Date(data.paused_until);
+                msgEl.innerHTML = '<div class="success-banner">⏸ Blocking paused until ' +
+                    until.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) + '</div>';
+                await loadStatus();
+            } catch (err) {
+                msgEl.innerHTML = '<div class="error-banner">Error: ' + err.message + '</div>';
+            }
+        }
+
+        async function resumeBlocking() {
+            const msgEl = document.getElementById('pauseMessage');
+            try {
+                const res = await fetch('/api/pause', {
+                    method: 'DELETE',
+                    headers: { 'X-Auth-Token': authToken }
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    msgEl.innerHTML = '<div class="error-banner">' + (data.error || 'Failed to resume') + '</div>';
+                    return;
+                }
+                msgEl.innerHTML = '<div class="success-banner">▶ Blocking resumed.</div>';
+                await loadStatus();
+            } catch (err) {
+                msgEl.innerHTML = '<div class="error-banner">Error: ' + err.message + '</div>';
             }
         }
         


### PR DESCRIPTION
Closes #14

## Summary

Adds a temporary pause mechanism that suspresses all blocking rules for a set duration, auto-expires, and can be resumed early. Accessible via both the API and the web dashboard.

- `POST /api/pause {"minutes": N}` — pause blocking for 1–240 minutes
- `DELETE /api/pause` — resume immediately
- Web dashboard Status tab — four preset buttons (15 min / 30 min / 1 hour / 2 hours); amber panel showing "Paused until HH:MM + Resume" when active

## How it works

**Config model** (`internal/config`):
- New `PauseWindow { Until time.Time }` struct stored as `"pause"` in config.json with `omitempty` — non-paused configs serialise identically to before, no migration needed
- `Config.IsPaused(t time.Time) bool` — single nil-safe predicate used throughout
- `config.SetPause(until)` / `config.ClearPause()` — thread-safe in-memory mutations; callers call `SaveConfig()` to persist

**Scheduler** (`internal/scheduler`):
- `EvaluateRulesAtTime` returns an empty map immediately when paused — all blocked domains appear in `newlyUnblocked` on the next tick and are deactivated via the enforcer within ≤1 minute of the pause being set
- `CheckWarningDomainsAtTime` returns nil when paused — no pre-block warnings fire during a pause
- `evaluateRules()` checks on every tick whether the pause window has expired; if so it clears `cfg.Pause` and saves config so config.json stays clean (no stale pause entries accumulate)

**API** (`internal/web`):
- `POST /api/pause` validates `minutes` is 1–240, sets `pause.until`, saves, returns `{"status":"ok","paused_until":"<RFC3339>"}`
- `DELETE /api/pause` clears pause, saves, returns `{"status":"ok"}`
- `GET/POST /api/status` extended with `"paused": bool` and `"paused_until": string` so the UI can render state in a single existing request

**Web UI** (`internal/web/static/index.html`):
- Status tab shows a pause panel below the blocked-domains list
- Not paused: four preset buttons
- Paused: amber panel with expiry time and Resume button
- Both actions call the API then refresh the status panel in-place

## Gotchas

- The pause is stored in config.json, so it survives a daemon restart — a pause set before a crash is still honoured after recovery
- Resume happens on the next scheduler tick (≤1 minute), not instantaneously — this is the same latency as normal block/unblock transitions
- UX friction (confirmation before pausing) is deferred to a follow-up issue per the discussion on #14

## Test plan

- [ ] Set a pause via `POST /api/pause {"minutes": 15}` — confirm `config.json` gains a `pause.until` field and blocked domains disappear within 1 minute
- [ ] `DELETE /api/pause` — confirm domains re-block within 1 minute
- [ ] Wait for pause to expire naturally — confirm `pause` field is removed from config.json on the next scheduler tick
- [ ] Web UI Status tab: pause buttons appear when not paused; amber panel appears when paused; Resume clears it
- [ ] `GET /api/status` reflects `"paused": true/false` correctly

https://claude.ai/code/session_01DQiZGfDYnQ5DdMyGphApeQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQiZGfDYnQ5DdMyGphApeQ)_