### PR TITLE
ci: add CI workflow and fix build badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.26.2'
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/vsangava/distractions-free?label=release)](https://github.com/vsangava/distractions-free/releases/latest)
 [![Release Date](https://img.shields.io/github/release-date/vsangava/distractions-free)](https://github.com/vsangava/distractions-free/releases/latest)
-[![Build](https://img.shields.io/github/actions/workflow/status/vsangava/distractions-free/release.yml?label=build)](https://github.com/vsangava/distractions-free/actions/workflows/release.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/vsangava/distractions-free/ci.yml?branch=main&label=build)](https://github.com/vsangava/distractions-free/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/distractions-free/releases/latest)
 


### PR DESCRIPTION
## What

Adds a dedicated `ci.yml` workflow and updates the build badge to point at it.

## Why the badge was failing

`release.yml` only triggers on `v*` tag pushes — it never runs against the `main` branch. Shields.io defaults to querying the default branch, finds no run, and renders the badge as failing (even when the last tagged release built successfully).

## Fix

- **New `.github/workflows/ci.yml`** — runs `go build ./...` + `go test ./...` on every push and PR to `main`, on `ubuntu-latest` with Go 1.26.2 (same version as the release matrix).
- **Badge updated** — points to `ci.yml?branch=main` instead of `release.yml`.

`release.yml` is unchanged — it still builds and attaches release artifacts on `v*` tags.

## Gotchas

The badge will show "no status" until `ci.yml` fires for the first time (i.e. until this PR merges and the CI run completes on `main`).