### PR TITLE
feat: domain groups — bind schedules to named domain sets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,7 +24,7 @@ This document describes how the daemon is built. It complements [README.md](./RE
 
 ## 1. Overview
 
-Distractions-Free is a single-binary Go daemon that runs as a privileged system service. It enforces per-domain, per-time-of-day blocking rules on the host so that distracting sites become unreachable during configured windows.
+Distractions-Free is a single-binary Go daemon that runs as a privileged system service. It enforces per-time-of-day blocking rules on the host — each rule binds a named group of domains (e.g. `games`, `social`) to a weekly schedule — so distracting sites become unreachable during configured windows.
 
 The interesting design decisions:
 
@@ -230,9 +230,9 @@ func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string
 `EvaluateRulesAtTime` returns the set of domains that should be blocked at `t`. Algorithm:
 
 1. If `cfg.IsPaused(t)` — return empty map (pause overrides everything).
-2. For each rule with `is_active=true`, look up `Schedules[t.Weekday().String()]`.
+2. For each rule with `is_active=true`, resolve `cfg.ResolveGroup(rule.Group)` to a domain list (skip the rule if the group is missing or empty), then look up `Schedules[t.Weekday().String()]`.
 3. For each slot, parse `Start`/`End` as `15:04`, build a same-day comparison time, check `slotStart <= now < slotEnd`.
-4. Add the domain on the first matching slot (no need to keep checking).
+4. On the first matching slot, add every domain in the resolved group to the result and stop checking remaining slots for that rule.
 
 `CheckWarningDomainsAtTime` returns domains whose block starts within `[now, now+3min)`. Logic mirrors the above but compares against the slot's start time, building a warning window of `[start-3min, start)`.
 
@@ -407,9 +407,10 @@ The web UI's `/api/pf-preview` endpoint calls `pf.GeneratePreview(domains, dnsSe
 
 ```go
 type Config struct {
-    Settings Settings     `json:"settings"`
-    Rules    []Rule       `json:"rules"`
-    Pause    *PauseWindow `json:"pause,omitempty"`
+    Settings Settings            `json:"settings"`
+    Groups   map[string][]string `json:"groups"`
+    Rules    []Rule              `json:"rules"`
+    Pause    *PauseWindow        `json:"pause,omitempty"`
 }
 
 type Settings struct {
@@ -420,9 +421,9 @@ type Settings struct {
 }
 
 type Rule struct {
-    Domain    string                `json:"domain"`
+    Group     string                `json:"group"`     // key into Config.Groups
     IsActive  bool                  `json:"is_active"`
-    Schedules map[string][]TimeSlot `json:"schedules"`  // weekday → slots
+    Schedules map[string][]TimeSlot `json:"schedules"` // weekday → slots
 }
 
 type TimeSlot struct {
@@ -435,7 +436,13 @@ type PauseWindow struct {
 }
 ```
 
+`Config.ResolveGroup(name)` returns the domain list for `name`, or `nil` if the group is missing — the scheduler treats a missing group as a silent no-op so a rule referencing a deleted group degrades safely instead of panicking.
+
 `Settings.GetEnforcementMode()` returns the validated mode, defaulting to `"hosts"` for empty or unrecognised values. This is what allows a pre-1.x config without the `enforcement_mode` field to upgrade transparently.
+
+### Why groups instead of inline domains
+
+A rule used to carry a single `Domain` string, which meant blocking five gaming sites required five rules with the same schedule duplicated five times. The groups indirection lets one schedule cover an arbitrary set of domains, and means edits to "what counts as a game" don't require touching any schedule. `EvaluateRulesAtTime` and `CheckWarningDomainsAtTime` resolve the group at evaluation time (per tick), so live edits to a group's member list propagate within 60 seconds without any rule changes. There is no inline-domains fallback — `ValidatePostedConfig` rejects any rule whose `group` doesn't reference an existing key.
 
 ### File location
 
@@ -455,7 +462,7 @@ On first run, if the config file doesn't exist, `LoadConfig()` writes a default 
 - `primary_dns: "8.8.8.8:53"`, `backup_dns: "1.1.1.1:53"`
 - `enforcement_mode: "hosts"`
 - A randomly generated 32-character hex `auth_token`
-- One seed rule blocking `youtube.com` Mon–Fri 09:00–17:00
+- Two seed groups — `games` (roblox/epic/steam/fortnite/minecraft) and `social` (discord/facebook/instagram/tiktok/snapchat/reddit) — each bound by an active rule to the school window (09:00–15:00 weekdays) plus a nightly window (21:30–23:59 every day).
 
 If an existing config has a missing `auth_token`, one is generated and the file is rewritten. This is the only field auto-modified on load.
 
@@ -501,11 +508,14 @@ This is local-only auth — the server binds `127.0.0.1`, never `0.0.0.0`. Anyth
 `ValidatePostedConfig(cfg)` runs server-side on every `POST /api/config/update`. Checks:
 
 - `enforcement_mode` is empty or one of `"hosts"`, `"dns"`, `"strict"`.
-- Every rule has a non-empty `domain`.
+- Every group has a non-empty name and at least one non-empty domain.
+- Every rule has a non-empty `group`, and that group exists in `cfg.Groups`.
 - Every schedule key is a valid weekday name.
 - Every weekday's slot list is non-empty.
 - Every slot has a valid `15:04` `Start` and `End`.
 - `Start < End`.
+
+The browser-side `parseAndValidate` mirrors the same rules so the textarea flags errors before they reach the server. Both are intentional duplicates — the JS catches typos in the editor; the Go is the source of truth.
 
 The auth token is preserved across updates regardless of what the client posts — so the dashboard can't accidentally rotate the secret out from under itself.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Unlike browser extensions — one click to disable — Distractions-Free puts th
 
 ## What it does
 
-- **Blocks distracting domains on a schedule** — per-day, per-time-slot rules per domain. The default mode rewrites `/etc/hosts`, so blocking works across every browser, every app, and every network without any client-side configuration.
+- **Blocks distracting domains on a schedule** — domains are organised into named groups (e.g. `games`, `social`); each rule binds one group to per-day, per-time-slot windows. The default mode rewrites `/etc/hosts`, so blocking works across every browser, every app, and every network without any client-side configuration.
 - **Closes browser tabs when a block starts** — native AppleScript closes matching tabs in Chrome and Safari at the moment the block begins (macOS only).
 - **Sends a 3-minute warning** — native macOS notification before a block starts so you can save your work.
 - **Auto-reloads config every minute** — edit the config file, save, and changes take effect on the next minute boundary. No restart needed.
@@ -155,40 +155,52 @@ The file is generated with sensible defaults on first launch. The scheduler relo
     "enforcement_mode": "hosts",
     "auth_token": "c911284368ac967797e8af4379b3bcb6"
   },
