### PR TITLE
docs: add project badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Distractions-Free
 
+[![Latest Release](https://img.shields.io/github/v/release/vsangava/distractions-free?label=release)](https://github.com/vsangava/distractions-free/releases/latest)
+[![Release Date](https://img.shields.io/github/release-date/vsangava/distractions-free)](https://github.com/vsangava/distractions-free/releases/latest)
+[![Build](https://img.shields.io/github/actions/workflow/status/vsangava/distractions-free/release.yml?label=build)](https://github.com/vsangava/distractions-free/actions/workflows/release.yml)
+[![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/distractions-free/releases/latest)
+
 A system-level focus daemon for **macOS** (and Windows). It enforces a productivity schedule by blocking distracting domains at the OS layer, closing browser tabs when a block begins, and warning you 3 minutes before. It runs as a privileged background service that ordinary users cannot disable on a whim.
 
 Unlike browser extensions — one click to disable — Distractions-Free puts the block in the operating system itself: `/etc/hosts`, the local DNS resolver, and (in strict mode) the `pf` firewall. To turn it off you have to type your admin password.


### PR DESCRIPTION
## What

Adds five shields.io badges to the top of the README, just below the title.

- **Latest Release** — dynamic badge showing the most recent GitHub release tag
- **Release Date** — shows when the last release was published
- **Build** — reflects the `release.yml` workflow status (triggered on `v*` tags)
- **Go 1.26.2** — static badge matching the version declared in `go.mod`
- **Platform** — macOS | Windows, matching the cross-compile matrix in the release workflow

## Why

Badges give visitors an at-a-glance signal of project health and currency without having to dig into the Actions tab or releases page.

## Gotchas

- The **Build** badge only lights up green once the `release.yml` workflow has run at least once (i.e. after the first tagged release). Until then it will show "no status".
- The **Go** badge is static — it will need a manual bump when `go.mod` is updated to a newer toolchain version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NC3EMKiJF3391gNqpXDYm2)_