### PR TITLE
Add Jekyll theme configuration and custom styling

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-hacker
+title: Distractions-Free
+description: A system-level focus daemon for macOS and Windows that enforces productivity schedules by blocking distracting domains at the OS layer.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,20 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+// Override hacker theme green (#b5e853) with a sky blue visible on black
+$blue: #4fc3f7;
+
+header h1                          { color: $blue; }
+#main_content h1,
+#main_content h2,
+#main_content h3,
+#main_content h4,
+#main_content h5,
+#main_content h6                   { color: $blue; }
+pre                                { color: $blue; }
+th                                 { border-bottom-color: $blue; }
+hr                                 { border-bottom-color: $blue; color: $blue; }
+a                                  { color: darken($blue, 10%); }
+a:hover                            { color: $blue; }


### PR DESCRIPTION
## Summary
This PR adds Jekyll configuration and custom CSS styling to support a themed documentation site for the Distractions-Free project.

## Key Changes
- **_config.yml**: Added Jekyll site configuration with:
  - Theme set to `jekyll-theme-hacker`
  - Site title and description for the project
  
- **assets/css/style.scss**: Created custom stylesheet that:
  - Imports the base hacker theme
  - Overrides the default green accent color (#b5e853) with sky blue (#4fc3f7) for better visibility on dark backgrounds
  - Applies the custom blue color to headers (h1-h6), pre-formatted text, table borders, and horizontal rules
  - Darkens the blue slightly for link text with a hover state that returns to the full blue color

## Implementation Details
The custom styling uses SCSS variables and the `darken()` function to maintain a cohesive color scheme while providing visual feedback for interactive elements. The color choice (sky blue) was selected for improved contrast and readability against the hacker theme's dark background.

https://claude.ai/code/session_01M4bbaRTZAAgY1Ao4bdLnNB