### PR TITLE
web: add binary download buttons to GitHub Pages header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/distractions-free/releases/latest)
 
-**Download latest:** [macOS (Apple Silicon)](https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-macos-arm64) · [Windows (x64)](https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-windows-amd64.exe)
-
 A system-level focus daemon for **macOS** (and Windows). It enforces a productivity schedule by blocking distracting domains at the OS layer, closing browser tabs when a block begins, and warning you 3 minutes before. It runs as a privileged background service that ordinary users cannot disable on a whim.
 
 Unlike browser extensions — one click to disable — Distractions-Free puts the block in the operating system itself: `/etc/hosts`, the local DNS resolver, and (in strict mode) the `pf` firewall. To turn it off you have to type your admin password.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% include head-custom.html %}
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <header>
+      <div class="container">
+        <a id="a-title" href="{{ '/' | relative_url }}">
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        </a>
+        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+
+        <section id="downloads">
+          <a href="https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-macos-arm64" class="btn">&#8595; macOS (Apple Silicon)</a>
+          <a href="https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-windows-amd64.exe" class="btn">&#8595; Windows (x64)</a>
+          <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+        </section>
+      </div>
+    </header>
+
+    <div class="container">
+      <section id="main_content">
+        {{ content }}
+      </section>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## What

Overrides the hacker theme's `_layouts/default.html` to add macOS and Windows binary download buttons to the site header, matching the existing **View on GitHub** button style.

Before (with `show_downloads: true`): `.zip` / `.tar.gz` source archive buttons
After: **↓ macOS (Apple Silicon)** · **↓ Windows (x64)** · **View on GitHub**

Also removes the inline `**Download latest:**` line from the README body since the header buttons replace it.

## Why

The hacker theme's `show_downloads` flag only generates source-archive (zip/tar) links — it has no built-in way to link to pre-built binaries. Overriding the layout gives full control over what appears in the header while keeping the same `.btn` / `.btn-github` CSS classes and exact HTML structure the theme expects.

## Gotchas

- The layout is a full copy of the upstream hacker theme `_layouts/default.html` — if the theme updates its layout we won't pick up those changes automatically. The layout is simple and unlikely to change.
- Download URLs use `/releases/latest/download/` so no update is needed when cutting new releases.