### PR TITLE
docs: add latest-release download links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/distractions-free/releases/latest)
 
+**Download latest:** [macOS (Apple Silicon)](https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-macos-arm64) · [Windows (x64)](https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-windows-amd64.exe)
+
 A system-level focus daemon for **macOS** (and Windows). It enforces a productivity schedule by blocking distracting domains at the OS layer, closing browser tabs when a block begins, and warning you 3 minutes before. It runs as a privileged background service that ordinary users cannot disable on a whim.
 
 Unlike browser extensions — one click to disable — Distractions-Free puts the block in the operating system itself: `/etc/hosts`, the local DNS resolver, and (in strict mode) the `pf` firewall. To turn it off you have to type your admin password.


### PR DESCRIPTION
## What

Adds a **Download latest** line between the badges and the description on the GitHub Pages site:

```
Download latest: macOS (Apple Silicon) · Windows (x64)
```

Both links use GitHub's stable `/releases/latest/download/` redirect, so they always resolve to the newest release without needing to update the README on each version bump.

## Why

The GitHub Pages site is the primary landing page; visitors need a clear, immediate path to get the binary without hunting through the Releases tab.

## Gotchas

- macOS Intel (`darwin/amd64`) is not included because it's not part of the release matrix in `release.yml` — only arm64 is built and uploaded.
- The links resolve to whichever assets were attached to the latest release. If a release is published without the expected filename (e.g. a partial release), the link will 404 until the asset is uploaded.