### PR TITLE
docs: rewrite README, DESIGN, and TROUBLESHOOTING (#16, #17)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,1489 +1,712 @@
-# Distractions-Free: System Design Document
+# Distractions-Free — System Design
 
-## Table of Contents
-1. [Overview](#overview)
-2. [Architecture](#architecture)
-3. [Core Modules](#core-modules)
-4. [Data Flow](#data-flow)
-5. [Service Operation](#service-operation)
-6. [Privileged Operations](#privileged-operations)
-7. [Testing Architecture](#testing-architecture)
-8. [Configuration](#configuration)
-9. [Mode of Operation](#mode-of-operation)
+This document describes how the daemon is built. It complements [README.md](./README.md), which is the user-facing guide, and [TROUBLESHOOTING.md](./TROUBLESHOOTING.md), which covers diagnostics and recovery.
 
----
+## Contents
 
-## Overview
-
-**Distractions-Free** is a system-level DNS proxy that enforces productivity schedules by intercepting DNS requests. Instead of allowing users to bypass time-blocking with browser extensions, this application runs as a background service with privileged access, making it impossible to disable without root password.
-
-### Key Characteristics
-- **System-level enforcement**: Runs as a service (macOS `launchd`, Windows `Service`)
-- **Zero-trust design**: Works even if applications try to bypass the OS DNS
-- **Real-time scheduling**: Evaluates rules every minute to handle laptop sleep/wake
-- **Multi-layer testing**: Comprehensive unit tests without requiring privileges or port binding
-- **Interactive testing**: CLI and web UI for testing blocking logic without service installation
-
-### Technology Stack
-- **Language**: Go 1.x
-- **DNS Library**: github.com/miekg/dns
-- **Service Framework**: github.com/kardianos/service
-- **Port**: 127.0.0.1:53 (requires root/admin)
-- **Web Server**: net/http (embedded, no external dependencies)
+1. [Overview](#1-overview)
+2. [System architecture](#2-system-architecture)
+3. [Module layout](#3-module-layout)
+4. [The enforcer abstraction](#4-the-enforcer-abstraction)
+5. [Scheduler](#5-scheduler)
+6. [DNS proxy](#6-dns-proxy)
+7. [pf (Packet Filter) integration](#7-pf-packet-filter-integration)
+8. [Configuration](#8-configuration)
+9. [Web server & HTTP API](#9-web-server--http-api)
+10. [Process lifecycle](#10-process-lifecycle)
+11. [Cleanup (`--clean`)](#11-cleanup---clean)
+12. [Testability strategy](#12-testability-strategy)
+13. [Concurrency model](#13-concurrency-model)
+14. [Security model](#14-security-model)
+15. [Platform-specific notes](#15-platform-specific-notes)
 
 ---
 
-## Architecture
+## 1. Overview
 
-### System-Level Components Diagram
+Distractions-Free is a single-binary Go daemon that runs as a privileged system service. It enforces per-domain, per-time-of-day blocking rules on the host so that distracting sites become unreachable during configured windows.
+
+The interesting design decisions:
+
+- **Three interchangeable enforcement backends.** Blocking can be done by editing `/etc/hosts` (default), by running a local DNS proxy on `127.0.0.1:53`, or by combining the DNS proxy with a `pf` packet-filter anchor on macOS. The scheduler does not know which is in use; it talks to an `Enforcer` interface.
+- **Pure functions for the parts worth testing.** Rule evaluation, DNS-response building, hosts-line generation, and pf-anchor generation are pure functions of `(time, config, …)` with no side effects. This means the test suite covers the core behaviour without needing root, port 53, or system-file access.
+- **Diff-based activation.** The scheduler runs once a minute and computes the diff against the previous tick. The enforcer is given only `newlyBlocked` and `newlyUnblocked` lists, not the full set, so a steady-state minute is a no-op.
+- **Auto-reloading config.** Every tick reloads `config.json` from disk. There is no inotify/FSEvents listener — the 60-second window is the maximum staleness, and is good enough for human-edited rules.
+- **Dashboard embedded in the binary.** Static HTML/CSS/JS is bundled via `go:embed`, so a single binary is the entire deliverable.
+
+### Tech stack
+
+- **Language:** Go (cross-compiles to `darwin/arm64`, `darwin/amd64`, `windows/amd64`).
+- **DNS:** [`github.com/miekg/dns`](https://github.com/miekg/dns).
+- **Service framework:** [`github.com/kardianos/service`](https://github.com/kardianos/service) — abstracts launchd / Windows Service Manager.
+- **Web:** `net/http` only.
+- **External binaries called:** `osascript`, `networksetup`, `dscacheutil`, `killall`, `pfctl` (macOS); `ipconfig`, `powershell` (Windows).
+
+---
+
+## 2. System architecture
+
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      Operating System                            │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │  System DNS: 127.0.0.1:53 (configured via networksetup)│    │
-│  └────────────────────────┬────────────────────────────────┘    │
-│                           │                                      │
-│                           ▼                                      │
-│  ┌─────────────────────────────────────────────────────────┐    │
-│  │      Distractions-Free Service (running as root)        │    │
-│  │                                                         │    │
-│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐ │    │
-│  │  │  Scheduler   │  │   Config     │  │  Web Server  │ │    │
-│  │  │  (1-min)     │  │  (Config.json)│ │ (8040)      │ │    │
-│  │  └──────────────┘  └──────────────┘  └──────────────┘ │    │
-│  │                           ▲                                   │
-│  │                           │                                   │
-│  │              ┌────────────┴────────────┐                     │
-│  │              ▼                         ▼                     │
-│  │   ┌──────────────────┐      ┌──────────────────┐             │
-│  │   │  DNS Proxy       │      │  Active Blocks   │             │
-│  │   │  (Port 53)       │      │  (Map)           │             │
-│  │   └──────────────────┘      └──────────────────┘             │
-│  │              │                                               │
-│  │              ▼                                               │
-│  │   ┌──────────────────┐      ┌──────────────────┐             │
-│  │   │  Upstream DNS    │      │  Tab Closer      │             │
-│  │   │  (8.8.8.8:53)    │      │  (AppleScript)   │             │
-│  │   └──────────────────┘      └──────────────────┘             │
-│  │                                                              │
-│  └──────────────────────────────────────────────────────────────┘
-│                                                                   │
-└─────────────────────────────────────────────────────────────────┘
+                                 ┌─────────────────────────────┐
+                                 │  config.json (auto-reloaded │
+                                 │  every minute from disk)    │
+                                 └──────────────┬──────────────┘
+                                                │
+                                                ▼
+   ┌─────────────────────────────────────────────────────────────────┐
+   │                       Scheduler (1-min tick)                     │
+   │  • Loads config                                                  │
+   │  • Calls EvaluateRulesAtTime(now, cfg) → set of blocked domains  │
+   │  • Diffs against previous tick → newlyBlocked, newlyUnblocked    │
+   │  • Calls enforcer.Activate / .Deactivate with the diffs          │
+   │  • Calls CheckWarningDomainsAtTime — fires AppleScript notification
+   │  • On block start, fires AppleScript to close Chrome/Safari tabs │
+   └──────────────────────────┬──────────────────────────────────────┘
+                              │
+                              ▼
+            ┌───────────────────────────────────────┐
+            │    enforcer.Enforcer (interface)      │
+            │       Setup / Teardown                │
+            │       Activate / Deactivate / All     │
+            └───┬───────────────┬──────────────┬────┘
+                │               │              │
+        ┌───────▼─────┐  ┌──────▼──────┐  ┌────▼─────────┐
+        │ HostsEnforce│  │ DNSEnforcer │  │ StrictEnforce│
+        │  edits      │  │  updates    │  │  composes    │
+        │  /etc/hosts │  │  blocked    │  │  DNS + pf    │
+        │             │  │  map →      │  │              │
+        │             │  │  proxy pkg  │  │              │
+        └─────────────┘  └──────┬──────┘  └──┬───────┬───┘
+                                │            │       │
+                                ▼            ▼       ▼
+                       ┌──────────────┐  ┌─────────────┐
+                       │  proxy.DNS   │  │  pf anchor  │
+                       │  Server      │  │  /etc/pf.   │
+                       │  127.0.0.1:53│  │  anchors/   │
+                       └──────────────┘  └─────────────┘
 
-  Application Requests
-        │
-        ▼
-  What IP is youtube.com?
-        │
-        ▼
-  ┌─────────────────────────────────────────┐
-  │  Is youtube.com in blocked domains?      │
-  │  (Check current time and rules)          │
-  └─────────────────────────────────────────┘
-        │
-        ├─ YES ──► Return 0.0.0.0 (BLOCKED)
-        │
-        └─ NO  ──► Forward to upstream DNS
-                   (Google 8.8.8.8 or Cloudflare)
+   ┌─────────────────────────────────────────────────────────────────┐
+   │              Web server on 127.0.0.1:8040                       │
+   │  • GET  /api/config            (public — bootstraps auth token) │
+   │  • POST /api/config/update     (auth)                           │
+   │  • GET/POST /api/status        (auth)                           │
+   │  • GET/POST /api/test-query    (auth)                           │
+   │  • GET/POST /api/hosts-preview (auth)                           │
+   │  • GET/POST /api/pf-preview    (auth)                           │
+   │  • POST /api/pause             (auth)                           │
+   │  • DELETE /api/pause           (auth)                           │
+   │  • Embedded static dashboard (Status / Test / Manage tabs)      │
+   └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Module Dependencies
+### Request paths
+
+**`hosts` mode (default):** the OS resolves names normally; `/etc/hosts` short-circuits the lookup for blocked domains. No port 53 is bound. The scheduler is the only thing the daemon needs to do.
+
+**`dns` mode:** the OS is configured to use `127.0.0.1:53` as its resolver. Each query is checked against the in-memory `blocked` map. Blocked A-record queries return `0.0.0.0`; everything else is forwarded to the upstream resolver (with backup-DNS failover).
+
+**`strict` mode:** like `dns`, plus the scheduler asks the pf enforcer to resolve each newly-blocked domain to A/AAAA addresses and load them into a `<blocked_ips>` table inside the `distractions-free` pf anchor. Outbound packets to those IPs are dropped at the kernel.
+
+---
+
+## 3. Module layout
+
+```
+cmd/app/main.go                  # entry point: dispatch and service wiring
+internal/
+  config/config.go               # JSON config + thread-safe in-memory copy
+  enforcer/
+    enforcer.go                  # Enforcer interface + factory + flushDNSCache
+    hosts.go                     # HostsEnforcer — edits /etc/hosts
+    dns.go                       # DNSEnforcer  — updates proxy's blocked map
+    strict.go                    # StrictEnforcer — DNS + pf composition
+  scheduler/scheduler.go         # 1-min ticker, diff computation, AppleScript
+  proxy/dns.go                   # DNS server, GetDNSResponse pure function
+  pf/pf.go                       # pf anchor management (macOS, root)
+  cleanup/cleanup.go             # --clean implementation: per-step, idempotent
+  cleanup/priv_unix.go           # IsPrivileged() — Geteuid()==0
+  cleanup/priv_windows.go        # IsPrivileged() — token IsMember Administrators
+  testcli/testcli.go             # --test-query CLI + GetQueryResult struct
+  web/server.go                  # HTTP handlers, auth middleware
+  web/static/index.html          # embedded SPA (Status/Test/Manage tabs)
+```
+
+Dependency direction:
+
 ```
 cmd/app/main.go
-│
-├── config
-│   └── config.go (loads/stores config.json)
-│
-├── scheduler
-│   └── scheduler.go (evaluates rules every minute)
-│       ├── config
-│       └── proxy (updates blocked domains)
-│
-├── proxy
-│   └── dns.go (intercepts port 53 DNS requests)
-│       ├── config (gets primary/backup DNS)
-│       └── miekg/dns (DNS protocol handling)
-│
-├── web
-│   ├── server.go (HTTP dashboard at :8040)
-│   └── static/* (embedded HTML/CSS/JS)
-│
-└── testcli
-    └── testcli.go (testing without service)
-        ├── config
-        ├── scheduler
-        └── proxy
+  ↓
+  ├── config        ← used by everything
+  ├── enforcer ──→ proxy, pf, config
+  ├── scheduler ──→ enforcer, config
+  ├── proxy ──→ config
+  ├── web ──→ scheduler, enforcer (preview), pf (preview), testcli, config
+  ├── cleanup ──→ enforcer (hosts cleanup), pf, config
+  └── testcli ──→ scheduler, proxy, config
 ```
+
+There are no circular imports. The `proxy` package has no dependency on `enforcer` or `scheduler` — the data flow is one-way: scheduler → enforcer → proxy.
 
 ---
 
-## Core Modules
+## 4. The enforcer abstraction
 
-### 1. Config Module (`internal/config/config.go`)
+The core extension point. Defined in `internal/enforcer/enforcer.go`:
 
-**Purpose**: Centralized configuration management with thread-safe access.
+```go
+type Enforcer interface {
+    Setup() error                       // called once at service start
+    Teardown() error                    // called once at service stop
+    Activate(domains []string) error    // newly-blocked diff
+    Deactivate(domains []string) error  // newly-unblocked diff
+    DeactivateAll() error               // remove every block (used on shutdown)
+}
 
-**Key Structures**:
+func New(cfg config.Config) Enforcer {
+    switch cfg.Settings.GetEnforcementMode() {
+    case "strict": return NewStrictEnforcer(cfg)
+    case "dns":    return NewDNSEnforcer(cfg)
+    default:       return NewHostsEnforcer(cfg)   // includes empty / unrecognised
+    }
+}
+```
+
+`Activate` and `Deactivate` are called with **diffs**, not the full blocked set. The scheduler is responsible for computing the diff from one tick to the next. This keeps the enforcer implementations simple and means a steady-state minute is a no-op.
+
+### `HostsEnforcer` (`hosts.go`)
+
+Edits `/etc/hosts` (or `C:\Windows\System32\drivers\etc\hosts`) between marker lines:
+
+```
+# distractions-free:begin
+0.0.0.0 youtube.com
+0.0.0.0 www.youtube.com
+0.0.0.0 m.youtube.com
+0.0.0.0 mobile.youtube.com
+0.0.0.0 app.youtube.com
+# distractions-free:end
+```
+
+Subdomain prefixes are hardcoded: `["", "www.", "m.", "mobile.", "app."]`. There is no wildcard support in `/etc/hosts`, so this is a deliberate, conservative list. Adding more would inflate the hosts file for marginal benefit.
+
+Writes are atomic: the new contents are written to `/etc/hosts.df.tmp` then renamed over `/etc/hosts`. A crash mid-write cannot leave the file half-rewritten.
+
+Activate is idempotent — entries already present are not duplicated. DeactivateAll removes the entire managed block (markers and all) so the file is restored to its pre-installation form.
+
+After every edit the enforcer flushes the OS resolver cache via `flushDNSCache()` so changes take effect without waiting for TTL.
+
+The `GenerateHostsEntries(domains []string) []string` function is exported so the web UI's `/api/hosts-preview` endpoint can show what *would* be written without root.
+
+### `DNSEnforcer` (`dns.go`)
+
+Maintains an in-memory `blocked map[string]bool` and pushes updates to the `proxy` package via `proxy.UpdateBlockedDomains(snapshot)` on every Activate/Deactivate. The DNS server itself is started by `cmd/app/main.go`, not by the enforcer — this separation matters because the server is the thing that blocks the goroutine forever, and `main.go` needs to control that.
+
+`Teardown` resets the system DNS to its previous state. **Caveat:** the current implementation only resets the `Wi-Fi` interface on macOS (and `Wi-Fi` on Windows). Multi-interface cleanup is delegated to the `--clean` command (see `internal/cleanup/cleanup.go`), which iterates every interface that points at `127.0.0.1`. Tracked in issue #12.
+
+### `StrictEnforcer` (`strict.go`)
+
+Composes a `DNSEnforcer` with the `pf` package. On `Setup` it tries to install the pf anchor; if that fails (non-darwin, missing `pfctl`, edited `pf.conf`) it logs a warning and continues with DNS-only enforcement — a graceful degradation rather than a hard failure.
+
+On `Activate(domains)` it calls `dns.Activate(domains)` then `pf.ActivateBlock(domains, primaryDNS)`, which resolves the domains to IPs and reloads the pf table.
+
+On `Deactivate(domains)` it calls `dns.Deactivate(domains)` then **rebuilds the pf table from scratch** using whatever's still in the DNS-blocked set. Selective IP removal isn't worth the complexity given how few domains are typically active simultaneously.
+
+---
+
+## 5. Scheduler
+
+`internal/scheduler/scheduler.go`. The orchestrator. Two responsibilities:
+
+1. Drive a 1-minute ticker that re-evaluates rules and tells the enforcer about changes.
+2. Fire the macOS-specific UI side effects: 3-minute warning notification and tab-closing AppleScript.
+
+### The pure functions
+
+```go
+func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool
+func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string
+```
+
+`EvaluateRulesAtTime` returns the set of domains that should be blocked at `t`. Algorithm:
+
+1. If `cfg.IsPaused(t)` — return empty map (pause overrides everything).
+2. For each rule with `is_active=true`, look up `Schedules[t.Weekday().String()]`.
+3. For each slot, parse `Start`/`End` as `15:04`, build a same-day comparison time, check `slotStart <= now < slotEnd`.
+4. Add the domain on the first matching slot (no need to keep checking).
+
+`CheckWarningDomainsAtTime` returns domains whose block starts within `[now, now+3min)`. Logic mirrors the above but compares against the slot's start time, building a warning window of `[start-3min, start)`.
+
+Both functions are deterministic and have no side effects — that's the entire point. Tests construct synthetic `time.Time` and `config.Config` values and assert on the returned maps/slices.
+
+### The tick loop
+
+```go
+func Start() {
+    ticker := time.NewTicker(1 * time.Minute)
+    go func() {
+        evaluateRules()              // run once immediately
+        for range ticker.C {
+            evaluateRules()
+        }
+    }()
+}
+
+func evaluateRules() {
+    config.LoadConfig()
+    cfg := config.GetConfig()
+    now := time.Now()
+
+    // 1. Self-clear an expired pause window so config.json stays clean.
+    if cfg.Pause != nil && !now.Before(cfg.Pause.Until) {
+        config.ClearPause()
+        config.SaveConfig()
+        cfg = config.GetConfig()
+    }
+
+    newBlocked := EvaluateRulesAtTime(now, cfg)
+    warningDomains := CheckWarningDomainsAtTime(now, cfg)
+
+    // 2. Diff against the previous tick.
+    var newlyBlocked, newlyUnblocked []string
+    // ... (set difference)
+
+    // 3. Push diff through the active enforcer.
+    if len(newlyBlocked) > 0 {
+        activeEnforcer.Activate(newlyBlocked)
+        closeMacOSTabs(newlyBlocked)
+    }
+    if len(newlyUnblocked) > 0 {
+        activeEnforcer.Deactivate(newlyUnblocked)
+    }
+
+    // 4. Fire warnings, debounced per-domain to once per minute.
+    if len(warningDomains) > 0 {
+        // for each domain, check lastWarningTime[domain]; if >=1min ago, run.
+        runMacOSWarning(domainsToWarn)
+    }
+}
+```
+
+The `activeEnforcer` is wired by `main.go` via `scheduler.SetEnforcer(e)` before `Start()` is called.
+
+`closeMacOSTabs` and `runMacOSWarning` are no-ops on non-darwin. On darwin they call into the AppleScript abstraction (next section).
+
+### AppleScript abstraction
+
+Two interfaces, both globally settable so tests can swap in stubs:
+
+```go
+type AppleScriptGenerator interface {
+    GenerateWarningScript(domains []string) string
+    GenerateCloseTabsScript(domains []string) string
+}
+
+type ScriptExecutor interface {
+    ExecuteScript(script string) error
+    LogScript(script string)
+}
+```
+
+The default executor (`MacOSScriptExecutor`) writes the script to `/tmp/df_script.scpt` and runs it via `osascript`. If the daemon is running as root, it shells out as the console user (via `su - <user> -c osascript ...`) so the notification appears in the user's UI session and AppleScript can talk to Chrome/Safari. Console user is detected via `stat -f %Su /dev/console`.
+
+The close-tabs script enumerates Chrome and Safari windows, matches tab URLs against the blocked domain list (substring match), and closes matching tabs in both browsers.
+
+The warning script first checks which of the upcoming-blocked domains actually have open browser tabs (`getOpenBrowserDomains`) and only fires a notification if there's at least one. This is why the warning UX isn't noisy: if you don't have YouTube open at 08:57, you don't get pinged about it at 09:00.
+
+### Internal state
+
+```go
+var activeBlocks    = make(map[string]bool)  // last tick's blocked set
+var lastEvalTime    time.Time
+var lastWarningTime = make(map[string]time.Time)  // per-domain debounce
+```
+
+All guarded by `activeBlocksMu sync.RWMutex` and `lastWarningMu sync.Mutex`. The `GetStatus()` function returns a copy of `activeBlocks` plus `lastEvalTime` for the `/api/status` endpoint.
+
+---
+
+## 6. DNS proxy
+
+`internal/proxy/dns.go`. Used only when `enforcement_mode` is `dns` or `strict`. Bypassed entirely in `hosts` mode.
+
+### The pure function
+
+```go
+func GetDNSResponse(
+    r *dns.Msg,
+    blocked map[string]bool,
+    primaryDNS, backupDNS string,
+) (*dns.Msg, error)
+```
+
+For each query:
+1. If the question name (suffix-trimmed) is in `blocked` and the qtype is `A`, answer `<name> 60 IN A 0.0.0.0` and return.
+2. Otherwise forward via `dns.Client.Exchange` to `primaryDNS`. On error, retry with `backupDNS`. Return the upstream response verbatim.
+
+This function is what the test suite hits — no port binding, no global state, just `(query, blocked-set, upstream-server)` → response.
+
+### Subdomain matching
+
+`IsDomainBlocked(domain, blocked)` checks both exact match and `.suffix` match — so `m.youtube.com` is blocked when `youtube.com` is in the set. This is `dns`-mode equivalent of the static prefix list that `HostsEnforcer` writes.
+
+### The server
+
+`StartDNSServer()` binds `127.0.0.1:53/udp`, registers `handleDNSRequest` for the `.` zone, and blocks. `handleDNSRequest` reads the current `blocked` map under a read-lock, then calls `GetDNSResponse`.
+
+`StopDNSServer()` calls `dns.Server.Shutdown()` for graceful cleanup. The shutdown happens in `program.Stop()` in `main.go`.
+
+`UpdateBlockedDomains(newBlocked)` is the only mutator — called by `DNSEnforcer.Activate/Deactivate/DeactivateAll` under its own mutex; the proxy then publishes the new map under its own write-lock. Two-tier locking keeps the per-query read lock on the hot path very cheap.
+
+---
+
+## 7. pf (Packet Filter) integration
+
+`internal/pf/pf.go`. macOS-only, requires root, currently used only by `StrictEnforcer`. All exported functions are no-ops on non-darwin so the package can be imported unconditionally.
+
+### Anchor file model
+
+The daemon owns one pf anchor named `distractions-free`, stored at `/etc/pf.anchors/distractions-free`. The anchor file content is regenerated on every Activate:
+
+```
+table <blocked_ips> persist {
+  142.251.215.110
+  142.251.215.111
+  ...
+}
+block drop out quick proto {tcp udp} from any to <blocked_ips>
+```
+
+The anchor is wired into `/etc/pf.conf` between marker lines:
+
+```
+# distractions-free:begin
+anchor "distractions-free"
+load anchor "distractions-free" from "/etc/pf.anchors/distractions-free"
+# distractions-free:end
+```
+
+`InstallAnchor()` writes a stub anchor file, injects the pf.conf block (idempotent — checks for the marker first), runs `pfctl -n -f /etc/pf.conf` to validate the config in dry-run mode, then `pfctl -f /etc/pf.conf` to load it, and finally `pfctl -e` to enable pf if it isn't already.
+
+`RemoveAnchor()` flushes the table, strips the marker block from pf.conf, reloads pf, and deletes the anchor file.
+
+`ActivateBlock(domains, primaryDNS)` resolves each domain to A and AAAA addresses (via `miekg/dns`, falling back to `net.LookupHost`), regenerates the anchor file, runs `pfctl -a distractions-free -f <anchor>` to load it, and then runs `pfctl -k <src> -k <ip>` per IP to kill any existing connections.
+
+`DeactivateBlock()` flushes the table via `pfctl -a distractions-free -t blocked_ips -T flush`, tolerating "No such table" since the table may not exist on first run.
+
+### Why preview functions are exported
+
+The web UI's `/api/pf-preview` endpoint calls `pf.GeneratePreview(domains, dnsServer)` to show users what *would* happen in strict mode without touching pf. This is essentially `ActivateBlock` minus all the side effects — pure resolution and content generation.
+
+---
+
+## 8. Configuration
+
+`internal/config/config.go`. Single global `AppConfig` guarded by an `RWMutex`. All access goes through `GetConfig()` (returns a value copy) and `LoadConfig()` / `SaveConfig()` (file I/O under exclusive lock).
+
+### Schema
+
 ```go
 type Config struct {
-    Settings Settings
-    Rules    []Rule
-}
-
-type Rule struct {
-    Domain    string                // e.g., "youtube.com"
-    IsActive  bool                  // Can disable/enable rules
-    Schedules map[string][]TimeSlot // Key: "Monday", "Tuesday", etc.
-}
-
-type TimeSlot struct {
-    Start string // "09:00"
-    End   string // "17:00"
+    Settings Settings     `json:"settings"`
+    Rules    []Rule       `json:"rules"`
+    Pause    *PauseWindow `json:"pause,omitempty"`
 }
 
 type Settings struct {
-    PrimaryDNS string // e.g., "8.8.8.8:53"
-    BackupDNS  string // e.g., "1.1.1.1:53"
+    PrimaryDNS      string `json:"primary_dns"`
+    BackupDNS       string `json:"backup_dns"`
+    AuthToken       string `json:"auth_token"`
+    EnforcementMode string `json:"enforcement_mode,omitempty"`
+}
+
+type Rule struct {
+    Domain    string                `json:"domain"`
+    IsActive  bool                  `json:"is_active"`
+    Schedules map[string][]TimeSlot `json:"schedules"`  // weekday → slots
+}
+
+type TimeSlot struct {
+    Start string `json:"start"`  // "HH:MM"
+    End   string `json:"end"`    // "HH:MM"
+}
+
+type PauseWindow struct {
+    Until time.Time `json:"until"`
 }
 ```
 
-**Config File Paths**:
-- **macOS**: `/Library/Application Support/DistractionsFree/config.json`
-- **Windows**: `C:\ProgramData\DistractionsFree\config.json`
-- **Linux**: `/etc/distractionsfree/config.json`
-- **Test Mode** (`UseLocalConfig=true`): `./config.json` (current directory)
+`Settings.GetEnforcementMode()` returns the validated mode, defaulting to `"hosts"` for empty or unrecognised values. This is what allows a pre-1.x config without the `enforcement_mode` field to upgrade transparently.
 
-**Key Functions**:
+### File location
 
-1. **GetConfigFilePath()**
-   - Returns the OS-appropriate config path
-   - Creates the directory if it doesn't exist
-   - Uses `UseLocalConfig` flag for test mode
+| OS | Path |
+|---|---|
+| macOS | `/Library/Application Support/DistractionsFree/config.json` |
+| Windows | `%PROGRAMDATA%\DistractionsFree\config.json` |
+| Linux | `/etc/distractionsfree/config.json` |
+| `UseLocalConfig=true` | `./config.json` |
 
-   ```go
-   func GetConfigFilePath() (string, error) {
-       if UseLocalConfig {
-           return "." // Current directory for testing
-       }
-       // Platform-specific paths...
-   }
-   ```
+`UseLocalConfig` is a package-level boolean set by `--no-service`, `--test-web`, and `--test-query` so they can run against a working-directory config without touching system paths.
 
-2. **LoadConfig()**
-   - Reads `config.json` from disk
-   - Parses JSON into `AppConfig`
-   - Returns error if file doesn't exist or is malformed
+### Bootstrap
 
-   ```go
-   func LoadConfig() error {
-       filePath, err := GetConfigFilePath()
-       // ... read file, parse JSON
-       mu.Lock()
-       AppConfig = cfg
-       mu.Unlock()
-       return nil
-   }
-   ```
+On first run, if the config file doesn't exist, `LoadConfig()` writes a default config:
 
-3. **GetConfig()**
-   - Returns a copy of current config
-   - Thread-safe using RWMutex
-   - Used by all modules that need access to rules
+- `primary_dns: "8.8.8.8:53"`, `backup_dns: "1.1.1.1:53"`
+- `enforcement_mode: "hosts"`
+- A randomly generated 32-character hex `auth_token`
+- One seed rule blocking `youtube.com` Mon–Fri 09:00–17:00
 
-   ```go
-   func GetConfig() Config {
-       mu.RLock()
-       defer mu.RUnlock()
-       return AppConfig
-   }
-   ```
+If an existing config has a missing `auth_token`, one is generated and the file is rewritten. This is the only field auto-modified on load.
 
-**Thread Safety**:
-- Uses `sync.RWMutex` for concurrent reads (many goroutines can read simultaneously)
-- Exclusive write lock only when loading new config
+### Reload cadence
+
+The scheduler calls `LoadConfig()` once per tick. `web.ConfigHandler` also calls it on every `GET /api/config` so the dashboard always sees the current file state, not a startup snapshot. There is no inotify/FSEvents listener — 60 seconds of staleness is acceptable for human-edited rules.
+
+### Pause window
+
+`PauseWindow.Until` is an absolute `time.Time` (RFC3339 in JSON). `Config.IsPaused(t)` returns true when the field is non-nil and `t < Until`. `EvaluateRulesAtTime` and `CheckWarningDomainsAtTime` both short-circuit to empty when paused. The scheduler self-clears expired pauses at the top of each tick so `config.json` doesn't accumulate stale entries.
 
 ---
 
-### 2. Scheduler Module (`internal/scheduler/scheduler.go`)
+## 9. Web server & HTTP API
 
-**Purpose**: Evaluates blocking rules at each minute and manages state transitions (tab closing, warnings).
+`internal/web/server.go`. Listens on `127.0.0.1:8040`. Two entry points:
 
-**Key Concept**: The scheduler uses a **testable pure function** (`EvaluateRulesAtTime`) that accepts time as a parameter, making it possible to unit test without mocking time.
+- `StartWebServer()` — used in service mode; same routes, called by `main.go`.
+- `StartTestWebServer()` — used in `--test-web`; loads config from working dir, otherwise identical.
 
-**Key Functions**:
+### Routes
 
-1. **EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool**
+| Path | Method | Auth | Purpose |
+|---|---|---|---|
+| `/` | GET | — | Embedded SPA (HTML/CSS/JS) |
+| `/api/config` | GET | none | Current config — public so the UI can bootstrap the auth token |
+| `/api/config/update` | POST | token | Validate and replace config |
+| `/api/status` | GET, POST | token | `{blocked_domains, last_evaluated, enforcement_mode, paused, paused_until}` |
+| `/api/test-query?time=&domain=` | GET, POST | token | Evaluate `(time, domain)`; POST a `config` form field to test against a custom config |
+| `/api/hosts-preview` | GET, POST | token | Show `/etc/hosts` lines for the current blocked set without writing |
+| `/api/pf-preview` | GET, POST | token | Show resolved IPs and pf anchor content (strict mode only) |
+| `/api/pause` | POST | token | Body `{"minutes": N}` — `1 <= N <= 240` |
+| `/api/pause` | DELETE | token | Clear pause |
 
-   This is the **core blocking logic** - it's a pure function with no side effects.
+### Auth model
 
-   ```go
-   func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
-       currentDay := t.Weekday().String()   // "Monday", "Tuesday", etc.
-       currentTime := t.Format("15:04")     // "10:30", "14:45", etc.
-       
-       newBlocked := make(map[string]bool)
-       
-       for _, rule := range cfg.Rules {
-           if !rule.IsActive {
-               continue
-           }
-           if slots, exists := rule.Schedules[currentDay]; exists {
-               for _, slot := range slots {
-                   // Check if current time falls within the slot
-                   if currentTime >= slot.Start && currentTime < slot.End {
-                       newBlocked[rule.Domain] = true
-                       break
-                   }
-               }
-           }
-       }
-       
-       return newBlocked
-   }
-   ```
+`authMiddleware` rejects any `/api/*` request whose `X-Auth-Token` header doesn't match `config.Settings.AuthToken`. **`GET /api/config` is intentionally exempt** so the SPA can fetch the token on first load and hold it in memory for subsequent calls. The token is treated like any other secret in the config file.
 
-   **Example**: Testing if youtube.com is blocked on Monday 10:30:
-   - `currentDay = "Monday"`
-   - `currentTime = "10:30"`
-   - Find youtube.com rule with schedule: `"Monday": [{"Start": "09:00", "End": "17:00"}]`
-   - Check: `"10:30" >= "09:00" && "10:30" < "17:00"` → **TRUE** → youtube.com is blocked
+This is local-only auth — the server binds `127.0.0.1`, never `0.0.0.0`. Anything running on the same machine as your user can still read the config file and impersonate the dashboard. The auth token's job is to distinguish "the dashboard you opened" from "the random local app that decided to fiddle with port 8040", not to defend against a determined local attacker.
 
-2. **CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string**
+### Validation
 
-   Returns domains that should trigger 3-minute warnings at this time.
+`ValidatePostedConfig(cfg)` runs server-side on every `POST /api/config/update`. Checks:
 
-   ```go
-   func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string {
-       currentDay := t.Weekday().String()
-       futureTime := t.Add(3 * time.Minute).Format("15:04")
-       
-       var warningDomains []string
-       
-       for _, rule := range cfg.Rules {
-           if !rule.IsActive {
-               continue
-           }
-           if slots, exists := rule.Schedules[currentDay]; exists {
-               for _, slot := range slots {
-                   // Warning triggers exactly 3 minutes before block
-                   if futureTime == slot.Start {
-                       warningDomains = append(warningDomains, rule.Domain)
-                   }
-               }
-           }
-       }
-       
-       return warningDomains
-   }
-   ```
+- `enforcement_mode` is empty or one of `"hosts"`, `"dns"`, `"strict"`.
+- Every rule has a non-empty `domain`.
+- Every schedule key is a valid weekday name.
+- Every weekday's slot list is non-empty.
+- Every slot has a valid `15:04` `Start` and `End`.
+- `Start < End`.
 
-   **Example**: At 08:57 AM on Monday, YouTube block starts at 09:00:
-   - `futureTime = 08:57 + 3 min = 09:00`
-   - Find youtube.com with start time 09:00
-   - `09:00 == 09:00` → **TRUE** → Include in warnings
+The auth token is preserved across updates regardless of what the client posts — so the dashboard can't accidentally rotate the secret out from under itself.
 
-3. **Start()**
+### The `resolveConfig` helper
 
-   Launches the scheduler loop that runs every minute.
+`/api/test-query`, `/api/hosts-preview`, and `/api/pf-preview` all support an optional posted config: if the request has a JSON body it's used as the config to evaluate against, otherwise the disk config is reloaded and used. This is what makes the **Test** tab able to "what-if" an arbitrary config without committing it.
 
-   ```go
-   func Start() {
-       ticker := time.NewTicker(1 * time.Minute)
-       go func() {
-           evaluateRules()  // Run immediately, don't wait 1 minute
-           for range ticker.C {
-               evaluateRules()  // Then run every minute
-           }
-       }()
-   }
-   ```
+### Embedded assets
 
-4. **evaluateRules() (internal)**
-
-   Called every minute - orchestrates the rule evaluation, state transitions, and side effects.
-
-   ```go
-   func evaluateRules() {
-       cfg := config.GetConfig()
-       
-       // Get blocked domains at this exact moment
-       newBlocked := EvaluateRulesAtTime(time.Now(), cfg)
-       
-       // Detect transitions
-       for domain, wasBlocked := range activeBlocks {
-           isNowBlocked := newBlocked[domain]
-           if wasBlocked && !isNowBlocked {
-               // TRANSITION: Blocked → Allowed (block ended)
-               log.Printf("Block ended for %s, reopening tabs", domain)
-               if runtime.GOOS == "darwin" {
-                   reopenTabs(domain)  // AppleScript to reopen closed tabs
-               }
-           }
-       }
-       
-       // Detect warnings
-       warnings := CheckWarningDomainsAtTime(time.Now(), cfg)
-       for _, domain := range warnings {
-           log.Printf("3-minute warning for %s", domain)
-           sendNotification(domain)  // Native notification
-       }
-       
-       // Update proxy with new blocked domains
-       proxy.UpdateBlockedDomains(newBlocked)
-       
-       // Store for next iteration
-       activeBlocks = newBlocked
-   }
-   ```
-
-**State Transitions**:
-```
-Time: 08:57 on Monday
-  ├─ Check warnings: youtube.com block starts in 3 min
-  ├─ Send notification: "YouTube will be blocked in 3 minutes"
-  └─ User sees warning
-
-Time: 09:00 on Monday
-  ├─ Check blocking: youtube.com now active
-  ├─ Update proxy's blocked map
-  ├─ AppleScript closes YouTube tabs in Chrome/Safari
-  └─ youtube.com DNS requests return 0.0.0.0
-
-Time: 17:00 on Monday
-  ├─ Check blocking: youtube.com block ended
-  ├─ Update proxy's blocked map
-  └─ youtube.com DNS requests forward to upstream DNS
-```
+`//go:embed static/*` bundles `static/index.html` (a single-page app: HTML + inline CSS/JS) into the binary. The static handler serves it via `http.FileServer(http.FS(fsys))`.
 
 ---
 
-### 3. DNS Proxy Module (`internal/proxy/dns.go`)
+## 10. Process lifecycle
 
-**Purpose**: Intercepts DNS requests on port 53 and either blocks or forwards them.
+`cmd/app/main.go` is both CLI dispatcher and `service.Service` implementation.
 
-**Key Concept**: Uses a **testable pure function** (`GetDNSResponse`) that processes DNS queries without binding to a port, enabling unit tests with real upstream DNS servers.
+### CLI dispatch order
 
-**Key Data Structures**:
+```
+1. --clean [--yes]           → cleanup.* steps, exit
+2. --test-web                → web.StartTestWebServer (UseLocalConfig=true)
+3. --test-query <t> <d>      → testcli.QueryBlocking, exit
+4. --test-applescript        → run AppleScript demo, exit
+5. --no-service              → run program.run() in foreground (UseLocalConfig=true)
+6. --strict                  → config.SetEnforcementMode("strict") + SaveConfig, exit
+7. install/uninstall/start/stop/status/run → service.Control(s, arg)
+8. (no args)                 → s.Run() — service supervisor mode
+```
+
+### Service start path
+
+`program.Start(s)` is called by the service framework. It spawns a goroutine running `program.run()` and returns immediately so the supervisor doesn't think the service hung.
+
 ```go
-var (
-    blockedDomains map[string]bool  // Fast O(1) lookup
-    blockMu        sync.RWMutex     // Thread-safe access
-)
-```
-
-**Key Functions**:
-
-1. **GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, primaryDNS, backupDNS string) (*dns.Msg, error)**
-
-   The testable DNS query processor.
-
-   ```go
-   func GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, 
-                       primaryDNS, backupDNS string) (*dns.Msg, error) {
-       m := new(dns.Msg)
-       m.SetReply(r)  // Copy request ID, question, flags
-       m.Compress = false
-       
-       if len(r.Question) == 0 {
-           return m, nil  // No questions, return empty
-       }
-       
-       q := r.Question[0]
-       domain := strings.TrimSuffix(q.Name, ".")  // "youtube.com." → "youtube.com"
-       
-       // Check if domain is blocked
-       isBlocked := blockedDomainsList[domain]
-       
-       if isBlocked && q.Qtype == dns.TypeA {
-           // Return 0.0.0.0 for blocked A records
-           rr, _ := dns.NewRR(q.Name + " 60 IN A 0.0.0.0")
-           m.Answer = append(m.Answer, rr)
-           return m, nil
-       }
-       
-       // Forward to upstream DNS
-       c := new(dns.Client)
-       
-       in, _, err := c.Exchange(r, primaryDNS)
-       if err != nil {
-           // Failover to backup DNS
-           in, _, err = c.Exchange(r, backupDNS)
-           if err != nil {
-               return nil, err
-           }
-       }
-       return in, nil
-   }
-   ```
-
-   **DNS Response Examples**:
-
-   *Blocked Query*:
-   ```
-   Query:  Q: youtube.com A?
-   Answer: youtube.com 60 IN A 0.0.0.0
-   ```
-
-   *Allowed Query*:
-   ```
-   Query:  Q: google.com A?
-   Answer: google.com 287 IN A 142.251.215.110  (from upstream)
-   ```
-
-2. **UpdateBlockedDomains(newBlocked map[string]bool)**
-
-   Thread-safe update of blocked domains (called by scheduler every minute).
-
-   ```go
-   func UpdateBlockedDomains(newBlocked map[string]bool) {
-       blockMu.Lock()
-       defer blockMu.Unlock()
-       blockedDomains = newBlocked
-   }
-   ```
-
-3. **handleDNSRequest(w dns.ResponseWriter, r *dns.Msg)**
-
-   The actual DNS request handler (called for each incoming DNS query).
-
-   ```go
-   func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
-       // Get current blocked list (read lock)
-       blockMu.RLock()
-       blockedCopy := blockedDomains
-       blockMu.RUnlock()
-       
-       cfg := config.GetConfig()
-       
-       // Process request
-       m, err := GetDNSResponse(r, blockedCopy, 
-                                cfg.Settings.PrimaryDNS, 
-                                cfg.Settings.BackupDNS)
-       if err != nil {
-           dns.HandleFailed(w, r)
-           return
-       }
-       
-       // Send response
-       w.WriteMsg(m)
-   }
-   ```
-
-4. **StartDNSServer()**
-
-   Binds to port 53 and starts accepting DNS requests. **Requires root/admin privileges.**
-
-   ```go
-   func StartDNSServer() {
-       UpdateBlockedDomains(make(map[string]bool))
-       dns.HandleFunc(".", handleDNSRequest)
-       
-       server := &dns.Server{Addr: "127.0.0.1:53", Net: "udp"}
-       log.Printf("Starting local DNS proxy on 127.0.0.1:53...")
-       if err := server.ListenAndServe(); err != nil {
-           log.Fatalf("Failed to start DNS server: %s", err.Error())
-       }
-   }
-   ```
-
-**DNS Flow Diagram**:
-```
-Application: "What's the IP for youtube.com?"
-             │
-             ▼
-System DNS (127.0.0.1:53) ← configured via networksetup
-             │
-             ▼
-handleDNSRequest()
-    │
-    ├─ Get current blocked domains list
-    │
-    ├─ Parse DNS query
-    │
-    └─ Call GetDNSResponse()
-           │
-           ├─ Is "youtube.com" in blocked list?
-           │
-           ├─ YES: Return 0.0.0.0
-           │       Application tries to connect to 0.0.0.0 → Connection fails
-           │
-           └─ NO: Forward to upstream DNS (8.8.8.8:53)
-                  │
-                  └─ Response: "142.251.215.110" (actual IP)
-                     Application connects successfully
-```
-
----
-
-### 4. Web Server Module (`internal/web/server.go`)
-
-**Purpose**: Provides HTTP API and dashboard at `http://127.0.0.1:8040`.
-
-**Key Functions**:
-
-1. **StartWebServer()**
-
-   Regular web server (runs alongside DNS proxy when service is active).
-
-   ```go
-   func StartWebServer() {
-       staticHandler, err := StaticFileHandler()
-       if err != nil {
-           log.Fatalf("Failed to load embedded web files: %v", err)
-       }
-       
-       http.Handle("/", staticHandler)          // Serve static files
-       http.HandleFunc("/api/config", ConfigHandler)
-       http.HandleFunc("/api/test-query", TestQueryHandler)
-       
-       log.Println("Web server starting on http://127.0.0.1:8040")
-       if err := http.ListenAndServe("127.0.0.1:8040", nil); err != nil {
-           log.Fatalf("Web server failed: %v", err)
-       }
-   }
-   ```
-
-2. **StartTestWebServer()**
-
-   Dedicated test UI server (runs when `--test-web` flag is used).
-
-   ```go
-   func StartTestWebServer() {
-       http.HandleFunc("/", TestPageHandler)        // Serve test UI page
-       http.HandleFunc("/api/config", ConfigHandler)
-       http.HandleFunc("/api/test-query", TestQueryHandler)
-       
-       log.Println("Test web server starting on http://127.0.0.1:8040")
-       if err := http.ListenAndServe("127.0.0.1:8040", nil); err != nil {
-           log.Fatalf("Test web server failed: %v", err)
-       }
-   }
-   ```
-
-3. **ConfigHandler(w http.ResponseWriter, r *http.Request)**
-
-   Returns current config as JSON.
-
-   ```go
-   func ConfigHandler(w http.ResponseWriter, r *http.Request) {
-       w.Header().Set("Content-Type", "application/json")
-       cfg := config.GetConfig()
-       json.NewEncoder(w).Encode(cfg)
-   }
-   ```
-
-   Response:
-   ```json
-   {
-     "settings": {
-       "primary_dns": "8.8.8.8:53",
-       "backup_dns": "1.1.1.1:53"
-     },
-     "rules": [
-       {
-         "domain": "youtube.com",
-         "is_active": true,
-         "schedules": {
-           "Monday": [{"start": "09:00", "end": "17:00"}]
-         }
-       }
-     ]
-   }
-   ```
-
-4. **TestQueryHandler(w http.ResponseWriter, r *http.Request)**
-
-   Processes test queries (both CLI and web UI use this).
-
-   ```go
-   func TestQueryHandler(w http.ResponseWriter, r *http.Request) {
-       w.Header().Set("Content-Type", "application/json")
-       
-       timeStr := r.URL.Query().Get("time")     // "2024-04-01 10:30"
-       domain := r.URL.Query().Get("domain")    // "youtube.com"
-       
-       if timeStr == "" || domain == "" {
-           w.WriteHeader(http.StatusBadRequest)
-           json.NewEncoder(w).Encode(map[string]string{
-               "error": "Missing time or domain parameter",
-           })
-           return
-       }
-       
-       result := testcli.GetQueryResult(timeStr, domain)
-       
-       w.WriteHeader(http.StatusOK)
-       json.NewEncoder(w).Encode(result)
-   }
-   ```
-
-5. **TestPageHandler(w http.ResponseWriter, r *http.Request)**
-
-   Serves the beautiful web UI page with embedded HTML/CSS/JavaScript.
-
-   - Purple gradient background (#667eea → #764ba2)
-   - Responsive form with time and domain inputs
-   - Live config JSON viewer
-   - Real-time results display with color coding
-   - Loading spinner animation
-   - All UI is embedded in the binary (no external files needed)
-
----
-
-### 5. Test CLI Module (`internal/testcli/testcli.go`)
-
-**Purpose**: Provides structured testing without service installation or privileges.
-
-**Key Structures**:
-```go
-type QueryResult struct {
-    Time            string     // "2024-04-01 10:30"
-    Weekday         string     // "Monday"
-    Domain          string     // "youtube.com"
-    IsBlocked       bool       // true
-    BlockingStatus  string     // "🚫 BLOCKED"
-    DNSResponse     string     // "0.0.0.0 (blocking response)"
-    ApplicableRules []RuleInfo // Rules that apply
-    HasWarning      bool       // Will warn in 3 mins?
-    WarningMessage  string     // "⚠️ Warning will trigger..."
-    Error           string     // Error if any
-}
-
-type RuleInfo struct {
-    Domain    string
-    Schedules []ScheduleInfo
-}
-
-type ScheduleInfo struct {
-    Weekday  string // "Monday"
-    Start    string // "09:00"
-    End      string // "17:00"
-    IsActive bool   // Is active right now?
-}
-```
-
-**Key Functions**:
-
-1. **GetQueryResult(timeStr, domain string) QueryResult**
-
-   Returns structured test result (used by both CLI and web UI).
-
-   ```go
-   func GetQueryResult(timeStr, domain string) QueryResult {
-       result := QueryResult{
-           Time:   timeStr,
-           Domain: domain,
-       }
-       
-       // Parse time: "2024-04-01 10:30"
-       testTime, err := time.Parse(timeFormat, timeStr)
-       if err != nil {
-           result.Error = fmt.Sprintf("Invalid time format. Use: %s", timeFormat)
-           return result
-       }
-       
-       result.Weekday = testTime.Weekday().String()
-       
-       // Normalize domain
-       domain = strings.TrimSuffix(domain, ".")
-       if domain == "" {
-           result.Error = "Domain cannot be empty"
-           return result
-       }
-       
-       // Load config
-       if err := config.LoadConfig(); err != nil {
-           result.Error = fmt.Sprintf("Failed to load config: %v", err)
-           return result
-       }
-       
-       cfg := config.GetConfig()
-       
-       // Evaluate blocking rules at this time
-       blockedDomains := scheduler.EvaluateRulesAtTime(testTime, cfg)
-       result.IsBlocked = blockedDomains[domain]
-       
-       // Create DNS query
-       dnsQuery := new(dns.Msg)
-       dnsQuery.SetQuestion(domain+".", dns.TypeA)
-       
-       // Get DNS response
-       response, err := proxy.GetDNSResponse(dnsQuery, blockedDomains,
-                                             cfg.Settings.PrimaryDNS,
-                                             cfg.Settings.BackupDNS)
-       if err != nil {
-           result.Error = fmt.Sprintf("DNS query failed: %v", err)
-           return result
-       }
-       
-       // Format result
-       if result.IsBlocked {
-           result.BlockingStatus = "🚫 BLOCKED"
-           if len(response.Answer) > 0 {
-               if a, ok := response.Answer[0].(*dns.A); ok {
-                   result.DNSResponse = fmt.Sprintf("%s (blocking response)", a.A.String())
-               }
-           }
-       } else {
-           result.BlockingStatus = "✓ ALLOWED (forwarded to upstream DNS)"
-           if len(response.Answer) > 0 {
-               result.DNSResponse = response.Answer[0].String()
-           }
-       }
-       
-       // Find applicable rules
-       for _, rule := range cfg.Rules {
-           if !rule.IsActive || rule.Domain != domain {
-               continue
-           }
-           
-           ruleInfo := RuleInfo{Domain: rule.Domain}
-           
-           if slots, exists := rule.Schedules[testTime.Weekday().String()]; exists {
-               for _, slot := range slots {
-                   currentTime := testTime.Format("15:04")
-                   isActive := currentTime >= slot.Start && currentTime < slot.End
-                   ruleInfo.Schedules = append(ruleInfo.Schedules, ScheduleInfo{
-                       Weekday:  testTime.Weekday().String(),
-                       Start:    slot.Start,
-                       End:      slot.End,
-                       IsActive: isActive,
-                   })
-               }
-           }
-           
-           if len(ruleInfo.Schedules) > 0 {
-               result.ApplicableRules = append(result.ApplicableRules, ruleInfo)
-           }
-       }
-       
-       // Check for warnings
-       warnings := scheduler.CheckWarningDomainsAtTime(testTime, cfg)
-       if contains(warnings, domain) {
-           result.HasWarning = true
-           result.WarningMessage = "⚠️ Warning will trigger 3 minutes before block!"
-       }
-       
-       return result
-   }
-   ```
-
-2. **QueryBlocking(timeStr, domain string) error**
-
-   CLI version - prints formatted output to stdout.
-
-   ```go
-   func QueryBlocking(timeStr, domain string) error {
-       result := GetQueryResult(timeStr, domain)
-       
-       if result.Error != "" {
-           return fmt.Errorf(result.Error)
-       }
-       
-       // Print formatted output
-       separator := strings.Repeat("=", 60)
-       dashLine := strings.Repeat("-", 60)
-       
-       fmt.Println(separator)
-       fmt.Printf("Test Query Result\n")
-       fmt.Println(separator)
-       fmt.Printf("Time:          %s (%s)\n", result.Time, result.Weekday)
-       fmt.Printf("Domain:        %s\n", result.Domain)
-       fmt.Println(dashLine)
-       fmt.Printf("Status:        %s\n", result.BlockingStatus)
-       fmt.Printf("Response:      %s\n", result.DNSResponse)
-       // ... print rules, warnings, etc.
-       fmt.Println(separator)
-       
-       return nil
-   }
-   ```
-
----
-
-## Data Flow
-
-### Flow 1: Service Startup (`./distractions-free install && ./distractions-free start`)
-
-```
-main.go
-  │
-  ├─ Parse args → "start" (service management command)
-  │
-  ├─ Create program{} struct implementing service.Service
-  │
-  ├─ Create service with Config {Name: "DistractionsFree", ...}
-  │
-  ├─ Call service.Control(s, "start")
-  │   │
-  │   ├─ Service framework registers launchd agent (macOS) or Windows Service
-  │   │
-  │   └─ Framework calls program.Start(s)
-  │        │
-  │        ├─ Spawn goroutine: p.run()
-  │        │
-  │        └─ Return success immediately (background)
-  │
-  └─ Exit (service continues in background)
-
-Background Service (p.run())
-  │
-  ├─ config.LoadConfig()
-  │  └─ Read /Library/Application Support/DistractionsFree/config.json
-  │
-  ├─ scheduler.Start()
-  │  └─ Start 1-minute ticker that calls evaluateRules()
-  │
-  ├─ web.StartWebServer()
-  │  └─ Bind to 127.0.0.1:8040 (dashboard)
-  │
-  └─ proxy.StartDNSServer()
-     └─ Bind to 127.0.0.1:53 (requires root, blocks until service stops)
-```
-
-### Flow 2: DNS Request (10:30 AM on Monday, YouTube blocked 09:00-17:00)
-
-```
-1. Application calls getaddrinfo("youtube.com")
-   │
-   ▼
-2. OS looks up system DNS: 127.0.0.1:53
-   │
-   ▼
-3. DNS packet arrives at proxy.StartDNSServer()
-   │
-   ├─ handleDNSRequest(w, r)
-   │  │
-   │  ├─ Get current blockedDomains from scheduler
-   │  │  └─ {"youtube.com": true, "facebook.com": false}
-   │  │
-   │  └─ Call proxy.GetDNSResponse(query, blocked, dnsServers...)
-   │     │
-   │     ├─ Extract domain: "youtube.com."  → "youtube.com"
-   │     │
-   │     ├─ Check: blockedDomainsList["youtube.com"] = true
-   │     │
-   │     └─ Return: "youtube.com 60 IN A 0.0.0.0"
-   │
-   ▼
-4. DNS response sent to application
-   │
-   ▼
-5. Application tries: connect("0.0.0.0:443")
-   │
-   ▼
-6. Connection fails → YouTube is blocked ✓
-```
-
-### Flow 3: Scheduler Minute Tick (09:00 AM on Monday)
-
-```
-Time: 09:00 AM Monday
-  │
-  ▼
-scheduler.Start() ticker fires
-  │
-  ▼
-evaluateRules() called
-  │
-  ├─ cfg = config.GetConfig()
-  │
-  ├─ oldBlocked = activeBlocks  (previous minute's blocked domains)
-  │
-  ├─ newBlocked = scheduler.EvaluateRulesAtTime(now.Time(), cfg)
-  │  │
-  │  └─ Loop through rules:
-  │     - youtube.com: Monday 09:00-17:00
-  │       - currentTime = "09:00"
-  │       - Check: "09:00" >= "09:00" && "09:00" < "17:00" ✓ → BLOCKED
-  │     - facebook.com: Monday 13:00-16:00
-  │       - Check: "09:00" >= "13:00" && "09:00" < "16:00" ✗ → ALLOWED
-  │
-  ├─ Detect state transitions
-  │  └─ oldBlocked has "twitter.com" but newBlocked doesn't
-  │     └─ Block ended! Close tabs with AppleScript
-  │
-  ├─ Check warnings (3 minutes before)
-  │  └─ CheckWarningDomainsAtTime() returns []
-  │
-  ├─ proxy.UpdateBlockedDomains(newBlocked)
-  │  └─ Update the blocked map for DNS requests
-  │
-  └─ activeBlocks = newBlocked
-     └─ Store for next comparison
-```
-
-### Flow 4: Test Query (`./distractions-free --test-query "2024-04-01 10:30" youtube.com`)
-
-```
-main.go
-  │
-  ├─ Parse args → "--test-query", "2024-04-01 10:30", "youtube.com"
-  │
-  ├─ Set config.UseLocalConfig = true
-  │
-  └─ testcli.QueryBlocking("2024-04-01 10:30", "youtube.com")
-     │
-     └─ testcli.GetQueryResult(...)
-        │
-        ├─ Parse time: "2024-04-01 10:30" → time.Time{...}
-        │  └─ Weekday = Monday
-        │
-        ├─ Load config from ./config.json
-        │
-        ├─ Call scheduler.EvaluateRulesAtTime(parsedTime, cfg)
-        │  └─ Returns {"youtube.com": true, ...}
-        │
-        ├─ Build DNS query: "youtube.com A?"
-        │
-        ├─ Call proxy.GetDNSResponse(query, blocked, ...)
-        │  └─ Returns "youtube.com. 60 IN A 0.0.0.0"
-        │
-        └─ Return QueryResult {
-              Time: "2024-04-01 10:30",
-              Weekday: "Monday",
-              Domain: "youtube.com",
-              IsBlocked: true,
-              BlockingStatus: "🚫 BLOCKED",
-              DNSResponse: "0.0.0.0 (blocking response)",
-              ApplicableRules: [{...}],
-              HasWarning: false
-           }
-
-Print formatted output to stdout
-```
-
----
-
-## Service Operation
-
-### Installation Process
-
-**macOS**:
-```bash
-./distractions-free install
-```
-
-Steps:
-1. Service framework creates LaunchAgent plist at `~/Library/LaunchAgents/com.github.distractions-free.plist`
-2. Sets up auto-start on system boot
-3. Requires user to enter password (sudo) for privileged operations
-
-**Windows**:
-```bash
-./distractions-free install
-```
-
-Steps:
-1. Service framework creates Windows Service
-2. Sets up auto-start on system boot
-3. Requires Administrator prompt
-
-### Running as Service
-
-```bash
-./distractions-free start
-```
-
-The service:
-- Runs continuously in background
-- Loads config at startup
-- Starts scheduler (1-minute ticks)
-- Binds to port 53 (requires root/admin)
-- Starts web dashboard on port 8040
-- Handles system sleep/wake gracefully (1-minute ticker resumption)
-
-### Stopping Service
-
-```bash
-./distractions-free stop
-```
-
-Triggers program.Stop():
-- Restores system DNS to default (networksetup)
-- Flushes DNS cache (dscacheutil)
-- Kills mDNSResponder to apply changes
-- All done automatically!
-
-### Accessing Dashboard
-
-While service is running:
-```
-http://127.0.0.1:8040/api/config  (JSON API)
-```
-
-### Non-Service Mode
-
-```bash
-./distractions-free --no-service
-```
-
-Runs exactly like service but in foreground:
-- No privilege escalation needed
-- Uses `./config.json` instead of system paths
-- Useful for testing or development
-
----
-
-## Privileged Operations
-
-### Why Root/Admin is Required
-
-1. **Port 53 Binding** (DNS)
-   - Ports < 1024 require root on Unix/macOS
-   - On Windows, service requires Administrator
-   - Cannot be run as regular user
-
-2. **System DNS Configuration**
-   - modifying system-wide DNS settings requires elevated privileges
-   - On macOS: `networksetup` needs admin
-   - On Windows: PowerShell requires Administrator
-
-3. **System Service Registration**
-   - LaunchAgent (macOS) requires admin
-   - Windows Service requires Administrator
-
-### Privileged Operations in Code
-
-**In proxy/dns.go**:
-```go
-func StartDNSServer() {
-    // This will fail without root/admin
-    server := &dns.Server{Addr: "127.0.0.1:53", Net: "udp"}
-    if err := server.ListenAndServe(); err != nil {
-        // "listen udp 127.0.0.1:53: permission denied"
-        log.Fatalf("Failed to start DNS server: %s", err.Error())
+func (p *program) run() {
+    config.LoadConfig()
+    cfg := config.GetConfig()
+    mode := cfg.Settings.GetEnforcementMode()
+
+    e := enforcer.New(cfg)
+    e.Setup()
+    p.enforcer = e
+
+    scheduler.SetEnforcer(e)
+    scheduler.Start()
+    go web.StartWebServer()
+
+    if mode == "dns" || mode == "strict" {
+        proxy.StartDNSServer()   // blocks until shutdown
+    } else {
+        select {}                // hosts mode: park the goroutine
     }
 }
 ```
 
-**In scheduler/scheduler.go (macOS)**:
-```go
-func evaluateRules() {
-    // ... when block starts ...
-    if runtime.GOOS == "darwin" {
-        // This requires user to be logged in + have access to Chrome/Safari
-        exec.Command("osascript", "-e", script).Run()
-    }
-}
-```
+The terminating call differs by mode: in `dns`/`strict` the DNS server holds the goroutine (and is what `program.Stop` shuts down); in `hosts` mode there's no port binding so we `select {}` to keep the goroutine alive.
 
-**In scheduler/scheduler.go (Stop)**:
+### Service stop path
+
 ```go
 func (p *program) Stop(s service.Service) error {
-    if runtime.GOOS == "darwin" {
-        // These require root/admin to execute
-        exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "Empty").Run()
-        exec.Command("dscacheutil", "-flushcache").Run()
-        exec.Command("killall", "-HUP", "mDNSResponder").Run()
+    proxy.StopDNSServer()
+    if p.enforcer != nil {
+        p.enforcer.Teardown()
     }
     return nil
 }
 ```
 
-### Operations WITHOUT Privileges
+`Teardown` is what restores the system to a usable state:
 
-The testing architecture allows comprehensive testing without root:
+- `HostsEnforcer.Teardown` → `DeactivateAll` → strip the managed block from `/etc/hosts`.
+- `DNSEnforcer.Teardown` → reset Wi-Fi DNS, flush DNS cache.
+- `StrictEnforcer.Teardown` → DNS teardown + `pf.RemoveAnchor`.
 
-**Testable Functions**:
-- `scheduler.EvaluateRulesAtTime()` - Pure function, no system access
-- `proxy.GetDNSResponse()` - No port binding, queries upstream DNS
-- Web handlers - Run on :8040 (no special privileges)
-
-**Why This Works**:
-- Testable functions accept parameters (time, blocked list) instead of calling system functions
-- No mocking needed - real upstream DNS servers respond to test queries
-- No port binding - tests use the functions directly
-- Thread-safe - tests can run in parallel
+`DNSEnforcer.Teardown` only resets the `Wi-Fi` interface today (issue #12). For multi-interface cleanup, use `--clean`.
 
 ---
 
-## Testing Architecture
+## 11. Cleanup (`--clean`)
 
-### Test Strategy
+`internal/cleanup/cleanup.go` plus `priv_unix.go` / `priv_windows.go`. The forensic recovery path: undo every system change distractions-free might have made, even if the service crashed mid-write.
 
-All tests run **without privileges**, **without mocking**, and **without port binding**.
+Each cleanup action is a `Step` with a status (`done`/`skipped`/`warn`/`error`) and an optional `Critical` flag. The summary is printed line-by-line at the end. Critical failures cause a non-zero exit code.
 
-### Unit Test Structure
+### Steps, in order
 
-**scheduler_test.go** (17 tests):
-```go
-func TestEvaluateRulesAtTime_DomainBlockedDuringSchedule(t *testing.T) {
-    cfg := config.Config{
-        Rules: []config.Rule{
-            {
-                Domain: "youtube.com",
-                IsActive: true,
-                Schedules: map[string][]config.TimeSlot{
-                    "Monday": {{Start: "09:00", End: "17:00"}},
-                },
-            },
-        },
-    }
-    
-    // Test specific time: Monday 10:30 (within block)
-    testTime := time.Date(2024, 4, 1, 10, 30, 0, 0, time.UTC)
-    
-    blocked := scheduler.EvaluateRulesAtTime(testTime, cfg)
-    
-    if !blocked["youtube.com"] {
-        t.Error("youtube.com should be blocked at Monday 10:30")
-    }
-}
-```
+1. **Stop the running service** (`service.Control(s, "stop")`). "Not running" is a warning, not an error.
+2. **Reset DNS on every interface** that points at `127.0.0.1`. On macOS this enumerates `networksetup -listallnetworkservices` and runs `networksetup -getdnsservers <name>` per interface. Only interfaces that match `127.0.0.1` are reset to `Empty`. On Windows: a one-liner PowerShell `Get-DnsClientServerAddress | Where ServerAddresses -contains "127.0.0.1" | Set-DnsClientServerAddress -Reset`.
+3. **Strip the managed block from `/etc/hosts`** via `HostsEnforcer.DeactivateAll`. Idempotent — no-op if no block is present.
+4. **Remove the pf anchor** via `pf.RemoveAnchor`. Skipped on non-darwin or if the anchor file doesn't exist.
+5. **Flush the DNS cache** (`dscacheutil -flushcache` + `killall -HUP mDNSResponder` on macOS; `ipconfig /flushdns` on Windows).
+6. **Uninstall the system service** (`service.Control(s, "uninstall")`). Critical.
+7. **Remove the config directory** (`config.ConfigDir()`). Prompts unless `--yes` is passed.
+8. **Remove temp files** (currently `/tmp/df_script.scpt`).
+9. **Verify port 53 is free** by attempting a UDP bind to `127.0.0.1:53`. If something else is holding it, emit a warning suggesting `lsof -i :53`.
 
-**proxy_test.go** (16 tests):
-```go
-func TestGetDNSResponse_AllowedDomainForwarded(t *testing.T) {
-    blocked := map[string]bool{}  // Empty - nothing blocked
-    
-    query := new(dns.Msg)
-    query.SetQuestion("google.com.", dns.TypeA)
-    
-    response, err := proxy.GetDNSResponse(
-        query, 
-        blocked,
-        "8.8.8.8:53",      // Real upstream
-        "1.1.1.1:53",      // Real backup
-    )
-    
-    if err != nil {
-        t.Fatalf("DNS query failed: %v", err)
-    }
-    
-    if len(response.Answer) == 0 {
-        t.Error("Should have DNS response")
-    }
-    
-    // Verify response is from real Google DNS
-    // (actual IP address, not 0.0.0.0)
-}
-```
+### Privilege check
 
-**web_test.go** (16 tests):
-```go
-func TestConfigHandler_ReturnsJSON(t *testing.T) {
-    req := httptest.NewRequest("GET", "/api/config", nil)
-    w := httptest.NewRecorder()
-    
-    ConfigHandler(w, req)
-    
-    if w.Header().Get("Content-Type") != "application/json" {
-        t.Error("Should return application/json")
-    }
-    
-    if w.Code != http.StatusOK {
-        t.Errorf("Expected 200, got %d", w.Code)
-    }
-}
-```
+`IsPrivileged()` is built per-OS:
 
-**testcli_test.go** (22 tests):
-```go
-func TestQueryBlocking_ValidTimeFormat(t *testing.T) {
-    config.UseLocalConfig = true
-    err := testcli.QueryBlocking("2024-04-01 10:30", "google.com")
-    if err != nil {
-        t.Errorf("Valid time format failed: %v", err)
-    }
-}
-```
+- Unix: `os.Geteuid() == 0`.
+- Windows: token-based check via `golang.org/x/sys/windows` against `SECURITY_BUILTIN_DOMAIN_RID + DOMAIN_ALIAS_RID_ADMINS`.
 
-### Running Tests
-
-```bash
-# All tests
-go test ./internal/... -v
-
-# Specific package
-go test ./internal/scheduler -v
-
-# Specific test
-go test ./internal/scheduler -run TestEvaluateRulesAtTime
-
-# Coverage
-go test ./internal/... -cover
-
-# Parallel execution
-go test -race ./internal/...
-```
-
-### Test Results (71 Total Tests)
-
-```
-ok      github.com/vsangava/distractions-free/internal/proxy      0.393s
-ok      github.com/vsangava/distractions-free/internal/scheduler   0.364s
-ok      github.com/vsangava/distractions-free/internal/testcli     0.938s
-ok      github.com/vsangava/distractions-free/internal/web         0.506s
-```
+`runClean` exits early with a clear error message if not privileged.
 
 ---
 
-## Configuration
+## 12. Testability strategy
 
-### Config File Format
+The principle: every piece of logic that's worth testing is a **pure function** of its inputs. Side-effecting code is the thinnest possible wrapper around those functions.
 
-Location: `/Library/Application Support/DistractionsFree/config.json` (macOS)
+| Pure function | Tested behaviour |
+|---|---|
+| `scheduler.EvaluateRulesAtTime(t, cfg)` | All rule semantics: weekday, time slot, multi-slot, inactive rule, paused config, edge times. |
+| `scheduler.CheckWarningDomainsAtTime(t, cfg)` | The 3-min pre-block window. |
+| `proxy.GetDNSResponse(query, blocked, primary, backup)` | Block-returns-0.0.0.0, allowed-forwarded, primary-failover, exact qtype handling, suffix subdomain matching. |
+| `proxy.IsDomainBlocked(domain, blocked)` | Exact and suffix matches. |
+| `enforcer.GenerateHostsEntries(domains)` | Hosts-line generation for the static prefix list. |
+| `pf.GenerateAnchorContent(ips)` | pf table syntax, empty-list behaviour. |
+| `pf.GeneratePreview(domains, dnsServer)` | Resolution + anchor content together. |
+| `web.ValidatePostedConfig(cfg)` | All the bad-input paths. |
+| `web.ConfigHandler` / `TestQueryHandler` etc. | HTTP shape via `httptest`. |
+| `testcli.GetQueryResult(...)` | The struct that drives both the CLI output and the web UI. |
 
-```json
-{
-  "settings": {
-    "primary_dns": "8.8.8.8:53",
-    "backup_dns": "1.1.1.1:53"
-  },
-  "rules": [
-    {
-      "domain": "youtube.com",
-      "is_active": true,
-      "schedules": {
-        "Monday": [
-          {"start": "09:00", "end": "17:00"}
-        ],
-        "Tuesday": [
-          {"start": "09:00", "end": "17:00"}
-        ],
-        "Wednesday": [
-          {"start": "09:00", "end": "17:00"}
-        ],
-        "Thursday": [
-          {"start": "09:00", "end": "17:00"}
-        ],
-        "Friday": [
-          {"start": "09:00", "end": "17:00"}
-        ]
-      }
-    },
-    {
-      "domain": "reddit.com",
-      "is_active": true,
-      "schedules": {
-        "Monday": [
-          {"start": "14:00", "end": "14:30"}
-        ]
-      }
-    },
-    {
-      "domain": "twitter.com",
-      "is_active": false,
-      "schedules": {
-        "Monday": [
-          {"start": "09:00", "end": "17:00"}
-        ]
-      }
-    }
-  ]
-}
-```
+The DNS-response test deliberately queries real `8.8.8.8` and `1.1.1.1` upstreams to verify the forwarding path end-to-end. This is the only test that requires network access.
 
-### Config Reloading
+What's **not** tested by the suite (validated by hand on a real macOS box):
 
-The service **automatically detects config changes** every minute:
+- Port 53 binding (`StartDNSServer`).
+- `networksetup`, `dscacheutil`, `killall mDNSResponder`.
+- `pfctl` invocations.
+- `osascript` invocations against running Chrome/Safari.
+- launchd / Windows Service Manager registration.
 
-```go
-func evaluateRules() {
-    cfg := config.GetConfig()  // Always loads latest from disk
-    // ... rest of evaluation ...
-}
-```
+The `--test-web`, `--test-query`, and `--test-applescript` CLI flags exist exactly to exercise these by-hand paths interactively.
 
-So you can:
-1. Edit `config.json`
-2. Save file
-3. Wait up to 1 minute
-4. New rules take effect automatically (no service restart needed)
+### AppleScript test seam
+
+The scheduler exposes `ScriptExecutor` and `AppleScriptGenerator` interfaces with package-level globals (`scriptExecutor`, `scriptGenerator`) and getters/setters. Tests inject a `TestScriptExecutor` that records executed scripts instead of running `osascript`. The interface boundary lets us assert on script *content* without touching the shell.
 
 ---
 
-## Mode of Operation
+## 13. Concurrency model
 
-### 1. Service Mode (Production)
+Three long-lived goroutines in service mode:
 
-```bash
-# Installation
-sudo ./distractions-free install
+1. **Scheduler tick loop** — single goroutine, fires `evaluateRules()` on a 1-min ticker.
+2. **DNS server** — one goroutine for `Accept`, plus per-request goroutines spawned by `miekg/dns`.
+3. **HTTP server** — one goroutine per request via `net/http` defaults.
 
-# Start service
-sudo ./distractions-free start
+### Shared state and locks
 
-# Verify running
-sudo ./distractions-free status
-```
+| State | Owner | Lock |
+|---|---|---|
+| `config.AppConfig` | `internal/config` | `sync.RWMutex mu` — read on `GetConfig`, write on `LoadConfig`/`SaveConfig`/`SetEnforcementMode`/`SetPause`/`ClearPause` |
+| `scheduler.activeBlocks` | scheduler | `sync.RWMutex activeBlocksMu` — read on diff computation and `GetStatus`, write on tick commit |
+| `scheduler.lastWarningTime` | scheduler | `sync.Mutex lastWarningMu` — only touched once per minute |
+| `proxy.blockedDomains` | proxy | `sync.RWMutex blockMu` — read on every DNS request, write on `UpdateBlockedDomains` |
+| `DNSEnforcer.blocked` | enforcer (one per process) | `sync.Mutex mu` — Activate/Deactivate batches |
 
-**What happens**:
-- Service runs continuously as root/admin
-- Binds to port 53 for DNS
-- Scheduler evaluates every minute
-- Web dashboard accessible at 127.0.0.1:8040
-- Config at system path (`/Library/Application Support/...`)
+The hot path is the per-DNS-query read of `proxy.blockedDomains`; that's why it's an `RWMutex` rather than a regular `Mutex`. Updates from the scheduler happen at most once per minute, so write contention is negligible.
 
----
-
-### 2. No-Service Mode (Local Development)
-
-```bash
-./distractions-free --no-service
-```
-
-**What happens**:
-- Runs in foreground
-- Uses `./config.json` (current directory)
-- Requires NO privileges
-- Perfect for development and testing
+`config.GetConfig()` returns a value copy of the `Config` struct. Slice and map fields inside (`Rules`, `Schedules`) are still references to shared memory — but nothing in the codebase mutates them through a `GetConfig` result. Mutations always go through `LoadConfig`/`SaveConfig`/`SetEnforcementMode`/`SetPause`.
 
 ---
 
-### 3. CLI Test Mode (Quick Testing)
+## 14. Security model
 
-```bash
-./distractions-free --test-query "2024-04-01 10:30" youtube.com
-```
+Distractions-Free is **not** a security tool. It's a friction tool against your own future self. Treat it accordingly:
 
-**Output**:
-```
-============================================================
-Test Query Result
-============================================================
-Time:          2024-04-01 10:30 (Monday)
-Domain:        youtube.com
-------------------------------------------------------------
-Status:        🚫 BLOCKED
-Response:      0.0.0.0 (blocking response)
-------------------------------------------------------------
-Applicable Rules:
-  Domain: youtube.com
-    ✓ Blocked on Monday from 09:00 to 17:00 (ACTIVE)
-------------------------------------------------------------
-⚠️ Warning will trigger 3 minutes before block!
-============================================================
-```
-
-**What happens**:
-- No service needed
-- No privileges required
-- Uses `./config.json`
-- Queries real upstream DNS
-- Exits immediately
+- The dashboard binds `127.0.0.1` only. Network attackers cannot reach `:8040`.
+- The auth token in `X-Auth-Token` keeps random local processes from poking the API by accident, but anything running as your user can read `config.json` and impersonate the dashboard. Same for the PIN — it's client-side only.
+- The Manage-tab PIN is not a password. It's a friction layer designed to make you pause and think before disabling your own focus rules. Trivially bypassed by anyone who reads the JS.
+- The service runs as root (macOS launchd daemon, Windows Service). Anything that compromises the binary inherits root. Build releases via the GitHub Actions workflow; don't run a binary you didn't compile or download from a release tag.
+- `/etc/hosts` and `/etc/pf.conf` edits use atomic temp-file + rename. A crash mid-write cannot corrupt the file. Markers (`# distractions-free:begin`/`:end`) mean other tools that respect them won't trample our entries.
+- The `--clean` command is the canonical recovery path. It iterates every interface, does not assume a happy-path service stop succeeded, and exits non-zero if any critical step fails.
 
 ---
 
-### 4. Web UI Test Mode (Interactive Testing)
+## 15. Platform-specific notes
 
-```bash
-./distractions-free --test-web
-```
+### macOS
 
-**What happens**:
-- Starts web server at 127.0.0.1:8040
-- Opens beautiful interactive UI in browser
-- Real-time DNS queries
-- Displays config and results
-- No privileges required
+- Service framework: `launchd`. The `kardianos/service` library writes a plist to `~/Library/LaunchAgents/com.github.distractions-free.plist` (or system equivalent depending on install context).
+- `osascript` is invoked as the console user (resolved via `stat -f %Su /dev/console`) so notifications appear in the user's UI session and AppleScript can talk to Chrome/Safari. Running `osascript` as root produces a notification nobody can see.
+- `networksetup` is the only supported way to set system DNS — there's no clean API.
+- `dscacheutil -flushcache` + `killall -HUP mDNSResponder` is the canonical cache-flush incantation. Both are needed.
+- `pfctl` requires root and a valid `/etc/pf.conf`. The pf integration validates with `pfctl -n -f` before applying with `pfctl -f`.
 
----
+### Windows
 
-## Request/Response Examples
+- Service framework: Windows Service Manager via `kardianos/service`.
+- Tab closing and pre-block notifications are not implemented — Windows has no equivalent of the AppleScript path. Could be done with PowerShell + browser automation, but isn't currently.
+- `pf` is macOS-only (BSD packet filter); Windows support for strict mode would require WFP integration and isn't planned.
+- DNS reset is done by PowerShell: `Set-DnsClientServerAddress -InterfaceAlias 'Wi-Fi' -ResetServerAddresses`.
+- `ipconfig /flushdns` for cache flush.
 
-### API: Get Current Config
+### Linux
 
-```bash
-curl http://127.0.0.1:8040/api/config
-```
-
-Response:
-```json
-{
-  "settings": {
-    "primary_dns": "8.8.8.8:53",
-    "backup_dns": "1.1.1.1:53"
-  },
-  "rules": [
-    {
-      "domain": "youtube.com",
-      "is_active": true,
-      "schedules": {
-        "Monday": [{"start": "09:00", "end": "17:00"}]
-      }
-    }
-  ]
-}
-```
-
-### API: Test Query (Blocked)
-
-```bash
-curl 'http://127.0.0.1:8040/api/test-query?time=2024-04-01%2010:30&domain=youtube.com'
-```
-
-Response:
-```json
-{
-  "time": "2024-04-01 10:30",
-  "weekday": "Monday",
-  "domain": "youtube.com",
-  "is_blocked": true,
-  "blocking_status": "🚫 BLOCKED",
-  "dns_response": "0.0.0.0 (blocking response)",
-  "applicable_rules": [
-    {
-      "domain": "youtube.com",
-      "schedules": [
-        {
-          "weekday": "Monday",
-          "start": "09:00",
-          "end": "17:00",
-          "is_active": true
-        }
-      ]
-    }
-  ],
-  "has_warning": false
-}
-```
-
-### API: Test Query (Allowed)
-
-```bash
-curl 'http://127.0.0.1:8040/api/test-query?time=2024-04-06%2010:30&domain=google.com'
-```
-
-Response:
-```json
-{
-  "time": "2024-04-06 10:30",
-  "weekday": "Saturday",
-  "domain": "google.com",
-  "is_blocked": false,
-  "blocking_status": "✓ ALLOWED (forwarded to upstream DNS)",
-  "dns_response": "google.com. 287 IN A 142.251.215.110",
-  "applicable_rules": null,
-  "has_warning": false
-}
-```
-
----
-
-## Summary
-
-**Distractions-Free** implements a comprehensive system-level DNS proxy with:
-
-1. **Three-tier architecture**:
-   - Scheduler (evaluates rules every minute)
-   - DNS Proxy (intercepts port 53)
-   - Web UI (dashboard and testing)
-
-2. **Testable design**:
-   - Pure functions for core logic
-   - No mocking needed
-   - Real DNS queries in tests
-
-3. **Multiple operating modes**:
-   - Service mode (production)
-   - No-service mode (development)
-   - CLI test mode (quick verification)
-   - Web UI test mode (interactive testing)
-
-4. **Production-ready**:
-   - Thread-safe operations
-   - Error handling and fallbacks
-   - Automatic config reloading
-   - Clean shutdown and DNS restoration
+- Compiles, but the service path is untested; `kardianos/service` supports systemd but the codebase has no systemd-specific work.
+- `hosts` mode works via `/etc/hosts`. `dns` mode works via `127.0.0.1:53`. AppleScript and pf paths are no-ops.
+- DNS reset is not implemented for Linux interfaces.

--- a/README.md
+++ b/README.md
@@ -1,166 +1,179 @@
-# 🚫 Distractions-Free
+# Distractions-Free
 
-A lightweight, system-level background daemon for macOS (and Windows) that enforces productivity schedules by acting as a local DNS proxy. 
+A system-level focus daemon for **macOS** (and Windows). It enforces a productivity schedule by blocking distracting domains at the OS layer, closing browser tabs when a block begins, and warning you 3 minutes before. It runs as a privileged background service that ordinary users cannot disable on a whim.
 
-Unlike browser extensions that can be easily disabled, **Distractions-Free** runs as a root system service, intercepts DNS requests to distracting domains, and seamlessly kills active browser tabs when a focus block begins.
+Unlike browser extensions — one click to disable — Distractions-Free puts the block in the operating system itself: `/etc/hosts`, the local DNS resolver, and (in strict mode) the `pf` firewall. To turn it off you have to type your admin password.
 
-## ✨ Features
-* **Local DNS Blackholing**: Blocks domains instantly at the OS level by returning \`0.0.0.0\`.
-* **Zero-CPU Polling**: Smart 1-minute scheduling that consumes 0% CPU and handles laptop sleep/wake cycles flawlessly.
-* **Intelligent Tab Killer (macOS)**: Native AppleScript integration closes blocked tabs automatically in Chrome and Safari when a schedule triggers.
-* **3-Minute Warnings**: Sends native macOS notifications as the logged-in user right before a block starts.
-* **Embedded Dashboard**: Ships with an embedded web UI and JSON API (no external web assets required).
-* **System Service Integration**: Installs itself automatically as a \`launchd\` daemon on macOS to survive reboots.
+---
 
-### Platform feature support
+## Table of contents
+
+**For users**
+- [What it does](#what-it-does)
+- [How it works](#how-it-works)
+- [Platform support](#platform-support)
+- [Install](#install)
+- [The web dashboard](#the-web-dashboard)
+- [Configuration](#configuration)
+- [Enforcement modes](#enforcement-modes)
+- [Pause & resume](#pause--resume)
+- [Uninstall & cleanup](#uninstall--cleanup)
+- [Command-line reference](#command-line-reference)
+
+**For developers**
+- [Building from source](#building-from-source)
+- [Running tests](#running-tests)
+- [Test utilities](#test-utilities)
+- [Releases](#releases)
+- [Architecture](#architecture)
+
+---
+
+## What it does
+
+- **Blocks distracting domains on a schedule** — per-day, per-time-slot rules per domain. The default mode rewrites `/etc/hosts`, so blocking works across every browser, every app, and every network without any client-side configuration.
+- **Closes browser tabs when a block starts** — native AppleScript closes matching tabs in Chrome and Safari at the moment the block begins (macOS only).
+- **Sends a 3-minute warning** — native macOS notification before a block starts so you can save your work.
+- **Auto-reloads config every minute** — edit the config file, save, and changes take effect on the next minute boundary. No restart needed.
+- **Survives sleep/wake** — the scheduler is tick-based; locking the lid and reopening hours later works correctly.
+- **Bundled web dashboard** — at `http://localhost:8040`, with status, a query-tester, and a PIN-locked management tab. Static assets are embedded in the binary.
+- **Forensic uninstall** — `--clean` removes every system change (hosts entries, pf anchor, DNS overrides, service registration, config dir, temp files) in a single command.
+
+## How it works
+
+A single Go binary runs as a privileged service (`launchd` on macOS, Windows Service on Windows). On every minute boundary the **scheduler** evaluates your rules against the current time and produces the set of domains that should be blocked right now. The **enforcer** — selected by `enforcement_mode` in config — applies that set:
+
+| Mode | Mechanism | Port 53? |
+|---|---|---|
+| `hosts` *(default)* | edits `/etc/hosts` between managed markers | no |
+| `dns` | local DNS proxy on `127.0.0.1:53`, returns `0.0.0.0` for blocked domains | yes |
+| `strict` | DNS proxy + `pf` firewall (macOS) — blocks the resolved IPs at the kernel | yes |
+
+The enforcer is given the *diff* each tick — domains newly blocked and newly unblocked — so changes are O(diff), not O(rules). The same scheduler also fires the 3-minute warning notification and the AppleScript that closes tabs in Chrome and Safari.
+
+Rule-evaluation logic, DNS-response generation, and hosts-file generation are pure functions that take the current time / config / domain list as arguments. That's how the test suite covers the core behaviour without root, without a real port-53 binding, and without modifying the system.
+
+## Platform support
 
 | Feature | macOS | Windows |
 |---|---|---|
-| Hosts-file blocking (default) | ✅ | ✅ |
-| DNS proxy blocking (`"dns"` mode) | ✅ | ✅ |
-| Strict mode — DNS + pf firewall (`"strict"`) | 🔜 planned | ❌ |
-| Automatic browser tab closing | ✅ (Chrome, Safari via AppleScript) | ❌ |
-| Pre-block warning notifications | ✅ (native macOS notifications) | ❌ |
-| System service (auto-start on boot) | ✅ (launchd) | ✅ (Windows Service) |
+| Hosts-file blocking (`hosts` mode, default) | ✅ | ✅ |
+| DNS proxy blocking (`dns` mode) | ✅ | ✅ |
+| `pf` firewall layer (`strict` mode) | ✅ (DNS-only fallback if pf setup fails) | ❌ |
+| Browser tab closing | ✅ Chrome, Safari (AppleScript) | ❌ |
+| 3-minute pre-block notifications | ✅ native notifications | ❌ |
+| System service / auto-start on boot | ✅ launchd | ✅ Windows Service |
+| `--clean` forensic uninstall | ✅ | ✅ |
 
 ---
 
-## ⚡ Quick Download
+## Install
 
-**Don't want to compile?** Download pre-built binaries from the latest [GitHub Release](https://github.com/vsangava/distractions-free/releases):
+### 1. Get the binary
 
-- 🍎 **macOS Apple Silicon** (M1/M2/M3): `distractions-free-macos-arm64`
-- 🪟 **Windows** (x86_64): `distractions-free-windows-amd64.exe`
+**Pre-built (recommended):** download from the latest [GitHub Release](https://github.com/vsangava/distractions-free/releases):
 
-Then skip to **Step 2** in the installation guide below.
+- macOS Apple Silicon: `distractions-free-macos-arm64`
+- macOS Intel: `distractions-free-macos-amd64`
+- Windows x86_64: `distractions-free-windows-amd64.exe`
 
----
+Then `chmod +x distractions-free-macos-*` on macOS.
 
-## 🛠 Prerequisites (For Building from Source)
+**From source:** see [Building from source](#building-from-source).
 
-If you want to compile the binary yourself, you need the Go compiler installed:
-``` bash
-brew install go
-```
+### 2. Install and start the service
 
----
+The service binds privileged resources (writes to `/etc/hosts`, or binds port 53), so installation requires admin rights:
 
-## 🚀 Installation & Setup
-
-### Step 1: Get the Binary
-
-**Option A: Download Pre-built Binary** (Recommended)
-1. Go to [GitHub Releases](https://github.com/vsangava/distractions-free/releases)
-2. Download the binary for your system
-3. Make it executable: `chmod +x distractions-free-macos-*`
-
-**Option B: Build from Source**
-Clone and build:
-``` bash
-git clone https://github.com/vsangava/distractions-free.git
-cd distractions-free
-go build -o distractions-free ./cmd/app
-```
-
-### Step 2: Install the Background Service
-Because this app runs a local DNS server on port 53, it requires Root/Administrator privileges.
-``` bash
+```bash
 sudo ./distractions-free install
-```
-
-### Step 3: Start the Service
-``` bash
 sudo ./distractions-free start
 ```
 
-### Step 4: Point Your OS to the Proxy
-Tell macOS to use your new local DNS proxy instead of your router's default DNS.
-``` bash
-# If using Wi-Fi:
-networksetup -setdnsservers Wi-Fi 127.0.0.1
+In `hosts` mode (the default) that is everything you need to do — no DNS reconfiguration, no extra steps.
 
-# If using Ethernet:
+In `dns` or `strict` mode you also need to point your OS resolver at the local proxy. Most users should not bother:
+
+```bash
+networksetup -setdnsservers Wi-Fi 127.0.0.1
+# or:
 networksetup -setdnsservers Ethernet 127.0.0.1
 ```
 
+### 3. Verify
+
+Open `http://localhost:8040` — the dashboard should load. You should see the seed rule blocking `youtube.com` Mon–Fri 09:00–17:00 (you'll edit this in [Configuration](#configuration)).
+
 ---
 
-## ⚙️ Administration & Configuration
+## The web dashboard
 
-### The Web Dashboard
-Once the service is running, you can access the local dashboard and API via:
-👉 **http://localhost:8040**
+Open **`http://localhost:8040`** while the service is running. The dashboard has three tabs:
 
-The dashboard has three tabs:
+| Tab | What it does |
+|---|---|
+| **Status** | Currently blocked domains, current enforcement mode, paused state, and the next 24 hours of upcoming block/unblock events. |
+| **Test** | Evaluate any `(time, domain)` pair against the live rules — useful when designing schedules. Optionally evaluate against a custom config without touching the live one. |
+| **Manage** | Edit the live config (rules, settings), trigger a pause, and resume. PIN-protected. |
 
-- **Status** — currently blocked domains, enforcement mode, and upcoming block/unblock events for the next 24 hours.
-- **Test** — test whether a domain would be blocked at any given time, optionally with a custom config (changes here don't affect the live service).
-- **Manage** — update the live config and pause/resume blocking. This tab is PIN-protected.
+### Manage-tab PIN
 
-#### Manage tab PIN
+The Manage tab requires a 4-digit PIN before any change is accepted. The PIN is the **current local time as `HHMM`**, in either 24-hour or 12-hour form. It validates client-side and unlocks the tab for the current page session:
 
-The Manage tab requires a 4-digit PIN before any changes can be made. The PIN is the current time formatted as `HHMM`. Both 24-hour and 12-hour formats are accepted:
-
-| Current time | Valid PINs |
+| Local time | Valid PINs |
 |---|---|
 | 2:35 PM | `1435` (24h) or `0235` (12h) |
-| 9:05 AM | `0905` (both formats are the same) |
+| 9:05 AM | `0905` |
 | 9:05 PM | `2105` (24h) or `0905` (12h) |
-| 12:00 noon | `1200` (both formats are the same) |
+| 12:00 noon | `1200` |
 | 12:00 midnight | `0000` (24h) or `1200` (12h) |
 
-The PIN is validated client-side only. It unlocks the Manage tab for the current browser session and resets on page reload.
+The PIN is a friction layer, not a security control. The server-side auth is the **auth token** stored in `config.json` under `settings.auth_token`. The web UI fetches it from the public `GET /api/config` endpoint on first load and sends it in the `X-Auth-Token` header for every other API call. If you don't trust local users on the machine, treat the auth token as a secret — the dashboard listens only on `127.0.0.1`, but anything running locally as your user can read it.
 
-### Enforcement Modes
+---
 
-Distractions-Free supports three enforcement modes, configured via the `enforcement_mode` field in `settings`. If the field is absent the daemon defaults to `"hosts"`.
+## Configuration
 
-| Mode | Value | How it blocks | Requires root |
-|---|---|---|---|
-| **Standard** (default) | `"hosts"` | Edits `/etc/hosts` | Yes (write to hosts file) |
-| **DNS Proxy** | `"dns"` | Local DNS proxy on 127.0.0.1:53 | Yes (port < 1024) |
-| **Strict** | `"strict"` | DNS proxy + pf firewall *(pf is planned; currently DNS-only)* | Yes |
+The daemon reads its configuration from a single JSON file:
 
-**Choosing a mode:**
-- `"hosts"` is the default and works without changing your system DNS settings. It adds entries to `/etc/hosts` inside clearly-marked managed markers and removes them when the block ends. Common subdomains (`www.`, `m.`, `mobile.`, `app.`) are blocked automatically. This is the best choice for most users.
-- `"dns"` is the legacy mode. It runs a local DNS proxy on port 53 and requires you to point your OS DNS at `127.0.0.1`. Use this if you relied on the old behaviour.
-- `"strict"` adds a `pf` firewall layer on top of DNS. Full pf integration is in development; for now it behaves identically to `"dns"`.
+| OS | Path |
+|---|---|
+| macOS (service) | `/Library/Application Support/DistractionsFree/config.json` |
+| Windows (service) | `%PROGRAMDATA%\DistractionsFree\config.json` |
+| Linux | `/etc/distractionsfree/config.json` |
+| Any (`--no-service`) | `./config.json` (working directory) |
 
-To switch to DNS proxy mode, set `"enforcement_mode": "dns"` in config and restart the service. Alternatively, use the `--strict` shorthand:
+The file is generated with sensible defaults on first launch. The scheduler reloads it every minute, so live edits take effect on the next tick — no restart required.
 
-```bash
-sudo ./distractions-free --strict   # sets mode to "strict" in config
-sudo ./distractions-free start      # service picks up the new mode
-```
+### Example
 
-### Modifying the Schedule
-By default, the daemon stores its configuration file at a secure, absolute system path:
-* **macOS:** \`/Library/Application Support/DistractionsFree/config.json\`
-* **Windows:** \`C:\ProgramData\DistractionsFree\config.json\`
-
-To update your rules, simply edit this file. The background daemon will automatically detect and apply the new rules on the next 1-minute tick!
-
-**Example Configuration:**
-``` json
+```json
 {
   "settings": {
     "primary_dns": "8.8.8.8:53",
     "backup_dns": "1.1.1.1:53",
-    "enforcement_mode": "hosts"
+    "enforcement_mode": "hosts",
+    "auth_token": "c911284368ac967797e8af4379b3bcb6"
   },
   "rules": [
+    {
+      "domain": "youtube.com",
+      "is_active": true,
+      "schedules": {
+        "Monday":    [{"start": "09:00", "end": "17:00"}],
+        "Tuesday":   [{"start": "09:00", "end": "17:00"}],
+        "Wednesday": [{"start": "09:00", "end": "17:00"}],
+        "Thursday":  [{"start": "09:00", "end": "17:00"}],
+        "Friday":    [{"start": "09:00", "end": "17:00"}]
+      }
+    },
     {
       "domain": "facebook.com",
       "is_active": true,
       "schedules": {
         "Monday": [
           {"start": "09:00", "end": "11:00"},
-          {"start": "13:00", "end": "15:00"},
-          {"start": "16:00", "end": "17:00"}
-        ],
-        "Wednesday": [
-          {"start": "09:00", "end": "12:00"},
-          {"start": "14:00", "end": "17:00"}
+          {"start": "13:00", "end": "15:00"}
         ]
       }
     }
@@ -168,328 +181,233 @@ To update your rules, simply edit this file. The background daemon will automati
 }
 ```
 
-> **Migrating from a previous version?** Older installs had no `enforcement_mode` field, which means they were using the DNS proxy. After upgrading, the daemon will switch to `"hosts"` mode automatically. If you want to keep the old DNS proxy behaviour, add `"enforcement_mode": "dns"` to your config and also restore your system DNS (which was pointing at `127.0.0.1`):
-> ```bash
-> networksetup -setdnsservers Wi-Fi 127.0.0.1   # macOS — point DNS at the proxy
-> ```
+### Field reference
+
+- **`settings.primary_dns` / `backup_dns`** — upstream resolvers for `dns`/`strict` mode. Ignored in `hosts` mode.
+- **`settings.enforcement_mode`** — `"hosts"` (default), `"dns"`, or `"strict"`. See [Enforcement modes](#enforcement-modes).
+- **`settings.auth_token`** — auto-generated 32-char hex on first launch. The web UI requires this token for every API call except `GET /api/config` (which is intentionally public so the UI can bootstrap the token).
+- **`rules[].domain`** — bare domain (no `www.`). In `hosts` mode the enforcer automatically also blocks the prefixes `www.`, `m.`, `mobile.`, `app.`. Subdomain matching in `dns` mode is suffix-based (`a.b.example.com` is blocked if `example.com` is blocked).
+- **`rules[].is_active`** — set to `false` to suspend a single rule without deleting it.
+- **`rules[].schedules`** — object keyed by weekday name (`"Monday"` … `"Sunday"`). Each value is an array of `{start, end}` slots in `HH:MM` 24-hour format. A domain is blocked when current time falls in `[start, end)`.
+- **`pause`** *(optional)* — `{"until": "<RFC3339 timestamp>"}`. While set, all blocking is suspended. Cleared automatically once `until` passes. Easiest to set via the dashboard or the [`/api/pause`](#http-api) endpoint.
+
+### Editing rules from the command line
+
+You can edit the config file directly with any editor — the daemon picks up changes within 60 seconds. It must be valid JSON; if parsing fails, the daemon logs a warning and keeps using the previous in-memory copy.
 
 ---
 
-## 🛑 Uninstallation & Safety
+## Enforcement modes
 
-**⚠️ CRITICAL:** Do not delete the application without restoring your system DNS settings first, or your internet will stop working!
+The default is `"hosts"`. Most users should leave it that way. Choose another mode only if you have a specific reason.
 
-To safely remove the app, run the built-in uninstall commands. Our daemon is programmed to automatically restore your default macOS Wi-Fi DNS and flush your cache upon shutdown:
-``` bash
-# 1. Stop the service (Automatically restores default OS DNS)
-sudo ./distractions-free stop
+### `hosts` (default)
 
-# 2. Remove the daemon from system startup
-sudo ./distractions-free uninstall
+Edits `/etc/hosts` (macOS/Linux) or `C:\Windows\System32\drivers\etc\hosts` (Windows). Blocked entries live between marker lines (`# distractions-free:begin` / `# distractions-free:end`) and are atomically rewritten via temp file + rename, so a crash mid-write cannot corrupt the file. Other entries are never touched.
 
-# 3. Clean up the configuration folder
+**Pros:** no port binding, works in every browser and every app, survives DNS-server changes, no system DNS reconfiguration.
+
+**Cons:** no wildcards (only the static prefix list), so very deep CDN domains are not covered.
+
+### `dns`
+
+Runs a local DNS proxy on `127.0.0.1:53`. Blocked domains return `0.0.0.0`; everything else is forwarded to `primary_dns` (failover to `backup_dns`). On macOS the daemon also resets system DNS on shutdown.
+
+**Pros:** suffix-matched subdomain blocking (`a.b.example.com` blocked if `example.com` is in the list).
+
+**Cons:** requires you to point your OS DNS at `127.0.0.1`. Apps that hard-code their own DNS resolver (some VPN clients, some browsers in DoH mode) bypass it.
+
+### `strict`
+
+Like `dns`, plus a `pf` (Packet Filter) anchor on macOS that drops outbound packets to the resolved IPs at the kernel level. Each tick, the enforcer resolves blocked domains to A/AAAA addresses and rewrites the pf anchor table. Existing connections to those IPs are killed.
+
+**Pros:** harder to bypass than DNS alone — even apps with their own resolver can't reach the IPs.
+
+**Cons:** macOS only. CDN-heavy domains rotate IPs and only the resolved subset is blocked. If pf setup fails (permissions, edited `pf.conf`), the enforcer logs a warning and degrades to DNS-only.
+
+### Switching modes
+
+Either edit `enforcement_mode` in `config.json` and restart the service, or use the shorthand:
+
+```bash
+sudo ./distractions-free --strict   # writes "strict" to config and exits
+sudo ./distractions-free start      # restart to pick it up
+```
+
+---
+
+## Pause & resume
+
+Need to break the rules — interview, demo, watching a YouTube link a colleague sent? Use the **Manage** tab to pause for up to 4 hours, or hit the API directly:
+
+```bash
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+
+# Pause for 30 minutes
+curl -X POST http://localhost:8040/api/pause \
+  -H "X-Auth-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"minutes": 30}'
+
+# Resume immediately
+curl -X DELETE http://localhost:8040/api/pause \
+  -H "X-Auth-Token: $TOKEN"
+```
+
+A pause window is persisted in `config.json` as `pause.until`. The scheduler clears it automatically once the timestamp passes, so you don't end up with stale pauses lying around.
+
+---
+
+## Uninstall & cleanup
+
+The recommended path is the all-in-one `--clean` command. It stops the service, removes hosts entries, removes the pf anchor, resets DNS on every interface that was pointing at `127.0.0.1`, flushes the resolver cache, uninstalls the service registration, removes the config directory, deletes temp files, and verifies port 53 is free:
+
+```bash
+sudo ./distractions-free --clean          # interactive: asks before deleting config
+sudo ./distractions-free --clean --yes    # non-interactive: deletes config without asking
+```
+
+If you'd rather drive the steps yourself:
+
+```bash
+sudo ./distractions-free stop        # restores DNS in dns/strict mode; clears hosts entries in hosts mode
+sudo ./distractions-free uninstall   # removes the service registration
 sudo rm -rf "/Library/Application Support/DistractionsFree"
+```
+
+> ⚠️ In `dns`/`strict` mode, do not delete the binary while the service is running with system DNS pointed at `127.0.0.1`, or the machine will lose name resolution. `--clean` handles this correctly; manual removal does not.
 
 ---
 
-## 🧪 Testing
+## Command-line reference
 
-The codebase includes comprehensive unit tests for the core blocking and scheduling logic that run **without requiring privileges, port binding, or system modifications**.
-
-### Run All Tests
-``` bash
-go test ./internal/... -v
+```
+distractions-free <subcommand>           # service management (kardianos/service)
+distractions-free [--flag]               # local / test mode
+sudo distractions-free --clean [--yes]   # forensic uninstall
 ```
 
-### Run Specific Test Suites
+| Command / flag | Privileges | What it does | More |
+|---|---|---|---|
+| `install` | sudo | Register the system service (launchd / Windows Service) | [Install](#install) |
+| `uninstall` | sudo | Remove the service registration | [Uninstall](#uninstall--cleanup) |
+| `start` | sudo | Start the service in the background | [Install](#install) |
+| `stop` | sudo | Stop the service; clears hosts entries / restores DNS as appropriate | [Uninstall](#uninstall--cleanup) |
+| `status` | sudo | Print whether the service is running | — |
+| `run` | sudo | Run as if launched by the service supervisor (foreground) | — |
+| `--no-service` | none | Run the daemon in the foreground using `./config.json` (skips system paths). In `dns`/`strict` mode you still need root to bind port 53. | [Test utilities](#test-utilities) |
+| `--strict` | sudo | Set `enforcement_mode` to `"strict"` in config and exit. Restart the service to apply. | [Switching modes](#switching-modes) |
+| `--clean [--yes]` | sudo | Forensic recovery: undo every system change. Use this before deleting the binary. | [Uninstall](#uninstall--cleanup) |
+| `--test-query "<YYYY-MM-DD HH:MM>" <domain>` | none | Print whether a domain would be blocked at a specific time, with the matching rules. Uses `./config.json`. | [Test utilities](#test-utilities) |
+| `--test-web` | none | Start the web dashboard standalone for testing schedules without installing the service. Uses `./config.json`. | [Test utilities](#test-utilities) |
+| `--test-applescript` | none | Generate the AppleScript that closes Chrome/Safari tabs and optionally execute it. macOS only. | [Test utilities](#test-utilities) |
 
-**Scheduler Tests** (time-based blocking rules evaluation):
-``` bash
-go test ./internal/scheduler -v
-```
-- Tests rule evaluation at specific times
-- Validates blocking windows (start/end times)
-- Tests warning triggers (3-minute pre-block notifications)
-- Tests all weekday schedules and edge cases
+### HTTP API
 
-**DNS Proxy Tests** (DNS request handling and forwarding):
-``` bash
-go test ./internal/proxy -v
-```
-- Tests blocked domain responses (returns `0.0.0.0`)
-- Tests allowed domain forwarding to **real upstream DNS servers** (Google 8.8.8.8, Cloudflare 1.1.1.1)
-- Tests DNS failover (primary → backup DNS)
-- Tests various DNS record types (A, AAAA, MX, CNAME)
-- Tests DNS reply formatting and TTL
+All endpoints listen on `127.0.0.1:8040`. Every endpoint except the first requires `X-Auth-Token: <auth_token>` (read it from `GET /api/config`).
 
-### Test Coverage
-**17 Scheduler Tests:**
-- Blocking logic during/outside schedules
-- Multiple domains and time slots
-- All 7 weekdays
-- Warning notification timing
-- Edge cases (exact start/end times)
-
-**16 DNS Proxy Tests:**
-- Domain blocking and forwarding
-- Upstream DNS queries
-- Failover behavior
-- Record type handling
-- TTL and reply flag validation
-
-### Why These Tests Work Without Privileges
-- ✅ **Testable pure functions**: Core logic extracted to accept time/config as parameters
-- ✅ **Real upstream DNS**: Tests query actual DNS servers to verify forwarding works
-- ✅ **No port binding**: DNS logic tested without binding to port 53
-- ✅ **No system modifications**: No DNS cache flushing or system DNS changes
-- ✅ **No mocking**: Tests use real DNS responses for authenticity
-
-### What's NOT Tested (Requires Privileges)
-These features require root/admin and service installation, so they're validated manually:
-- ❌ Port 53 binding
-- ❌ System DNS cache flushing
-- ❌ Browser tab closing
-- ❌ Service installation/management
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/config` | GET | Current config (public — used to bootstrap the token in the UI) |
+| `/api/config/update` | POST | Replace the rules / settings; validated server-side |
+| `/api/status` | GET / POST | Current blocked domains, last evaluation, paused state |
+| `/api/test-query?time=&domain=` | GET / POST | Evaluate `(time, domain)`; POST a `config` form field to test against a custom config |
+| `/api/hosts-preview` | GET / POST | Show the `/etc/hosts` lines that would be written for the currently blocked set |
+| `/api/pf-preview` | GET / POST | Show the resolved IPs and `pf` anchor content (strict mode only) |
+| `/api/pause` | POST | Body `{"minutes": N}` (1–240) |
+| `/api/pause` | DELETE | Resume immediately |
 
 ---
 
-## 🧪 Interactive Testing with --test-query
+# For developers
 
-Test whether specific domains would be blocked at any given time **without installing the service or requiring privileges**.
+## Building from source
 
-### Quick Test
-Check if a domain is blocked at a specific time:
-``` bash
+Requires Go 1.21+ (the release pipeline uses 1.26.2).
+
+```bash
+git clone https://github.com/vsangava/distractions-free.git
+cd distractions-free
+
+make build         # current OS only
+make build-all     # macOS arm64 + amd64 + Windows amd64
+```
+
+`make help` lists every target. The full list:
+
+| Target | What it does |
+|---|---|
+| `make build` | Build for current OS into `./distractions-free` |
+| `make build-all` | Cross-compile macOS arm64, macOS amd64, and Windows amd64 |
+| `make test` | `go test ./...` |
+| `make release` | `test` + `build-all` + `verify-binaries` (pre-release sanity check) |
+| `make clean` | Remove built binaries |
+
+## Running tests
+
+```bash
+go test ./...                       # everything
+go test ./internal/scheduler -v     # rule evaluation
+go test ./internal/proxy -v         # DNS response generation
+go test ./internal/enforcer -v      # hosts/dns/strict enforcer logic
+go test ./internal/web -v           # HTTP handlers
+```
+
+The whole suite runs without root, without binding port 53, and without modifying any system file. Core logic is implemented as pure functions (`scheduler.EvaluateRulesAtTime`, `proxy.GetDNSResponse`, `enforcer.GenerateHostsEntries`, `pf.GenerateAnchorContent`) so tests pass `time.Time`, `config.Config`, and domain lists in directly.
+
+The DNS-response tests query real upstream resolvers (`8.8.8.8`, `1.1.1.1`) to verify forwarding and failover, so you'll need internet access for `./internal/proxy`.
+
+What the test suite does **not** cover (these are validated by hand because they need root and a live macOS environment):
+
+- Port 53 binding
+- System DNS reconfiguration (`networksetup`)
+- `pf` rule loading
+- AppleScript tab-closing in Chrome/Safari
+- Service registration in launchd / Windows Service Manager
+
+## Test utilities
+
+Three flags let you exercise the daemon without installing it:
+
+### `--test-query "<time>" <domain>`
+
+```bash
 ./distractions-free --test-query "2024-04-01 10:30" youtube.com
 ```
 
-### Output Example
-```
-============================================================
-Test Query Result
-============================================================
-Time:          2024-04-01 10:30 (Monday)
-Domain:        youtube.com
-------------------------------------------------------------
-Status:        🚫 BLOCKED
-Response:      0.0.0.0 (blocking response)
-------------------------------------------------------------
-Applicable Rules:
-  Domain: youtube.com
-    ✓ Blocked on Monday from 09:00 to 17:00 (ACTIVE)
-------------------------------------------------------------
-============================================================
-```
+Prints whether the domain would be blocked at that moment, the matching rule(s), and whether a 3-minute warning would fire. Uses `./config.json`. Time format: `YYYY-MM-DD HH:MM` (24-hour).
 
-### Time Format
-Use **`2006-01-02 15:04`** format (YYYY-MM-DD HH:MM in 24-hour time):
-- Example: `2024-04-01 10:30` = Monday, April 1, 2024 at 10:30 AM
-- Example: `2024-04-01 09:00` = Monday, April 1, 2024 at 9:00 AM (start of block)
+### `--test-web`
 
-### Test Cases
-
-**Check if a domain is allowed:**
-``` bash
-./distractions-free --test-query "2024-04-06 10:30" youtube.com
-```
-Output: `✓ ALLOWED (forwarded to upstream DNS)` with DNS response
-
-**Test warning trigger (3 minutes before block):**
-``` bash
-./distractions-free --test-query "2024-04-01 08:57" youtube.com
-```
-Output: Shows `⚠️ Warning will trigger 3 minutes before block!`
-
-**Multi-slot schedule tests:**
-``` bash
-./distractions-free --test-query "2024-04-01 10:30" facebook.com   # Monday first block
-./distractions-free --test-query "2024-04-01 12:30" facebook.com   # Monday gap between blocks
-./distractions-free --test-query "2024-04-01 14:30" facebook.com   # Monday second block
-./distractions-free --test-query "2024-04-01 17:45" linkedin.com   # Monday evening block
-./distractions-free --test-query "2024-04-02 12:30" linkedin.com   # Tuesday midday block
-```
-
-**Test different domains and times:**
-``` bash
-./distractions-free --test-query "2024-04-01 17:00" facebook.com  # After block ends
-./distractions-free --test-query "2024-04-02 10:30" linkedin.com  # Tuesday schedule
-```
-
-### Why This Feature is Useful
-- ✅ **Verify your rules**: Confirm blocking schedules work as expected
-- ✅ **No system impact**: Uses local config file, no service needed
-- ✅ **Real DNS queries**: Shows actual upstream DNS responses
-- ✅ **Debug schedules**: Check if a specific time/domain/day combination triggers blocking
-- ⚠️ **Root still required**: `--no-service` avoids service installation but still binds port 53, which requires root on all Unix systems. Use `sudo` even in this mode.
-
-
----
-
-## 🌐 Web UI Test Mode (`}--test-web`)
-
-A beautiful, interactive web interface for testing DNS blocking queries in your browser.
-
-### Launch the Test UI
 ```bash
 ./distractions-free --test-web
+# open http://localhost:8040
 ```
-Then open your browser to **http://localhost:8040**
 
-### Features
-- **Beautiful gradient UI**: Modern purple gradient design with responsive layout
-- **Time input**: Pick any date/time in format `YYYY-MM-DD HH:MM`
-- **Domain input**: Enter the domain to test (with example placeholder)
-- **Live config viewer**: See the current config in read-only JSON format
-- **Real-time results**: Displays:
-  - Weekday (calculated from the date)
-  - Blocking status with emoji (🚫 BLOCKED or ✓ ALLOWED)
-  - Actual DNS response (real IPs from upstream DNS)
-  - Applicable rules with schedule details
-  - Warning notifications (3-minute pre-block alerts)
-- **Color-coded display**: 
-  - Red for blocked status
-  - Green for allowed status
-  - Yellow warnings for pre-block notifications
-- **Loading animation**: Spinner while query executes
+Runs the full dashboard against `./config.json` without installing the service. The Manage tab can edit the local config; nothing system-level is touched. The hosts-preview and pf-preview endpoints are particularly useful here — they show exactly what *would* be written to `/etc/hosts` or loaded into pf, without root.
 
-### Web UI Screenshots
-When testing YouTube on Monday at 10:30 (blocked):
-- Status shows: 🚫 **BLOCKED**
-- DNS Response: `0.0.0.0 (blocking response)`
-- Applicable Rules: "✓ ACTIVE: Monday 09:00-17:00"
+### `--test-applescript`
 
-When testing Google on Saturday at 10:30 (allowed):
-- Status shows: ✓ **ALLOWED (forwarded to upstream DNS)**
-- DNS Response: `google.com. 287 IN A 142.251.215.110`
-- Applicable Rules: "No rules apply"
-
-### Why Use the Web UI Instead of CLI
-- 🎨 **Visual**: See results in a beautiful, easy-to-read format
-- 🔄 **Fast iterations**: Quickly test multiple times/domains without typing commands
-- 📋 **Config viewer**: See your rules configuration side-by-side with results
-- 🌟 **Better UX**: Emoji status indicators, color coding, and smooth animations
-- ⌨️ **Press Enter to submit**: Type time/domain and hit Enter to test
-
-### Example Usage
-1. Launch: `./distractions-free --test-web`
-2. Browser opens to http://localhost:8040
-3. Time field pre-filled with current time
-4. Enter domain: `youtube.com`
-5. Click "Test Query" or press Enter
-6. Instantly see if it's blocked with rule details
-7. Modify time to test different schedules
-8. See DNS responses from real upstream servers
-
----
-
-## 🖥️ AppleScript Test Mode (`--test-applescript`)
-
-Test the macOS AppleScript integration for warning notifications and tab closing **without requiring privileges or service installation**.
-
-### Quick Test
-Run the AppleScript test to verify GUI interactions:
-``` bash
+```bash
 ./distractions-free --test-applescript
 ```
 
-### What It Does
-- **Scans Browser Tabs**: Checks Chrome and Safari for open tabs matching test domains
-- **Conditional Warnings**: Shows native macOS alert only for domains that have open tabs
-- **Closes Tabs**: Automatically closes tabs for facebook.com after a brief delay
-- **Interactive Confirmation**: Asks for user confirmation before executing scripts
+Generates the AppleScript used by the tab-closer and optionally executes it. macOS only. Test domains: `facebook.com` (close), `reddit.com` and `roblox.com` (warning — only fires if a tab is open).
 
-### Test Domains
-- **Warning Domains**: reddit.com, roblox.com (alert shown only if tabs are open)
-- **Close Domains**: facebook.com (tabs closed regardless of open status)
+## Releases
 
-### Output Example
-```
-=== CLOSE TABS SCRIPT (facebook.com) ===
-tell application "Google Chrome"
-    repeat with w in windows
-        set tabList to tabs of w whose URL contains "facebook.com"
-        repeat with t in tabList
-            close t
-        end repeat
-    end repeat
-end tell
-tell application "Safari"
-    repeat with w in windows
-        set tabList to tabs of w whose URL contains "facebook.com"
-        repeat with t in tabList
-            close t
-        end repeat
-    end repeat
-end tell
-
-Execute scripts? (y/N): y
-Executing warning script...
-Sleeping 2 seconds before close tabs script...
-Executing close tabs script...
-```
-
-### Why This Feature is Useful
-- ✅ **Verify AppleScript**: Test that macOS GUI interactions work correctly
-- ✅ **No system impact**: Uses test domains and requires user confirmation
-- ✅ **Debug notifications**: Ensure alerts display properly in user context
-- ✅ **Test tab closing**: Validate browser automation works across Chrome/Safari
-- ✅ **Service compatibility**: Confirms scripts work in both interactive and service modes
-
----
-
-## 📦 Release Process (For Maintainers)
-
-### How Releases Work
-
-This project uses **GitHub Actions** to automatically build and release binaries whenever a new version tag is pushed.
-
-### Making a Release
-
-1. **Create a version tag** (semantic versioning):
-   ```bash
-   git tag v1.0.0
-   git push origin v1.0.0
-   ```
-
-2. **Automatic Build Process**:
-   - GitHub Actions workflow triggers automatically
-   - Builds binaries for macOS ARM64 and Windows (x86_64)
-   - Runs full test suite on each platform
-   - Uploads binaries to the release
-
-3. **Release is Created**:
-   - Visit [Releases page](https://github.com/vsangava/distractions-free/releases)
-   - Add release notes describing changes
-   - Users can now download binaries
-
-### Workflow Details
-
-The `.github/workflows/release.yml` file:
-- **Triggers on**: Git tags matching `v*` (e.g., `v1.0.0`)
-- **Builds for**:
-  - macOS ARM64 (Apple Silicon: M1/M2/M3)
-  - Windows x86_64
-- **Tests**: Runs `go test ./...` on each platform before release
-- **Uploads**: Uses GitHub's release artifacts API
-
-### Example Release Workflow
+Tagged commits matching `v*` trigger the GitHub Actions workflow at `.github/workflows/release.yml`:
 
 ```bash
-# Make final commits and tag version
-git tag v1.0.0
-git push origin v1.0.0
-
-# → GitHub Actions automatically:
-#   1. Builds 3 binaries
-#   2. Runs all tests
-#   3. Creates release with binaries attached
-#   4. Available at https://github.com/vsangava/distractions-free/releases/tag/v1.0.0
+make release          # local sanity check: tests + build-all
+git tag v1.2.3
+git push origin v1.2.3
 ```
 
-### Next Steps for Production
+The workflow builds for `darwin/arm64` and `windows/amd64`, runs `go test ./...` on each, and attaches the binaries to the release. macOS Intel (`darwin/amd64`) is built locally by `make build-all` but is **not** part of the release matrix at the moment — add a row to `.github/workflows/release.yml` if you need it on the release page.
 
-When ready for wider distribution:
-- [ ] Add code signing for macOS (required for newer macOS versions)
-- [ ] Create Homebrew formula for `brew install distractions-free`
-- [ ] Create Scoop manifest for Windows package manager
-- [ ] Consider Windows installer (.msi) using WiX or NSIS
+The release matrix uses Go 1.26.2 with `CGO_ENABLED=0` so the resulting binaries are statically linked.
+
+## Architecture
+
+For a deep dive into modules, data flow, and the enforcer abstraction, see [DESIGN.md](./DESIGN.md). For diagnostic and recovery procedures, see [TROUBLESHOOTING.md](./TROUBLESHOOTING.md).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,517 +1,465 @@
-# Privileged Operations Testing & Troubleshooting Guide
+# Troubleshooting & Recovery
 
-## Part 1: Testing Privileged Operations
+This document is for when something is wrong. If you're just installing for the first time, read [README.md](./README.md). If you want to understand how the daemon works internally, read [DESIGN.md](./DESIGN.md).
 
-### ✅ What Can Be Tested WITHOUT Service Installation
+## Contents
 
-The current setup allows testing these operations without privileges:
-
-1. **Rule Evaluation Logic** (✓ Verified)
-   ```bash
-   ./distractions-free --test-query "2024-04-01 10:30" youtube.com
-   ```
-   - Tests `scheduler.EvaluateRulesAtTime()` (pure function)
-   - Queries real upstream DNS
-   - Shows what WOULD happen at that time
-
-2. **DNS Response Generation** (✓ Verified)
-   - Uses real 8.8.8.8 and 1.1.1.1 DNS servers
-   - No port binding needed
-   - Tests blocking logic without port 53
-
-3. **Web API** (✓ Verified)
-   ```bash
-   ./distractions-free --test-web
-   curl http://127.0.0.1:8040/api/test-query?time=2024-04-01%2010:30&domain=youtube.com
-   ```
-
-4. **Configuration Loading** (✓ Verified)
-   - Uses `./config.json` with `UseLocalConfig=true`
-   - Tests config parsing without system paths
+1. [If your internet is broken — read this first](#1-if-your-internet-is-broken--read-this-first)
+2. [Quick triage by symptom](#2-quick-triage-by-symptom)
+3. [Inspecting service state](#3-inspecting-service-state)
+4. [Mode-specific diagnostics](#4-mode-specific-diagnostics)
+5. [Reading logs](#5-reading-logs)
+6. [Manual install / start / stop / uninstall](#6-manual-install--start--stop--uninstall)
+7. [Verifying behaviour without installing the service](#7-verifying-behaviour-without-installing-the-service)
+8. [The `--clean` recovery path](#8-the---clean-recovery-path)
+9. [Common errors](#9-common-errors)
 
 ---
 
-## Part 2: Testing Privileged Operations (Requires sudo)
+## 1. If your internet is broken — read this first
 
-To test the actual privileged operations, you need to install the service:
+If you removed or stopped the service while it was in `dns` or `strict` mode and now nothing resolves, your system DNS is still pointing at `127.0.0.1` but the proxy isn't there to answer.
 
-### 2.1 Build the Binary
-
-```bash
-cd /Users/phani/code/distractions-free
-go build -o distractions-free ./cmd/app
-```
-
-### 2.2 Set Up Test Config
+**Fix it in one command (requires sudo):**
 
 ```bash
-# Create the system config directory
-sudo mkdir -p "/Library/Application Support/DistractionsFree"
-
-# Create a test config file
-sudo tee "/Library/Application Support/DistractionsFree/config.json" > /dev/null << 'EOF'
-{
-  "settings": {
-    "primary_dns": "8.8.8.8:53",
-    "backup_dns": "1.1.1.1:53"
-  },
-  "rules": [
-    {
-      "domain": "youtube.com",
-      "is_active": true,
-      "schedules": {
-        "Monday": [{"start": "09:00", "end": "17:00"}],
-        "Tuesday": [{"start": "09:00", "end": "17:00"}],
-        "Wednesday": [{"start": "09:00", "end": "17:00"}],
-        "Thursday": [{"start": "09:00", "end": "17:00"}],
-        "Friday": [{"start": "09:00", "end": "17:00"}]
-      }
-    }
-  ]
-}
-EOF
-
-echo "Config file created successfully"
+sudo ./distractions-free --clean --yes
 ```
 
-### 2.3 Install the Service
+That iterates every network interface, resets the ones pointing at `127.0.0.1`, flushes the resolver cache, and verifies port 53 is free. It also handles the case where you've already deleted the binary's config dir.
+
+**If you no longer have the binary**, do it by hand:
 
 ```bash
-sudo ./distractions-free install
+# macOS — list every interface, reset any whose DNS shows 127.0.0.1
+networksetup -listallnetworkservices
+networksetup -getdnsservers Wi-Fi          # check
+networksetup -setdnsservers Wi-Fi Empty    # reset
+networksetup -setdnsservers Ethernet Empty # repeat per interface
+sudo dscacheutil -flushcache
+sudo killall -HUP mDNSResponder
 ```
 
-**Expected output**:
-```
-[sudo] password for phani:
-Installing service... 
-Service installed successfully
+```powershell
+# Windows
+Get-DnsClientServerAddress | Where-Object { $_.ServerAddresses -contains "127.0.0.1" } |
+  ForEach-Object { Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ResetServerAddresses }
+ipconfig /flushdns
 ```
 
-**Verify installation**:
+`hosts` mode (the default) does not change your DNS settings, so this scenario doesn't apply to it. If you're on `hosts` mode and resolution is broken, the cause is almost certainly an entry in `/etc/hosts` — see [section 4](#4-mode-specific-diagnostics).
+
+---
+
+## 2. Quick triage by symptom
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| Blocked sites still load | Wrong mode for your setup, or current time isn't in a block window | [§4 Mode-specific diagnostics](#4-mode-specific-diagnostics) |
+| All DNS broken (nothing resolves) | DNS-mode service stopped without restoring system DNS | [§1](#1-if-your-internet-is-broken--read-this-first) |
+| Service won't start: `permission denied` on port 53 | Running without sudo, or another process holds port 53 | [§9](#9-common-errors) |
+| Service installed but `start` does nothing | Service framework is silent about startup failures — check logs | [§5 Reading logs](#5-reading-logs) |
+| Tabs aren't being closed | Not running as console user, AppleScript permissions, browser not running | [§4 macOS AppleScript path](#macos-applescript-path) |
+| Web dashboard returns 401 unauthorized | Auth token mismatch — UI didn't bootstrap | [§9](#9-common-errors) |
+| Config edits aren't taking effect | Bad JSON, or you didn't wait 60 seconds | [§9](#9-common-errors) |
+| `/api/pause` returns 400 | `minutes` outside 1–240 range | — |
+| `--clean` reports critical failures | A step couldn't undo something — output tells you which | [§8 The --clean recovery path](#8-the---clean-recovery-path) |
+
+---
+
+## 3. Inspecting service state
+
 ```bash
-# Check if LaunchAgent is created
-ls -la ~/Library/LaunchAgents/com.github.distractions-free.plist
-```
-
-If successful, you should see:
-```
--rw-r--r-- 1 phani staff 1234 Apr 18 10:00 ~/Library/LaunchAgents/com.github.distractions-free.plist
-```
-
-### 2.4 Start the Service
-
-```bash
-sudo ./distractions-free start
-```
-
-**Expected output**:
-```
-Service started successfully
-```
-
-**Verify it's running**:
-```bash
+# Service registered & running?
 sudo ./distractions-free status
+
+# What does the live daemon think is blocked right now?
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+curl -s -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/status | jq
+# → { "blocked_domains": {...}, "last_evaluated": "...", "enforcement_mode": "hosts", "paused": false }
+
+# What rules are loaded?
+curl -s http://localhost:8040/api/config | jq
+
+# Would a specific (time, domain) be blocked?
+curl -s -H "X-Auth-Token: $TOKEN" \
+  "http://localhost:8040/api/test-query?time=2024-04-01%2010:30&domain=youtube.com" | jq
 ```
 
-Should show:
-```
-Service is running
-```
+The same checks via the dashboard: open `http://localhost:8040`, look at the **Status** tab. The blocked-domains list and `last_evaluated` timestamp tell you whether the scheduler is ticking and what it last decided.
 
-### 2.5 Test Privileged Operations
-
-#### Test 1: Port 53 Binding
-
-```bash
-# Check if DNS server is listening on port 53
-sudo lsof -i :53
-
-# Expected output (should show distractions-free process)
-```
-
-#### Test 2: System DNS Configuration
-
-```bash
-# Check current DNS settings
-networksetup -getdnsservers Wi-Fi
-
-# Expected output AFTER service starts should show:
-# 127.0.0.1 (or similar if configured)
-
-# View all DNS configurations
-scutil --dns | grep -A 5 "resolver"
-```
-
-#### Test 3: DNS Resolution Through Proxy
-
-```bash
-# Query through system DNS (which is now pointing to our proxy)
-nslookup youtube.com 127.0.0.1
-
-# If youtube.com is blocked at current time, you should get:
-# Address: 0.0.0.0
-
-# If it's allowed (or outside schedule), you should get:
-# Address: actual IP address
-```
-
-#### Test 4: Web Dashboard Access
-
-```bash
-# Access the dashboard
-open http://127.0.0.1:8040
-
-# Should see:
-# - Dashboard page
-# - Current config JSON
-# - Test query interface (still works in service mode)
-```
-
-### 2.6 Stop the Service
-
-```bash
-sudo ./distractions-free stop
-```
-
-**Expected output**:
-```
-Service stopped successfully
-```
-
-**Verify DNS is restored**:
-```bash
-# Check DNS settings are restored to system defaults
-networksetup -getdnsservers Wi-Fi
-
-# Should show original DNS servers (not 127.0.0.1)
-```
-
-### 2.7 Uninstall the Service
-
-```bash
-sudo ./distractions-free uninstall
-```
-
-**Expected output**:
-```
-Service uninstalled successfully
-```
-
-**Verify uninstallation**:
-```bash
-# Check if LaunchAgent is removed
-ls -la ~/Library/LaunchAgents/com.github.distractions-free.plist
-
-# Should show: No such file or directory
-```
+A `last_evaluated` more than ~70 seconds old means the tick loop has died. Restart the service.
 
 ---
 
-## Part 3: Debugging - Viewing Logs
+## 4. Mode-specific diagnostics
 
-### 3.1 LaunchAgent Logs (macOS)
-
-When the service is installed as a LaunchAgent, logs go to standard output/error files:
+What "blocking is broken" looks like depends on the active enforcement mode. Check it via:
 
 ```bash
-# View service logs
+curl -s http://localhost:8040/api/config | jq -r '.settings.enforcement_mode // "hosts"'
+```
+
+### `hosts` mode (default)
+
+The daemon edits `/etc/hosts`. To see what it's currently writing:
+
+```bash
+# macOS / Linux
+sed -n '/# distractions-free:begin/,/# distractions-free:end/p' /etc/hosts
+
+# Windows (PowerShell)
+Get-Content C:\Windows\System32\drivers\etc\hosts |
+  Select-String -Pattern "distractions-free:begin" -Context 0,100
+```
+
+If the block isn't there during a scheduled window, the scheduler hasn't fired (check `/api/status` `last_evaluated`).
+
+If the block *is* there but the site loads anyway:
+
+- Your browser or app may have cached the DNS resolution. Try a private window, or restart the app.
+- The browser may be using DNS-over-HTTPS (DoH) or DNS-over-TLS (DoT), which bypasses `/etc/hosts`. **Disable DoH** in the browser, or switch to `dns`/`strict` mode (which also won't help against DoH unless you can intercept the upstream — `pf` in strict mode does, since it blocks the resolved IPs at the kernel).
+- The site may be served from a CDN domain not covered by the static prefix list (`""`, `www.`, `m.`, `mobile.`, `app.`). Add the relevant subdomain as its own rule.
+
+To preview what *would* be written without root:
+
+```bash
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+curl -s -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/hosts-preview | jq
+```
+
+### `dns` mode
+
+Verify the proxy is up and your OS is using it:
+
+```bash
+# Is anything listening on UDP port 53?
+sudo lsof -i :53 -P -n
+
+# Is the system DNS pointing at 127.0.0.1?
+networksetup -getdnsservers Wi-Fi
+scutil --dns | grep nameserver
+
+# Does the proxy actually return 0.0.0.0 for blocked domains?
+dig @127.0.0.1 youtube.com
+# → If blocked: ANSWER section shows youtube.com 60 IN A 0.0.0.0
+# → If allowed: forwarded result from 8.8.8.8
+
+# What does the system see (uses configured resolver)?
+dig youtube.com
+```
+
+If `dig @127.0.0.1` returns `0.0.0.0` but `dig youtube.com` returns a real IP, the proxy is working but the OS DNS is not pointed at it. Reset:
+
+```bash
+networksetup -setdnsservers Wi-Fi 127.0.0.1
+sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+```
+
+### `strict` mode
+
+Strict mode = DNS mode + pf. Verify both layers:
+
+```bash
+# pf enabled?
+sudo pfctl -s info | head -3
+# → Status: Enabled
+
+# Our anchor loaded?
+sudo pfctl -s Anchors
+# → distractions-free should appear
+
+# What IPs are currently blocked at the firewall?
+sudo pfctl -a distractions-free -t blocked_ips -T show
+
+# Preview what strict mode would produce for current blocks (no root needed)
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+curl -s -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/pf-preview | jq
+```
+
+If `Setup` failed (logs show `pf anchor setup failed`), the strict enforcer is degraded to DNS-only. That's intentional — better to keep blocking at the DNS layer than crash the daemon. Look in the daemon logs for the specific pfctl error.
+
+If pf is loaded but the site still loads:
+
+- The CDN may have rotated to a fresh IP not in your table. The next scheduler tick (within 60 s) re-resolves and reloads.
+- Existing TCP connections survive an anchor reload by default — the daemon does run `pfctl -k` to kill matching states, but a connection that was opened *before* the IP made it onto the table is unaffected. Close the browser and retry.
+
+### macOS AppleScript path
+
+The 3-minute warning notification and the tab-closing only fire on macOS, only via `osascript`. If they're not happening:
+
+```bash
+# Test the script generation + execution by hand (no service install needed)
+./distractions-free --test-applescript
+```
+
+Common gotchas:
+
+- **Running as root via launchd, but no console user detected.** `osascript` invoked as root with no user context produces a notification nobody can see. The daemon detects the console user via `stat -f %Su /dev/console` and shells out via `su - <user> -c osascript ...`. If `/dev/console` returns `root` (no one logged in), notifications are silently skipped.
+- **macOS Automation permissions.** First run, macOS prompts: *"distractions-free wants to control 'Google Chrome'."* If you click Don't Allow, AppleScript silently fails forever after. Reset in System Settings → Privacy & Security → Automation.
+- **Browsers not running.** The warning script first checks for open tabs; if no Chrome or Safari window matches, the notification is suppressed by design.
+
+---
+
+## 5. Reading logs
+
+### macOS
+
+The daemon logs to stdout/stderr; launchd routes that to the system log:
+
+```bash
+# Live tail
 log stream --predicate 'process == "distractions-free"' --level debug
 
-# Or view system logs for the service
+# Last hour
 log show --predicate 'process == "distractions-free"' --last 1h
 
-# View last 100 lines in real-time
-tail -f /var/log/system.log | grep "distractions-free"
+# Just the scheduler ticks
+log show --predicate 'process == "distractions-free"' --last 1h | grep -E "scheduler|hosts|dns"
 ```
 
-### 3.2 LaunchAgent Plist File
+If the service was installed via `kardianos/service` defaults, the launchd plist is at `~/Library/LaunchAgents/com.github.distractions-free.plist`:
 
 ```bash
-# View the actual LaunchAgent configuration
 cat ~/Library/LaunchAgents/com.github.distractions-free.plist
-
-# Expected content (XML format):
-# <key>Label</key>
-# <string>com.github.distractions-free</string>
-# <key>Program</key>
-# <string>/path/to/distractions-free</string>
-# <key>RunAtLoad</key>
-# <true/>
-```
-
-### 3.3 Service Status Commands
-
-```bash
-# Check if service is loaded
-launchctl list | grep distractions-free
-
-# Check service logs through launchctl
-launchctl log level all
-launchctl log show system | grep distractions-free
-
-# Get detailed service information
 launchctl print system/com.github.distractions-free
 ```
 
-### 3.4 Process Monitoring
+### Windows
 
-```bash
-# Check if process is running
-ps aux | grep distractions-free
-
-# Expected (if running):
-# root    12345   0.0  0.1 234567 8901 ??  Ss   10:00AM   0:00.25 /path/to/distractions-free
-
-# Check process status with detailed info
-sudo lsof -c distractions-free
-
-# Should show:
-# - Open files/directories
-# - Network connections (port 53)
-# - Memory usage
+```powershell
+Get-EventLog -LogName Application -Source "DistractionsFree" -Newest 50
+# Service status
+Get-Service "DistractionsFree"
 ```
 
-### 3.5 DNS Server Verification
+### Anywhere
+
+If launchd / Service Manager logs aren't useful, run the daemon in the foreground to see everything live:
 
 ```bash
-# Check if DNS server is bound to port 53
-sudo lsof -i :53
-
-# Expected output:
-# COMMAND    PID USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME
-# distractions-free 12345 root    3u  IPv4  0x1234567      0t0  UDP 127.0.0.1:53
-
-# Check DNS traffic
-sudo tcpdump -i lo0 port 53
-
-# Should show DNS queries passing through port 53
+sudo ./distractions-free stop          # stop the service version
+sudo ./distractions-free run           # run with the supervisor (foreground)
+# or, even simpler, no privileges needed for hosts-mode rule evaluation:
+./distractions-free --no-service       # uses ./config.json
 ```
 
-### 3.6 System DNS Configuration Log
+`--no-service` is a fast way to validate that the rules and scheduler logic work — it skips system paths and won't install anything.
+
+---
+
+## 6. Manual install / start / stop / uninstall
+
+The normal happy path is `sudo ./distractions-free install && sudo ./distractions-free start`. If something goes wrong, here's how to verify each step independently.
 
 ```bash
-# View system DNS resolver configuration
-scutil --dns
+sudo ./distractions-free install
+# Verify on macOS:
+ls -la ~/Library/LaunchAgents/com.github.distractions-free.plist
+launchctl list | grep distractions-free
+```
 
-# Should show:
-# resolver #1
-#   search domain[0] : local
-#   nameserver[0] : 127.0.0.1  (if our proxy is set as primary)
+```bash
+sudo ./distractions-free start
+# Verify:
+sudo ./distractions-free status         # Should print: running
+ps aux | grep distractions-free | grep -v grep
+sudo lsof -i :53 -P -n                  # only relevant in dns/strict mode
+sudo lsof -i :8040 -P -n                # web dashboard
+curl -s http://localhost:8040/api/config | jq -r '.settings.enforcement_mode'
+```
+
+```bash
+sudo ./distractions-free stop
+# Verify (mode-dependent):
+#   hosts: managed block removed from /etc/hosts
+#   dns:   networksetup -getdnsservers Wi-Fi → restored to upstream
+#   strict: above + pf anchor removed (sudo pfctl -s Anchors)
+```
+
+```bash
+sudo ./distractions-free uninstall
+# Verify:
+ls ~/Library/LaunchAgents/com.github.distractions-free.plist  # should be gone
+launchctl list | grep distractions-free                       # should be empty
 ```
 
 ---
 
-## Part 4: Common Troubleshooting Issues
+## 7. Verifying behaviour without installing the service
 
-### Issue 1: Service Won't Start - "Permission Denied"
+Three flags exist exactly so you can test the daemon's core logic without privileges, without binding port 53, and without modifying the system.
 
-**Symptom**:
-```
-Error: listen tcp 127.0.0.1:53: permission denied
-```
-
-**Cause**: Port 53 binding requires root privileges
-
-**Solution**:
 ```bash
-# Make sure you're using sudo
-sudo ./distractions-free start
+# Will youtube.com be blocked at this specific time per current ./config.json?
+./distractions-free --test-query "2024-04-01 10:30" youtube.com
+# Output includes: applicable rules, would-block status, and a real DNS response
+# from upstream so you can verify what the upstream resolver returns.
 
-# Check if another process is using port 53
-sudo lsof -i :53
+# Run the full dashboard against ./config.json (no service install, no system changes).
+# All endpoints work, including hosts-preview and pf-preview.
+./distractions-free --test-web
+# → http://localhost:8040
 
-# If something else is using it, kill it first
-sudo kill -9 <PID>
+# Generate (and optionally execute) the AppleScript that closes Chrome/Safari tabs.
+./distractions-free --test-applescript
 ```
 
-### Issue 2: Installation Fails - "LaunchAgent Already Exists"
+`--test-query` and `--test-web` use `./config.json` in the working directory rather than the system path, so you can iterate on rules without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new rule shapes.
 
-**Symptom**:
-```
-Error: service is already installed
-```
+---
 
-**Solution**:
+## 8. The `--clean` recovery path
+
+`--clean` is the canonical "make it like distractions-free was never installed" command. Run it any time the system is in an unknown state — it does not assume `stop` succeeded, and every step is idempotent.
+
 ```bash
-# Uninstall first
+sudo ./distractions-free --clean         # interactive: prompts before deleting config dir
+sudo ./distractions-free --clean --yes   # non-interactive
+```
+
+The output is one line per step:
+
+```
+[✓] Service stopped
+[✓] DNS on Wi-Fi
+[—] DNS on Bluetooth PAN: already Empty
+[✓] DNS on Ethernet
+[✓] Clean /etc/hosts
+[✓] Remove pf anchor
+[✓] Flush DNS cache
+[✓] Service uninstalled
+[✓] Remove config directory
+[—] Remove temp files: none found
+[✓] Port 53 is free
+```
+
+Status meanings:
+
+| Icon | Meaning |
+|---|---|
+| `[✓]` done | Step completed successfully |
+| `[—]` skipped | Step was a no-op (already in the desired state, or not applicable on this OS) |
+| `[!]` warn | Non-critical failure; cleanup continues |
+| `[✗]` error | Critical failure; if any are present `--clean` exits non-zero |
+
+If `Port 53 is free` reports a warning, something unrelated is holding the port:
+
+```bash
+sudo lsof -i :53 -P -n
+# Find the PID, decide whether to kill it.
+```
+
+If `Reset DNS interfaces` fails on macOS, `networksetup -listallnetworkservices` may be returning interfaces with unusual names. Reset them by hand:
+
+```bash
+networksetup -listallnetworkservices
+for svc in "Wi-Fi" "Ethernet" "Thunderbolt Bridge"; do
+  networksetup -getdnsservers "$svc"
+done
+networksetup -setdnsservers "Wi-Fi" Empty
+```
+
+---
+
+## 9. Common errors
+
+### `listen udp 127.0.0.1:53: permission denied`
+
+Port 53 is privileged. Run with `sudo`. If you *are* using sudo, something else holds the port:
+
+```bash
+sudo lsof -i :53 -P -n
+sudo kill <PID>           # only if you know what it is
+```
+
+This error only applies to `dns` and `strict` modes. In `hosts` mode the daemon doesn't bind any port (besides 8040 for the dashboard, which is unprivileged).
+
+### `service is already installed`
+
+```bash
 sudo ./distractions-free uninstall
-
-# Or manually remove the plist
-rm ~/Library/LaunchAgents/com.github.distractions-free.plist
-
-# Then install again
 sudo ./distractions-free install
 ```
 
-### Issue 3: DNS Not Being Intercepted
+If `uninstall` claims it isn't installed, the plist is dangling:
 
-**Symptom**: Blocked domains still load
-
-**Troubleshooting**:
 ```bash
-# 1. Verify service is running
-sudo ./distractions-free status
-
-# 2. Check if DNS is pointed to our proxy
-networksetup -getdnsservers Wi-Fi
-
-# 3. Check if blocked domains are in config
-cat "/Library/Application Support/DistractionsFree/config.json"
-
-# 4. Check current time matches block schedule
-date  # Compare with config schedule
-
-# 5. Query DNS directly to our proxy
-dig @127.0.0.1 youtube.com
-
-# 6. Check if port 53 is listening
-sudo lsof -i :53
-```
-
-### Issue 4: Service Crashes - "Segmentation Fault"
-
-**Symptom**:
-```
-Error: service exited with status 139 (segmentation fault)
-```
-
-**Troubleshooting**:
-```bash
-# 1. Check system logs for crash details
-log show --predicate 'process == "distractions-free"' --last 1h
-
-# 2. Check if config file is valid JSON
-cat "/Library/Application Support/DistractionsFree/config.json" | python3 -m json.tool
-
-# 3. Try running in no-service mode for debugging
-./distractions-free --no-service
-
-# 4. Check for OS-specific issues
-uname -a
-go version
-```
-
-### Issue 5: Can't Uninstall - "Service Still Running"
-
-**Symptom**:
-```
-Error: cannot uninstall while service is running
-```
-
-**Solution**:
-```bash
-# Stop the service first
-sudo ./distractions-free stop
-
-# Wait a moment
-sleep 2
-
-# Then uninstall
-sudo ./distractions-free uninstall
-
-# If still stuck, forcefully stop it
-sudo pkill -f "distractions-free"
-
-# Remove LaunchAgent manually
+launchctl unload ~/Library/LaunchAgents/com.github.distractions-free.plist
 rm ~/Library/LaunchAgents/com.github.distractions-free.plist
+sudo ./distractions-free install
 ```
 
----
-
-## Part 5: Verification Checklist
-
-Use this checklist to verify all privileged operations are working:
-
-```
-Installation & Registration:
-  [ ] Binary builds without errors
-  [ ] Config file created at /Library/Application Support/DistractionsFree/config.json
-  [ ] LaunchAgent plist exists at ~/Library/LaunchAgents/com.github.distractions-free.plist
-  [ ] Service appears in launchctl list
-
-Service Startup:
-  [ ] Service starts without errors
-  [ ] Process appears in ps aux
-  [ ] No "Permission denied" errors
-  [ ] Service status shows "running"
-
-Port 53 Binding:
-  [ ] Port 53 is listening (lsof -i :53)
-  [ ] Only our process is bound to port 53
-  [ ] Can send DNS queries to 127.0.0.1:53
-
-System DNS Configuration:
-  [ ] networksetup shows 127.0.0.1 as nameserver
-  [ ] DNS cache flush completes
-  [ ] mDNSResponder is active
-
-DNS Interception:
-  [ ] Blocked domain returns 0.0.0.0
-  [ ] Allowed domain returns real IP
-  [ ] DNS failover works (primary → backup)
-
-Web Dashboard:
-  [ ] Dashboard accessible at 127.0.0.1:8040
-  [ ] Config API returns valid JSON
-  [ ] Test query API works
-
-Service Cleanup:
-  [ ] Service stops cleanly
-  [ ] DNS is restored to original
-  [ ] networksetup shows original DNS servers
-  [ ] Uninstallation completes
-  [ ] LaunchAgent plist is removed
-```
-
----
-
-## Part 6: Advanced Debugging
-
-### Real-Time Log Monitoring
+### `cannot uninstall while service is running`
 
 ```bash
-# Monitor all DNS queries in real-time
-sudo tcpdump -i lo0 -nn port 53
-
-# Monitor service logs with timestamps
-sudo log stream --predicate 'process == "distractions-free"' --level debug --style compact
-
-# Monitor system events
-log stream --predicate 'eventMessage contains "distractions"' --level debug
+sudo ./distractions-free stop
+sudo ./distractions-free uninstall
 ```
 
-### Performance Profiling
+If `stop` hangs or fails, force it:
 
 ```bash
-# Profile CPU usage
-sudo sample distractions-free 5
-
-# Check memory usage
-ps aux | grep distractions-free | awk '{print $2, $3, $4, $6}'
-
-# Monitor network connections
-netstat -an | grep 53
+sudo pkill -f "distractions-free"
+launchctl unload ~/Library/LaunchAgents/com.github.distractions-free.plist
+sudo ./distractions-free uninstall
 ```
 
-### Config Reload Testing
+### Web dashboard returns 401 unauthorized
+
+The dashboard fetches the auth token from `GET /api/config` on first load. If you see 401s on `/api/status`, `/api/test-query`, etc., the JS didn't pick up the token. Hard-refresh the page (`Cmd+Shift+R`).
+
+If you're hitting the API from `curl`, set the header explicitly:
 
 ```bash
-# 1. Start service
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+curl -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/status
+```
+
+### Config edits aren't taking effect
+
+The scheduler reloads `config.json` once per minute. Wait 60 seconds.
+
+If they're still not applied:
+
+```bash
+# Validate JSON
+python3 -m json.tool < /Library/Application\ Support/DistractionsFree/config.json
+
+# Check the daemon's logs for parse errors
+log show --predicate 'process == "distractions-free"' --last 5m | grep -i config
+```
+
+If the file is malformed, the daemon logs a warning and keeps using the previous in-memory copy — your changes won't apply until you fix the JSON.
+
+You can also force a reload by hitting `GET /api/config` (which calls `LoadConfig()`):
+
+```bash
+curl -s http://localhost:8040/api/config > /dev/null
+```
+
+### `pf anchor setup failed` in logs (strict mode)
+
+The strict enforcer degrades to DNS-only when pf setup fails. Common causes:
+
+- `/etc/pf.conf` is non-standard and the daemon doesn't recognise it.
+- Another tool has its own anchors and is fighting for control.
+- pf is disabled in a way that `pfctl -e` can't fix.
+
+To start fresh:
+
+```bash
+sudo ./distractions-free --clean --yes   # removes our anchor + pf.conf injection
+# inspect /etc/pf.conf — should be back to its original state
+sudo ./distractions-free install
 sudo ./distractions-free start
-
-# 2. Query a domain (should be allowed)
-dig @127.0.0.1 example.com
-
-# 3. Edit config to block example.com
-sudo vi "/Library/Application Support/DistractionsFree/config.json"
-
-# 4. Wait up to 1 minute for scheduler to reload
-
-# 5. Query again (should now be blocked or allowed based on new config)
-dig @127.0.0.1 example.com
-
-# Check logs to see when config was reloaded
-log show --predicate 'process == "distractions-free"' --last 2m
+# logs should show "pf: anchor installed"
 ```
 
+### Tabs don't close on block start
+
+See [§4 macOS AppleScript path](#macos-applescript-path). The most common cause is denied automation permissions for Chrome/Safari — fix in System Settings → Privacy & Security → Automation.
+
+### `--clean` says "could not create service handle"
+
+Usually means the binary you're running was built for a different OS. Check `file ./distractions-free` and rebuild for the current platform with `make build`.


### PR DESCRIPTION
## Summary

Rewrites all three documentation files to reflect the current architecture and to put user concerns ahead of developer concerns where appropriate.

- **README.md** — user-first ordering per [#16](https://github.com/vsangava/distractions-free/issues/16). Features → install → dashboard → config → enforcement modes → pause/resume → uninstall come first; build/test/release are now in a clearly separated developer section. Adds a single CLI reference table with cross-links to each section's deep-dive, and an HTTP API table covering every current endpoint.
- **DESIGN.md** — rewritten around the current implementation per [#17](https://github.com/vsangava/distractions-free/issues/17). Replaces the proxy-centric narrative with the enforcer abstraction (hosts/dns/strict). Adds new sections for the pause window, the auth-token model, the cleanup subsystem, the pf integration, and explicit concurrency / security / platform-specific notes.
- **TROUBLESHOOTING.md** — restructured around real failure scenarios per [#17](https://github.com/vsangava/distractions-free/issues/17). Leads with the broken-internet recovery (the most painful failure mode for `dns`/`strict` users — fixed by `sudo distractions-free --clean --yes`). Mode-specific diagnostics for hosts/dns/strict. Removes the hardcoded `/Users/phani` path from the manual install section.

Closes #16, #17.

## Gotchas for reviewers

- The previous DESIGN.md described a daemon that no longer exists (DNS-proxy-only with no enforcer abstraction, no pause, no cleanup). I removed those sections rather than tried to reconcile them — diff is large but mostly net-new content.
- The README CLI reference table is now the single source of truth for flag/subcommand behaviour; if a flag changes, it has to be updated in two places (the table plus the per-flag walkthrough). Worth keeping in mind for future PRs.
- The HTTP API tables in README and DESIGN both list every endpoint — kept them deliberately consistent. If you add a route, both need an entry.
- `--strict` is documented as the shorthand for setting `enforcement_mode` in config; if `--hosts` and `--dns` shorthands are added later, the README CLI table is the place to mention them.
- Auth model is documented honestly: the X-Auth-Token + Manage-tab PIN are friction layers, not security controls. The dashboard binds 127.0.0.1 only. Wanted to make sure that's clear so nobody mistakes this for a hardened admin panel.
- TROUBLESHOOTING leads with the broken-internet recovery rather than with installation diagnostics — most users who reach for the troubleshooting doc are doing so because something already broke.

## Test plan

- [ ] Render README.md, DESIGN.md, TROUBLESHOOTING.md on GitHub and verify table-of-contents links resolve
- [ ] Verify the example config snippet in README parses as valid JSON
- [ ] Verify the curl examples in README's Pause & resume section work against a running daemon
- [ ] Sanity-check that the HTTP API tables in README and DESIGN match the routes registered in \`internal/web/server.go\`
- [ ] Skim DESIGN's module-layout section against the actual \`internal/\` tree