+  "groups": {
+    "games":  ["roblox.com", "epicgames.com", "steampowered.com", "fortnite.com", "minecraft.net"],
+    "social": ["discord.com", "facebook.com", "instagram.com", "tiktok.com", "snapchat.com", "reddit.com"]
+  },
   "rules": [
     {
-      "domain": "youtube.com",
+      "group": "games",
       "is_active": true,
       "schedules": {
-        "Monday":    [{"start": "09:00", "end": "17:00"}],
-        "Tuesday":   [{"start": "09:00", "end": "17:00"}],
-        "Wednesday": [{"start": "09:00", "end": "17:00"}],
-        "Thursday":  [{"start": "09:00", "end": "17:00"}],
-        "Friday":    [{"start": "09:00", "end": "17:00"}]
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
       }
     },
     {
-      "domain": "facebook.com",
+      "group": "social",
       "is_active": true,
       "schedules": {
-        "Monday": [
-          {"start": "09:00", "end": "11:00"},
-          {"start": "13:00", "end": "15:00"}
-        ]
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
       }
     }
   ]
 }
 ```
 
+The default seed above blocks both groups during school hours (9–3 weekdays) plus every night from 9:30pm — adjust the slots, drop a group from `rules`, or define your own (`work`, `news`, `streaming`…) as needed.
+
 ### Field reference
 
 - **`settings.primary_dns` / `backup_dns`** — upstream resolvers for `dns`/`strict` mode. Ignored in `hosts` mode.
 - **`settings.enforcement_mode`** — `"hosts"` (default), `"dns"`, or `"strict"`. See [Enforcement modes](#enforcement-modes).
 - **`settings.auth_token`** — auto-generated 32-char hex on first launch. The web UI requires this token for every API call except `GET /api/config` (which is intentionally public so the UI can bootstrap the token).
-- **`rules[].domain`** — bare domain (no `www.`). In `hosts` mode the enforcer automatically also blocks the prefixes `www.`, `m.`, `mobile.`, `app.`. Subdomain matching in `dns` mode is suffix-based (`a.b.example.com` is blocked if `example.com` is blocked).
+- **`groups`** — named lists of bare domains (no `www.`) that schedules are bound to. Edit a group once and every rule that uses it updates. In `hosts` mode the enforcer automatically also blocks the prefixes `www.`, `m.`, `mobile.`, `app.` for each member; in `dns` mode subdomain matching is suffix-based (`a.b.example.com` is blocked if `example.com` is in the group).
+- **`rules[].group`** — the group name this rule schedules. Must match a key in `groups`. Validation rejects unknown references.
 - **`rules[].is_active`** — set to `false` to suspend a single rule without deleting it.
-- **`rules[].schedules`** — object keyed by weekday name (`"Monday"` … `"Sunday"`). Each value is an array of `{start, end}` slots in `HH:MM` 24-hour format. A domain is blocked when current time falls in `[start, end)`.
+- **`rules[].schedules`** — object keyed by weekday name (`"Monday"` … `"Sunday"`). Each value is an array of `{start, end}` slots in `HH:MM` 24-hour format. Every domain in the rule's group is blocked when current time falls in `[start, end)`.
 - **`pause`** *(optional)* — `{"until": "<RFC3339 timestamp>"}`. While set, all blocking is suspended. Cleared automatically once `until` passes. Easiest to set via the dashboard or the [`/api/pause`](#http-api) endpoint.
 
 ### Editing rules from the command line

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -78,12 +78,13 @@ TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
 curl -s -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/status | jq
 # → { "blocked_domains": {...}, "last_evaluated": "...", "enforcement_mode": "hosts", "paused": false }
 
-# What rules are loaded?
+# What groups and rules are loaded?
 curl -s http://localhost:8040/api/config | jq
 
 # Would a specific (time, domain) be blocked?
+# (Response includes the group name and which member of the group matched.)
 curl -s -H "X-Auth-Token: $TOKEN" \
-  "http://localhost:8040/api/test-query?time=2024-04-01%2010:30&domain=youtube.com" | jq
+  "http://localhost:8040/api/test-query?time=2024-04-01%2010:30&domain=roblox.com" | jq
 ```
 
 The same checks via the dashboard: open `http://localhost:8040`, look at the **Status** tab. The blocked-domains list and `last_evaluated` timestamp tell you whether the scheduler is ticking and what it last decided.
