### PR TITLE
web: add logo to GitHub Pages header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
     <header>
       <div class="container">
         <a id="a-title" href="{{ '/' | relative_url }}">
+          <img src="{{ '/img/logo.png' | relative_url }}" alt="{{ site.title }}" class="site-logo">
           <h1>{{ site.title | default: site.github.repository_name }}</h1>
         </a>
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -18,3 +18,9 @@ th                                 { border-bottom-color: $blue; }
 hr                                 { border-bottom-color: $blue; color: $blue; }
 a                                  { color: darken($blue, 10%); }
 a:hover                            { color: $blue; }
+
+.site-logo {
+  display: block;
+  width: 96px;
+  margin: 0 auto 12px;
+}


### PR DESCRIPTION
## What

Adds `img/logo.png` to the GitHub Pages site header, centered above the site title.

- Logo sits inside the `#a-title` anchor so clicking it navigates home, consistent with the title link behaviour.
- Sized at 96px wide via `.site-logo` in the stylesheet; the transparent background lets it sit cleanly on the hacker theme's dark header.

## Gotchas

Jekyll serves files from the repo root so `img/logo.png` is accessible at `/img/logo.png` — no copying or symlinking needed.