@@ -119,7 +120,7 @@ If the block *is* there but the site loads anyway:
 
 - Your browser or app may have cached the DNS resolution. Try a private window, or restart the app.
 - The browser may be using DNS-over-HTTPS (DoH) or DNS-over-TLS (DoT), which bypasses `/etc/hosts`. **Disable DoH** in the browser, or switch to `dns`/`strict` mode (which also won't help against DoH unless you can intercept the upstream — `pf` in strict mode does, since it blocks the resolved IPs at the kernel).
-- The site may be served from a CDN domain not covered by the static prefix list (`""`, `www.`, `m.`, `mobile.`, `app.`). Add the relevant subdomain as its own rule.
+- The site may be served from a CDN domain not covered by the static prefix list (`""`, `www.`, `m.`, `mobile.`, `app.`). Add the relevant subdomain to the relevant group in `config.json`.
 
 To preview what *would* be written without root:
 
@@ -305,7 +306,7 @@ Three flags exist exactly so you can test the daemon's core logic without privil
 ./distractions-free --test-applescript
 ```
 
-`--test-query` and `--test-web` use `./config.json` in the working directory rather than the system path, so you can iterate on rules without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new rule shapes.
+`--test-query` and `--test-web` use `./config.json` in the working directory rather than the system path, so you can iterate on groups and rules without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new group shapes or schedule timings.
 
 ---
 

--- a/cmd/app/config.json
+++ b/cmd/app/config.json
@@ -4,41 +4,48 @@
     "backup_dns": "1.1.1.1:53",
     "enforcement_mode": "hosts"
   },
+  "groups": {
+    "games": [
+      "roblox.com",
+      "epicgames.com",
+      "steampowered.com",
+      "fortnite.com",
+      "minecraft.net"
+    ],
+    "social": [
+      "discord.com",
+      "facebook.com",
+      "instagram.com",
+      "tiktok.com",
+      "snapchat.com",
+      "reddit.com"
+    ]
+  },
   "rules": [
     {
-      "domain": "youtube.com",
+      "group": "games",
       "is_active": true,
       "schedules": {
-        "Friday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Monday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Thursday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Tuesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Wednesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ]
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
+      }
+    },
+    {
+      "group": "social",
+      "is_active": true,
+      "schedules": {
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
       }
     }
   ]

--- a/config.json
+++ b/config.json
@@ -2,44 +2,51 @@
   "settings": {
     "primary_dns": "8.8.8.8:53",
     "backup_dns": "1.1.1.1:53",
-    "enforcement_mode": "hosts",
-    "auth_token": "c911284368ac967797e8af4379b3bcb6"
+    "auth_token": "c911284368ac967797e8af4379b3bcb6",
+    "enforcement_mode": "hosts"
+  },
+  "groups": {
+    "games": [
+      "roblox.com",
+      "epicgames.com",
+      "steampowered.com",
+      "fortnite.com",
+      "minecraft.net"
+    ],
+    "social": [
+      "discord.com",
+      "facebook.com",
+      "instagram.com",
+      "tiktok.com",
+      "snapchat.com",
+      "reddit.com"
+    ]
   },
   "rules": [
     {
-      "domain": "youtube.com",
+      "group": "games",
       "is_active": true,
       "schedules": {
-        "Friday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Monday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Thursday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Tuesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Wednesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ]
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
+      }
+    },
+    {
+      "group": "social",
+      "is_active": true,
+      "schedules": {
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
       }
     }
   ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,10 @@ type TimeSlot struct {
 	End   string `json:"end"`
 }
 
+// Rule binds a named group of domains to a weekly schedule.
+// Group must reference a key in Config.Groups.
 type Rule struct {
-	Domain    string                `json:"domain"`
+	Group     string                `json:"group"`
 	IsActive  bool                  `json:"is_active"`
 	Schedules map[string][]TimeSlot `json:"schedules"`
 }
@@ -47,14 +49,23 @@ type PauseWindow struct {
 }
 
 type Config struct {
-	Settings Settings     `json:"settings"`
-	Rules    []Rule       `json:"rules"`
-	Pause    *PauseWindow `json:"pause,omitempty"`
+	Settings Settings            `json:"settings"`
+	Groups   map[string][]string `json:"groups"`
+	Rules    []Rule              `json:"rules"`
+	Pause    *PauseWindow        `json:"pause,omitempty"`
 }
 
 // IsPaused reports whether all blocking rules are suspended at time t.
 func (c Config) IsPaused(t time.Time) bool {
 	return c.Pause != nil && t.Before(c.Pause.Until)
+}
+
+// ResolveGroup returns the domains in the named group, or nil if the group does not exist.
+func (c Config) ResolveGroup(name string) []string {
+	if c.Groups == nil {
+		return nil
+	}
+	return c.Groups[name]
 }
 
 var (
@@ -171,16 +182,35 @@ func saveDefaultConfig(path string) error {
 			AuthToken:       token,
 			EnforcementMode: "hosts",
 		},
+		Groups: map[string][]string{
+			"games":  {"roblox.com", "epicgames.com", "steampowered.com", "fortnite.com", "minecraft.net"},
+			"social": {"discord.com", "facebook.com", "instagram.com", "tiktok.com", "snapchat.com", "reddit.com"},
+		},
 		Rules: []Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "games",
 				IsActive: true,
 				Schedules: map[string][]TimeSlot{
-					"Monday":    {{Start: "09:00", End: "17:00"}},
-					"Tuesday":   {{Start: "09:00", End: "17:00"}},
-					"Wednesday": {{Start: "09:00", End: "17:00"}},
-					"Thursday":  {{Start: "09:00", End: "17:00"}},
-					"Friday":    {{Start: "09:00", End: "17:00"}},
+					"Monday":    {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Tuesday":   {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Wednesday": {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Thursday":  {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Friday":    {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Saturday":  {{Start: "21:30", End: "23:59"}},
+					"Sunday":    {{Start: "21:30", End: "23:59"}},
+				},
+			},
+			{
+				Group:    "social",
+				IsActive: true,
+				Schedules: map[string][]TimeSlot{
+					"Monday":    {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Tuesday":   {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Wednesday": {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Thursday":  {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Friday":    {{Start: "09:00", End: "15:00"}, {Start: "21:30", End: "23:59"}},
+					"Saturday":  {{Start: "21:30", End: "23:59"}},
+					"Sunday":    {{Start: "21:30", End: "23:59"}},
 				},
 			},
 		},

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -186,6 +186,10 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 		if !rule.IsActive {
 			continue
 		}
+		domains := cfg.ResolveGroup(rule.Group)
+		if len(domains) == 0 {
+			continue
+		}
 		if slots, exists := rule.Schedules[currentDay]; exists {
 			for _, slot := range slots {
 				slotStart, errS := time.Parse("15:04", slot.Start)
@@ -194,7 +198,9 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 					continue
 				}
 				if (now.Equal(slotStart) || now.After(slotStart)) && now.Before(slotEnd) {
-					newBlocked[rule.Domain] = true
+					for _, d := range domains {
+						newBlocked[d] = true
+					}
 					break
 				}
 			}
@@ -217,8 +223,13 @@ func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string {
 	var warningDomains []string
 
 	// Check for warnings within 3-minute window before block start
+	seen := make(map[string]bool)
 	for _, rule := range cfg.Rules {
 		if !rule.IsActive {
+			continue
+		}
+		domains := cfg.ResolveGroup(rule.Group)
+		if len(domains) == 0 {
 			continue
 		}
 		if slots, exists := rule.Schedules[currentDay]; exists {
@@ -242,7 +253,12 @@ func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string {
 
 				// Warn if current time is within [warningStart, blockTime)
 				if (t.After(warningStart) || t.Equal(warningStart)) && t.Before(blockTime) {
-					warningDomains = append(warningDomains, rule.Domain)
+					for _, d := range domains {
+						if !seen[d] {
+							seen[d] = true
+							warningDomains = append(warningDomains, d)
+						}
+					}
 				}
 			}
 		}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/vsangava/distractions-free/internal/config"
 )
 
+// helpers ────────────────────────────────────────────────────────────────────
+
+// singleGroup builds a config with exactly one group containing one domain
+// and one rule that references it. Most tests want this shape.
+func singleGroup(domain string, isActive bool, schedules map[string][]config.TimeSlot) config.Config {
+	groupName := domain
+	return config.Config{
+		Groups: map[string][]string{groupName: {domain}},
+		Rules: []config.Rule{
+			{Group: groupName, IsActive: isActive, Schedules: schedules},
+		},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 func TestEvaluateRulesAtTime_NoActiveRules(t *testing.T) {
 	cfg := config.Config{
 		Rules: []config.Rule{},
@@ -21,19 +37,9 @@ func TestEvaluateRulesAtTime_NoActiveRules(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_InactiveRule(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: false,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "09:00", End: "17:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("youtube.com", false, map[string][]config.TimeSlot{
+		"Monday": {{Start: "09:00", End: "17:00"}},
+	})
 
 	// Monday 10:30 (should be blocked if rule was active)
 	testTime := time.Date(2024, time.April, 1, 10, 30, 0, 0, time.UTC)
@@ -45,19 +51,9 @@ func TestEvaluateRulesAtTime_InactiveRule(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_DomainBlockedDuringSchedule(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "09:00", End: "17:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "09:00", End: "17:00"}},
+	})
 
 	// Monday 10:30 (within block time)
 	testTime := time.Date(2024, time.April, 1, 10, 30, 0, 0, time.UTC)
@@ -69,19 +65,9 @@ func TestEvaluateRulesAtTime_DomainBlockedDuringSchedule(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_DomainNotBlockedOutsideSchedule(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "09:00", End: "17:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "09:00", End: "17:00"}},
+	})
 
 	// Monday 18:30 (after block time)
 	testTime := time.Date(2024, time.April, 1, 18, 30, 0, 0, time.UTC)
@@ -93,19 +79,9 @@ func TestEvaluateRulesAtTime_DomainNotBlockedOutsideSchedule(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_DomainNotBlockedWrongDay(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "09:00", End: "17:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "09:00", End: "17:00"}},
+	})
 
 	// Tuesday 10:30 (different day, no schedule)
 	testTime := time.Date(2024, time.April, 2, 10, 30, 0, 0, time.UTC)
@@ -117,19 +93,9 @@ func TestEvaluateRulesAtTime_DomainNotBlockedWrongDay(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_BlockedAtExactStartTime(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "reddit.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Wednesday": {
-						{Start: "14:00", End: "15:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("reddit.com", true, map[string][]config.TimeSlot{
+		"Wednesday": {{Start: "14:00", End: "15:00"}},
+	})
 
 	// Wednesday 14:00 (exact start time)
 	testTime := time.Date(2024, time.April, 3, 14, 0, 0, 0, time.UTC)
@@ -141,19 +107,9 @@ func TestEvaluateRulesAtTime_BlockedAtExactStartTime(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_NotBlockedAtExactEndTime(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "twitter.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Friday": {
-						{Start: "09:00", End: "17:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("twitter.com", true, map[string][]config.TimeSlot{
+		"Friday": {{Start: "09:00", End: "17:00"}},
+	})
 
 	// Friday 17:00 (exact end time, should NOT be blocked)
 	testTime := time.Date(2024, time.April, 5, 17, 0, 0, 0, time.UTC)
@@ -166,23 +122,28 @@ func TestEvaluateRulesAtTime_NotBlockedAtExactEndTime(t *testing.T) {
 
 func TestEvaluateRulesAtTime_MultipleDomainsMultipleSchedules(t *testing.T) {
 	cfg := config.Config{
+		Groups: map[string][]string{
+			"youtube.com": {"youtube.com"},
+			"reddit.com":  {"reddit.com"},
+			"twitter.com": {"twitter.com"},
+		},
 		Rules: []config.Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "youtube.com",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
 					"Monday": {{Start: "09:00", End: "17:00"}},
 				},
 			},
 			{
-				Domain:   "reddit.com",
+				Group:    "reddit.com",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
 					"Monday": {{Start: "09:00", End: "12:00"}},
 				},
 			},
 			{
-				Domain:   "twitter.com",
+				Group:    "twitter.com",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
 					"Monday": {{Start: "14:00", End: "17:00"}},
@@ -207,20 +168,12 @@ func TestEvaluateRulesAtTime_MultipleDomainsMultipleSchedules(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_MultipleTimeSlotsPerDay(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "09:00", End: "12:00"},
-						{Start: "14:00", End: "17:00"},
-					},
-				},
-			},
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {
+			{Start: "09:00", End: "12:00"},
+			{Start: "14:00", End: "17:00"},
 		},
-	}
+	})
 
 	// Monday 10:30 (first slot)
 	testTime1 := time.Date(2024, time.April, 1, 10, 30, 0, 0, time.UTC)
@@ -244,20 +197,61 @@ func TestEvaluateRulesAtTime_MultipleTimeSlotsPerDay(t *testing.T) {
 	}
 }
 
-func TestCheckWarningDomainsAtTime_WarningTriggersAt3MinBefore(t *testing.T) {
+func TestEvaluateRulesAtTime_GroupExpandsToAllDomains(t *testing.T) {
 	cfg := config.Config{
+		Groups: map[string][]string{
+			"games": {"roblox.com", "fortnite.com", "minecraft.net"},
+		},
 		Rules: []config.Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "games",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "10:00", End: "12:00"},
-					},
+					"Monday": {{Start: "09:00", End: "15:00"}},
 				},
 			},
 		},
 	}
+
+	testTime := time.Date(2024, time.April, 1, 10, 0, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	for _, d := range []string{"roblox.com", "fortnite.com", "minecraft.net"} {
+		if !result[d] {
+			t.Errorf("expected %s to be blocked (group expansion)", d)
+		}
+	}
+	if len(result) != 3 {
+		t.Errorf("expected exactly 3 blocked domains, got %d: %v", len(result), result)
+	}
+}
+
+func TestEvaluateRulesAtTime_RuleWithMissingGroupIsSkipped(t *testing.T) {
+	cfg := config.Config{
+		Groups: map[string][]string{}, // intentionally empty
+		Rules: []config.Rule{
+			{
+				Group:    "phantom",
+				IsActive: true,
+				Schedules: map[string][]config.TimeSlot{
+					"Monday": {{Start: "09:00", End: "17:00"}},
+				},
+			},
+		},
+	}
+
+	testTime := time.Date(2024, time.April, 1, 10, 30, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if len(result) != 0 {
+		t.Errorf("expected rule with missing group to be skipped, got %v", result)
+	}
+}
+
+func TestCheckWarningDomainsAtTime_WarningTriggersAt3MinBefore(t *testing.T) {
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "10:00", End: "12:00"}},
+	})
 
 	// Monday 09:57 (3 minutes before 10:00)
 	testTime := time.Date(2024, time.April, 1, 9, 57, 0, 0, time.UTC)
@@ -272,19 +266,9 @@ func TestCheckWarningDomainsAtTime_WarningTriggersAt3MinBefore(t *testing.T) {
 }
 
 func TestCheckWarningDomainsAtTime_NoWarningOutsideWindow(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "reddit.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Tuesday": {
-						{Start: "14:00", End: "16:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("reddit.com", true, map[string][]config.TimeSlot{
+		"Tuesday": {{Start: "14:00", End: "16:00"}},
+	})
 
 	// Tuesday 13:54 (more than 3 minutes before)
 	testTime := time.Date(2024, time.April, 2, 13, 54, 0, 0, time.UTC)
@@ -296,19 +280,9 @@ func TestCheckWarningDomainsAtTime_NoWarningOutsideWindow(t *testing.T) {
 }
 
 func TestCheckWarningDomainsAtTime_NoWarningForInactiveRule(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "twitter.com",
-				IsActive: false,
-				Schedules: map[string][]config.TimeSlot{
-					"Wednesday": {
-						{Start: "11:00", End: "13:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("twitter.com", false, map[string][]config.TimeSlot{
+		"Wednesday": {{Start: "11:00", End: "13:00"}},
+	})
 
 	// Wednesday 10:57 (3 minutes before, but rule inactive)
 	testTime := time.Date(2024, time.April, 3, 10, 57, 0, 0, time.UTC)
@@ -321,23 +295,23 @@ func TestCheckWarningDomainsAtTime_NoWarningForInactiveRule(t *testing.T) {
 
 func TestCheckWarningDomainsAtTime_MultipleWarnings(t *testing.T) {
 	cfg := config.Config{
+		Groups: map[string][]string{
+			"youtube.com": {"youtube.com"},
+			"reddit.com":  {"reddit.com"},
+		},
 		Rules: []config.Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "youtube.com",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
-					"Thursday": {
-						{Start: "09:00", End: "10:00"},
-					},
+					"Thursday": {{Start: "09:00", End: "10:00"}},
 				},
 			},
 			{
-				Domain:   "reddit.com",
+				Group:    "reddit.com",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
-					"Thursday": {
-						{Start: "09:00", End: "10:00"},
-					},
+					"Thursday": {{Start: "09:00", End: "10:00"}},
 				},
 			},
 		},
@@ -352,20 +326,34 @@ func TestCheckWarningDomainsAtTime_MultipleWarnings(t *testing.T) {
 	}
 }
 
-func TestCheckWarningDomainsAtTime_WarningTriggersAtEveryMinute(t *testing.T) {
+func TestCheckWarningDomainsAtTime_GroupExpandsToAllDomains(t *testing.T) {
 	cfg := config.Config{
+		Groups: map[string][]string{
+			"games": {"roblox.com", "fortnite.com"},
+		},
 		Rules: []config.Rule{
 			{
-				Domain:   "facebook.com",
+				Group:    "games",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "10:00", End: "12:00"},
-					},
+					"Monday": {{Start: "10:00", End: "12:00"}},
 				},
 			},
 		},
 	}
+
+	testTime := time.Date(2024, time.April, 1, 9, 57, 0, 0, time.UTC)
+	warnings := CheckWarningDomainsAtTime(testTime, cfg)
+
+	if len(warnings) != 2 {
+		t.Errorf("expected 2 warning domains from group, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestCheckWarningDomainsAtTime_WarningTriggersAtEveryMinute(t *testing.T) {
+	cfg := singleGroup("facebook.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "10:00", End: "12:00"}},
+	})
 
 	testCases := []struct {
 		name        string
@@ -448,19 +436,9 @@ func TestEvaluateRulesAtTime_AllWeekdaySchedules(t *testing.T) {
 	}
 
 	for _, wd := range weekdays {
-		cfg := config.Config{
-			Rules: []config.Rule{
-				{
-					Domain:   "youtube.com",
-					IsActive: true,
-					Schedules: map[string][]config.TimeSlot{
-						wd.day: {
-							{Start: "09:00", End: "17:00"},
-						},
-					},
-				},
-			},
-		}
+		cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+			wd.day: {{Start: "09:00", End: "17:00"}},
+		})
 
 		testTime := time.Date(2024, time.April, wd.dayOfWeek, 10, 0, 0, 0, time.UTC)
 		result := EvaluateRulesAtTime(testTime, cfg)
@@ -472,19 +450,9 @@ func TestEvaluateRulesAtTime_AllWeekdaySchedules(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_EdgeCaseMinuteBefore(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "youtube.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Monday": {
-						{Start: "10:00", End: "11:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("youtube.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "10:00", End: "11:00"}},
+	})
 
 	// Monday 09:59 (1 minute before start)
 	testTime := time.Date(2024, time.April, 1, 9, 59, 0, 0, time.UTC)
@@ -496,19 +464,9 @@ func TestEvaluateRulesAtTime_EdgeCaseMinuteBefore(t *testing.T) {
 }
 
 func TestEvaluateRulesAtTime_EdgeCaseMinuteAfterEnd(t *testing.T) {
-	cfg := config.Config{
-		Rules: []config.Rule{
-			{
-				Domain:   "reddit.com",
-				IsActive: true,
-				Schedules: map[string][]config.TimeSlot{
-					"Friday": {
-						{Start: "14:00", End: "15:00"},
-					},
-				},
-			},
-		},
-	}
+	cfg := singleGroup("reddit.com", true, map[string][]config.TimeSlot{
+		"Friday": {{Start: "14:00", End: "15:00"}},
+	})
 
 	// Friday 15:01 (1 minute after end)
 	testTime := time.Date(2024, time.April, 5, 15, 1, 0, 0, time.UTC)

--- a/internal/testcli/config.json
+++ b/internal/testcli/config.json
@@ -2,44 +2,51 @@
   "settings": {
     "primary_dns": "8.8.8.8:53",
     "backup_dns": "1.1.1.1:53",
-    "enforcement_mode": "hosts",
-    "auth_token": "19b5931dd350a82f1ad86f2592e2dbe7"
+    "auth_token": "19b5931dd350a82f1ad86f2592e2dbe7",
+    "enforcement_mode": "hosts"
+  },
+  "groups": {
+    "games": [
+      "roblox.com",
+      "epicgames.com",
+      "steampowered.com",
+      "fortnite.com",
+      "minecraft.net"
+    ],
+    "social": [
+      "discord.com",
+      "facebook.com",
+      "instagram.com",
+      "tiktok.com",
+      "snapchat.com",
+      "reddit.com"
+    ]
   },
   "rules": [
     {
-      "domain": "youtube.com",
+      "group": "games",
       "is_active": true,
       "schedules": {
-        "Friday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Monday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Thursday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Tuesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ],
-        "Wednesday": [
-          {
-            "start": "09:00",
-            "end": "17:00"
-          }
-        ]
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
+      }
+    },
+    {
+      "group": "social",
+      "is_active": true,
+      "schedules": {
+        "Monday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Tuesday":   [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Wednesday": [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Thursday":  [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Friday":    [{"start": "09:00", "end": "15:00"}, {"start": "21:30", "end": "23:59"}],
+        "Saturday":  [{"start": "21:30", "end": "23:59"}],
+        "Sunday":    [{"start": "21:30", "end": "23:59"}]
       }
     }
   ]

--- a/internal/testcli/testcli.go
+++ b/internal/testcli/testcli.go
@@ -28,9 +28,13 @@ type QueryResult struct {
 }
 
 // RuleInfo holds information about an applicable blocking rule.
+// Group is the rule's group name; MatchedDomain is the specific
+// domain in the group that matched the query (e.g. "roblox.com" when
+// querying "m.roblox.com" against the "games" group).
 type RuleInfo struct {
-	Domain    string         `json:"domain"`
-	Schedules []ScheduleInfo `json:"schedules"`
+	Group         string         `json:"group"`
+	MatchedDomain string         `json:"matched_domain"`
+	Schedules     []ScheduleInfo `json:"schedules"`
 }
 
 // ScheduleInfo holds schedule information.
@@ -118,11 +122,22 @@ func GetQueryResultWithConfig(timeStr, domain string, cfg config.Config) QueryRe
 		if !rule.IsActive {
 			continue
 		}
-		if !proxy.IsDomainBlocked(domain, map[string]bool{rule.Domain: true}) {
+		groupDomains := cfg.ResolveGroup(rule.Group)
+		if len(groupDomains) == 0 {
+			continue
+		}
+		var matched string
+		for _, d := range groupDomains {
+			if proxy.IsDomainBlocked(domain, map[string]bool{d: true}) {
+				matched = d
+				break
+			}
+		}
+		if matched == "" {
 			continue
 		}
 
-		ruleInfo := RuleInfo{Domain: rule.Domain}
+		ruleInfo := RuleInfo{Group: rule.Group, MatchedDomain: matched}
 
 		if slots, exists := rule.Schedules[testTime.Weekday().String()]; exists {
 			for _, slot := range slots {
@@ -242,12 +257,23 @@ func QueryBlocking(timeStr, domain string) error {
 		if !rule.IsActive {
 			continue
 		}
-		if !proxy.IsDomainBlocked(domain, map[string]bool{rule.Domain: true}) {
+		groupDomains := cfg.ResolveGroup(rule.Group)
+		if len(groupDomains) == 0 {
+			continue
+		}
+		var matched string
+		for _, d := range groupDomains {
+			if proxy.IsDomainBlocked(domain, map[string]bool{d: true}) {
+				matched = d
+				break
+			}
+		}
+		if matched == "" {
 			continue
 		}
 
 		foundRules = true
-		fmt.Printf("  Domain: %s\n", rule.Domain)
+		fmt.Printf("  Group: %s (matched %s)\n", rule.Group, matched)
 
 		if slots, exists := rule.Schedules[testTime.Weekday().String()]; exists {
 			for _, slot := range slots {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -68,9 +68,26 @@ func ValidatePostedConfig(cfg config.Config) error {
 		}
 	}
 
+	for groupName, domains := range cfg.Groups {
+		if groupName == "" {
+			return errors.New("group name cannot be empty")
+		}
+		if len(domains) == 0 {
+			return errors.New("group '" + groupName + "' must contain at least one domain")
+		}
+		for _, d := range domains {
+			if d == "" {
+				return errors.New("group '" + groupName + "' contains an empty domain")
+			}
+		}
+	}
+
 	for _, rule := range cfg.Rules {
-		if rule.Domain == "" {
-			return errors.New("rule domain cannot be empty")
+		if rule.Group == "" {
+			return errors.New("rule group cannot be empty")
+		}
+		if _, ok := cfg.Groups[rule.Group]; !ok {
+			return errors.New("rule references unknown group: " + rule.Group)
 		}
 		for day, slots := range rule.Schedules {
 			if !validDays[day] {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -245,8 +245,8 @@ func TestConfigHandler_RulesStructure(t *testing.T) {
 
 	// If there are rules, verify they have expected fields
 	for _, rule := range cfg.Rules {
-		if rule.Domain == "" {
-			t.Errorf("rule missing Domain field")
+		if rule.Group == "" {
+			t.Errorf("rule missing Group field")
 		}
 
 		if rule.Schedules == nil {
@@ -355,9 +355,10 @@ func TestStatusHandler_UsesPostedConfig(t *testing.T) {
 
 	blocked := config.Config{
 		Settings: config.Settings{PrimaryDNS: "8.8.8.8:53", BackupDNS: "1.1.1.1:53"},
+		Groups:   map[string][]string{"video": {"youtube.com"}},
 		Rules: []config.Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "video",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
 					day: {{Start: start, End: end}},
@@ -396,9 +397,10 @@ func TestStatusHandler_UsesPostedConfig(t *testing.T) {
 func TestStatusHandler_EmptyWhenNotBlocked(t *testing.T) {
 	notBlocked := config.Config{
 		Settings: config.Settings{PrimaryDNS: "8.8.8.8:53", BackupDNS: "1.1.1.1:53"},
+		Groups:   map[string][]string{"video": {"youtube.com"}},
 		Rules: []config.Rule{
 			{
-				Domain:   "youtube.com",
+				Group:    "video",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
 					// Window in the past — never active now

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -616,29 +616,28 @@ var WEEKDAYS = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Sat
 
 var EXAMPLE_CONFIG = {
     "settings": {"primary_dns": "8.8.8.8:53", "backup_dns": "1.1.1.1:53", "enforcement_mode": "hosts"},
+    "groups": {
+        "games":  ["roblox.com", "epicgames.com", "steampowered.com", "fortnite.com", "minecraft.net"],
+        "social": ["discord.com", "facebook.com", "instagram.com", "tiktok.com", "snapchat.com", "reddit.com"]
+    },
     "rules": [
-        {"domain": "youtube.com", "is_active": true, "schedules": {
-            "Monday":    [{"start":"09:00","end":"17:00"}],
-            "Tuesday":   [{"start":"09:00","end":"17:00"}],
-            "Wednesday": [{"start":"09:00","end":"17:00"}],
-            "Thursday":  [{"start":"09:00","end":"17:00"}],
-            "Friday":    [{"start":"09:00","end":"17:00"}]
+        {"group": "games", "is_active": true, "schedules": {
+            "Monday":    [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Tuesday":   [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Wednesday": [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Thursday":  [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Friday":    [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Saturday":  [{"start":"21:30","end":"23:59"}],
+            "Sunday":    [{"start":"21:30","end":"23:59"}]
         }},
-        {"domain": "instagram.com", "is_active": true, "schedules": {
-            "Monday":    [{"start":"09:00","end":"11:00"},{"start":"13:00","end":"17:00"}],
-            "Tuesday":   [{"start":"09:00","end":"17:00"}],
-            "Wednesday": [{"start":"09:00","end":"17:00"}],
-            "Thursday":  [{"start":"09:00","end":"17:00"}],
-            "Friday":    [{"start":"09:00","end":"15:00"}]
-        }},
-        {"domain": "reddit.com", "is_active": true, "schedules": {
-            "Monday":  [{"start":"09:00","end":"17:00"}],
-            "Tuesday": [{"start":"09:00","end":"17:00"}],
-            "Thursday":[{"start":"09:00","end":"17:00"}]
-        }},
-        {"domain": "twitter.com", "is_active": false, "schedules": {
-            "Saturday": [{"start":"10:00","end":"20:00"}],
-            "Sunday":   [{"start":"10:00","end":"20:00"}]
+        {"group": "social", "is_active": true, "schedules": {
+            "Monday":    [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Tuesday":   [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Wednesday": [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Thursday":  [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Friday":    [{"start":"09:00","end":"15:00"},{"start":"21:30","end":"23:59"}],
+            "Saturday":  [{"start":"21:30","end":"23:59"}],
+            "Sunday":    [{"start":"21:30","end":"23:59"}]
         }}
     ]
 };
@@ -698,22 +697,42 @@ function parseAndValidate(text) {
     var parsed;
     try { parsed = JSON.parse(text); } catch(e) { return {valid: false, error: 'Invalid JSON: ' + e.message}; }
     if (!parsed || typeof parsed !== 'object') return {valid: false, error: 'Config must be an object'};
-    if (!Array.isArray(parsed.rules))           return {valid: false, error: 'Config must have a rules array'};
+    if (!parsed.groups || typeof parsed.groups !== 'object' || Array.isArray(parsed.groups)) {
+        return {valid: false, error: 'Config must have a groups object'};
+    }
+    if (!Array.isArray(parsed.rules)) return {valid: false, error: 'Config must have a rules array'};
+
+    var groupNames = Object.keys(parsed.groups);
+    for (var gi = 0; gi < groupNames.length; gi++) {
+        var gn = groupNames[gi];
+        if (!gn) return {valid: false, error: 'Group name cannot be empty'};
+        var domains = parsed.groups[gn];
+        if (!Array.isArray(domains) || domains.length === 0) {
+            return {valid: false, error: 'Group "' + gn + '" must contain at least one domain'};
+        }
+        for (var di = 0; di < domains.length; di++) {
+            if (!domains[di] || typeof domains[di] !== 'string') {
+                return {valid: false, error: 'Group "' + gn + '" contains an empty/non-string domain'};
+            }
+        }
+    }
+
     for (var i = 0; i < parsed.rules.length; i++) {
         var rule = parsed.rules[i];
-        if (!rule.domain) return {valid: false, error: 'Each rule must have a domain'};
-        if (typeof rule.is_active !== 'boolean') return {valid: false, error: rule.domain + ': is_active must be boolean'};
-        if (!rule.schedules || typeof rule.schedules !== 'object') return {valid: false, error: rule.domain + ': missing schedules'};
+        if (!rule.group) return {valid: false, error: 'Each rule must reference a group'};
+        if (!parsed.groups[rule.group]) return {valid: false, error: 'Rule references unknown group: ' + rule.group};
+        if (typeof rule.is_active !== 'boolean') return {valid: false, error: rule.group + ': is_active must be boolean'};
+        if (!rule.schedules || typeof rule.schedules !== 'object') return {valid: false, error: rule.group + ': missing schedules'};
         var days = Object.keys(rule.schedules);
         for (var j = 0; j < days.length; j++) {
             var day = days[j];
             if (!VALID_DAYS[day]) return {valid: false, error: 'Invalid day: ' + day};
             var slots = rule.schedules[day];
-            if (!Array.isArray(slots) || slots.length === 0) return {valid: false, error: rule.domain + '/' + day + ': needs at least one slot'};
+            if (!Array.isArray(slots) || slots.length === 0) return {valid: false, error: rule.group + '/' + day + ': needs at least one slot'};
             for (var k = 0; k < slots.length; k++) {
                 var s = slots[k];
-                if (!s.start || !s.end) return {valid: false, error: rule.domain + '/' + day + ': slots need start and end'};
-                if (s.start >= s.end)   return {valid: false, error: rule.domain + '/' + day + ': start must be before end'};
+                if (!s.start || !s.end) return {valid: false, error: rule.group + '/' + day + ': slots need start and end'};
+                if (s.start >= s.end)   return {valid: false, error: rule.group + '/' + day + ': start must be before end'};
             }
         }
     }
@@ -869,6 +888,8 @@ function computeUpcoming(cfg, now, maxEvents, hoursAhead) {
     for (var i = 0; i < cfg.rules.length; i++) {
         var rule = cfg.rules[i];
         if (!rule.is_active) continue;
+        var groupDomains = (cfg.groups && cfg.groups[rule.group]) || [];
+        if (groupDomains.length === 0) continue;
         for (var offset = 0; offset <= 1; offset++) {
             var day     = new Date(now);
             day.setDate(day.getDate() + offset);
@@ -887,11 +908,12 @@ function computeUpcoming(cfg, now, maxEvents, hoursAhead) {
                 var tEnd = new Date(day);
                 tEnd.setHours(parseInt(ep[0], 10), parseInt(ep[1], 10), 0, 0);
 
+                var label = rule.group + ' (' + groupDomains.length + ' domain' + (groupDomains.length === 1 ? '' : 's') + ')';
                 if (tStart > now && tStart <= cutoff) {
-                    events.push({domain: rule.domain, type: 'block',   time: tStart, slot: slot});
+                    events.push({domain: label, type: 'block',   time: tStart, slot: slot});
                 }
                 if (tEnd > now && tEnd <= cutoff) {
-                    events.push({domain: rule.domain, type: 'unblock', time: tEnd,   slot: slot});
+                    events.push({domain: label, type: 'unblock', time: tEnd,   slot: slot});
                 }
             }
         }
@@ -953,8 +975,13 @@ function renderRulesSummary(cfg) {
         var badge = rule.is_active
             ? '<span class="active-badge on">active</span>'
             : '<span class="active-badge off">paused</span>';
+        var groupDomains = (cfg.groups && cfg.groups[rule.group]) || [];
+        var domainsCell = groupDomains.length === 0
+            ? '<span style="color:#dc3545">unknown group</span>'
+            : groupDomains.join(', ');
         return '<tr>' +
-            '<td>' + rule.domain + '</td>' +
+            '<td>' + rule.group + '</td>' +
+            '<td style="font-family:monospace;font-size:12px;color:#495057">' + domainsCell + '</td>' +
             '<td>' + badge + '</td>' +
             '<td>' + fmtSlots(rule.schedules && rule.schedules[todayName]) + '</td>' +
             '<td>' + fmtSlots(rule.schedules && rule.schedules[tomorrowName]) + '</td>' +
@@ -962,7 +989,7 @@ function renderRulesSummary(cfg) {
     }).join('');
 
     el.innerHTML = '<table class="rules-table"><thead><tr>' +
-        '<th>Domain</th><th>Status</th>' +
+        '<th>Group</th><th>Domains</th><th>Status</th>' +
         '<th>Today (' + todayName + ')</th>' +
         '<th>Tomorrow (' + tomorrowName + ')</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
@@ -1066,7 +1093,9 @@ function displayTestResult(result) {
     if (result.applicable_rules && result.applicable_rules.length > 0) {
         rulesEl.innerHTML = result.applicable_rules.map(function(rule) {
             return '<div class="rule-result-item">' +
-                '<div class="rule-result-domain">' + rule.domain + '</div>' +
+                '<div class="rule-result-domain">' + rule.group +
+                    ' <span style="color:#6c757d;font-weight:400">(matched ' + rule.matched_domain + ')</span>' +
+                '</div>' +
                 rule.schedules.map(function(s) {
                     var cls = s.is_active ? 'active-slot' : 'inactive-slot';
                     return '<div class="slot-result ' + cls + '">' +


### PR DESCRIPTION
## Summary

Replaces the old per-rule `domain` string with a named-group indirection. Configs now have a top-level `groups` map (e.g. `games`, `social`) and each rule references a group by name. One rule, many domains, one schedule — editing the group's member list updates every rule that uses it without touching any schedule.

The default seed shipped to fresh installs blocks `games` and `social` during the school weekday window (09:00–15:00) plus a nightly window every day (21:30–23:59).

## Why

Blocking five gaming sites used to require five rules with the same schedule duplicated five times. The groups indirection collapses that to one rule + one group, and means a kid (or someone helping them) can keep the "what counts as a distraction" list and the "when am I blocked" schedule in separate edits.

Strict groups-only — there is no inline-domains fallback. `ValidatePostedConfig` rejects any rule whose `group` doesn't reference an existing key.

## Commits (granular, one concern each)

| Commit | What |
|---|---|
| `f45e5c2` | `config`: add `Groups`, replace `Rule.Domain` with `Rule.Group`, add `ResolveGroup` helper, regenerate default seed |
| `55a8126` | `scheduler`: resolve `rule.Group` → domains during `EvaluateRulesAtTime` and `CheckWarningDomainsAtTime`; rewrite tests with a `singleGroup()` helper + new group-expansion / missing-group cases |
| `810960b` | `testcli`: surface `Group: <name> (matched <domain>)` in CLI prints and the structured `QueryResult.ApplicableRules` consumed by the web UI |
| `41c4f23` | `web`: server- and browser-side validation for groups + group references; Status tab Rules table now shows Group + member-domain list; Test tab shows `group (matched member)`; `EXAMPLE_CONFIG` reseeded |
| `542cf4a` | `config`: regenerate the three checked-in example configs (root, `cmd/app/`, `internal/testcli/`) — the old schema would now fail validation on load |
| `f652b75` | `docs`: rewrite README §Configuration, DESIGN §1/§5/§8/§9, and TROUBLESHOOTING examples for the new schema |

## Schema before/after

```diff
 {
   "settings": { ... },
+  "groups": {
+    "games":  ["roblox.com", "epicgames.com", "steampowered.com", "fortnite.com", "minecraft.net"],
+    "social": ["discord.com", "facebook.com", "instagram.com", "tiktok.com", "snapchat.com", "reddit.com"]
+  },
   "rules": [
     {
-      "domain": "youtube.com",
+      "group": "games",
       "is_active": true,
       "schedules": { ... }
     }
   ]
 }
```

## Gotchas

- **Breaking schema change with no migration shim.** Pre-existing configs that still carry `rules[].domain` will be rejected by `ValidatePostedConfig` and the rules silently ignored by the scheduler (because `cfg.ResolveGroup("")` returns nil). This is acceptable per the original direction — pre-release, no migration concerns — but worth flagging for the release notes.
- **`rule.Group` referencing a missing group is a silent no-op** in the scheduler (rule is skipped). The browser textarea and `ValidatePostedConfig` both reject it loudly on edit, but a hand-edited config-on-disk with a typo will just stop blocking instead of erroring. This is intentional: a deleted/renamed group should fail safe (less blocking) rather than crash the daemon.
- **Status tab Rules table grew a new column** ("Domains") so wide group memberships will wrap. Acceptable for the dashboard; just be aware of the visual shift.
- **Default seed is opinionated.** New installs now block `games` and `social` 9–3 weekdays + 9:30pm–midnight every day, instead of the old single-rule `youtube.com` Mon–Fri seed. Anyone testing fresh-install behaviour will see a much more aggressive default.
- **`internal/testcli/config.json` and `cmd/app/config.json` were regenerated** with the new shape and the existing `auth_token` values preserved. These are fixture files, not user data — but if you grep for the old token strings in scripts, they're unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes — scheduler suite covers group expansion + missing-group skip; web suite covers updated fixtures
- [ ] Manual: run `./distractions-free --no-service`, open `http://localhost:8040`, verify Status / Test / Manage tabs render the group + matched-domain UI correctly
- [ ] Manual: edit the textarea on the Manage tab to introduce an unknown `group` reference and confirm it's rejected by both the JS validator and the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)