### PR TITLE
refactor: rename binary and system identifiers to sentinel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
           - os: macos-latest
             goos: darwin
             goarch: arm64
-            output_name: distractions-free-macos-arm64
+            output_name: sentinel-macos-arm64
           # Windows build
           - os: windows-latest
             goos: windows
             goarch: amd64
-            output_name: distractions-free-windows-amd64.exe
+            output_name: sentinel-windows-amd64.exe
 
     runs-on: ${{ matrix.os }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ AppleScript execution uses `AppleScriptGenerator` and `ScriptExecutor` interface
 
 | OS | Path |
 |---|---|
-| macOS (service) | `/Library/Application Support/DistractionsFree/config.json` |
+| macOS (service) | `/Library/Application Support/Sentinel/config.json` |
 | `--no-service` | `./config.json` (working directory) |
 
 Config is re-read every scheduler tick — live edits take effect within 60 seconds, no restart needed.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,4 +1,4 @@
-# Distractions-Free — System Design
+# Sentinel — System Design
 
 This document describes how the daemon is built. It complements [README.md](./README.md), which is the user-facing guide, and [TROUBLESHOOTING.md](./TROUBLESHOOTING.md), which covers diagnostics and recovery.
 
@@ -24,7 +24,7 @@ This document describes how the daemon is built. It complements [README.md](./RE
 
 ## 1. Overview
 
-Distractions-Free is a single-binary Go daemon that runs as a privileged system service. It enforces per-time-of-day blocking rules on the host — each rule binds a named group of domains (e.g. `games`, `social`) to a weekly schedule — so distracting sites become unreachable during configured windows.
+Sentinel is a single-binary Go daemon that runs as a privileged system service. It enforces per-time-of-day blocking rules on the host — each rule binds a named group of domains (e.g. `games`, `social`) to a weekly schedule — so distracting sites become unreachable during configured windows.
 
 The interesting design decisions:
 
@@ -105,7 +105,7 @@ The interesting design decisions:
 
 **`dns` mode:** the OS is configured to use `127.0.0.1:53` as its resolver. Each query is checked against the in-memory `blocked` map. Blocked A-record queries return `0.0.0.0`; everything else is forwarded to the upstream resolver (with backup-DNS failover).
 
-**`strict` mode:** like `dns`, plus the scheduler asks the pf enforcer to resolve each newly-blocked domain to A/AAAA addresses and load them into a `<blocked_ips>` table inside the `distractions-free` pf anchor. Outbound packets to those IPs are dropped at the kernel.
+**`strict` mode:** like `dns`, plus the scheduler asks the pf enforcer to resolve each newly-blocked domain to A/AAAA addresses and load them into a `<blocked_ips>` table inside the `sentinel` pf anchor. Outbound packets to those IPs are dropped at the kernel.
 
 ---
 
@@ -178,13 +178,13 @@ func New(cfg config.Config) Enforcer {
 Edits `/etc/hosts` (or `C:\Windows\System32\drivers\etc\hosts`) between marker lines:
 
 ```
-# distractions-free:begin
+# sentinel:begin
 0.0.0.0 youtube.com
 0.0.0.0 www.youtube.com
 0.0.0.0 m.youtube.com
 0.0.0.0 mobile.youtube.com
 0.0.0.0 app.youtube.com
-# distractions-free:end
+# sentinel:end
 ```
 
 Subdomain prefixes are hardcoded: `["", "www.", "m.", "mobile.", "app."]`. There is no wildcard support in `/etc/hosts`, so this is a deliberate, conservative list. Adding more would inflate the hosts file for marginal benefit.
@@ -365,7 +365,7 @@ This function is what the test suite hits — no port binding, no global state, 
 
 ### Anchor file model
 
-The daemon owns one pf anchor named `distractions-free`, stored at `/etc/pf.anchors/distractions-free`. The anchor file content is regenerated on every Activate:
+The daemon owns one pf anchor named `sentinel`, stored at `/etc/pf.anchors/sentinel`. The anchor file content is regenerated on every Activate:
 
 ```
 table <blocked_ips> persist {
@@ -379,19 +379,19 @@ block drop out quick proto {tcp udp} from any to <blocked_ips>
 The anchor is wired into `/etc/pf.conf` between marker lines:
 
 ```
-# distractions-free:begin
-anchor "distractions-free"
-load anchor "distractions-free" from "/etc/pf.anchors/distractions-free"
-# distractions-free:end
+# sentinel:begin
+anchor "sentinel"
+load anchor "sentinel" from "/etc/pf.anchors/sentinel"
+# sentinel:end
 ```
 
 `InstallAnchor()` writes a stub anchor file, injects the pf.conf block (idempotent — checks for the marker first), runs `pfctl -n -f /etc/pf.conf` to validate the config in dry-run mode, then `pfctl -f /etc/pf.conf` to load it, and finally `pfctl -e` to enable pf if it isn't already.
 
 `RemoveAnchor()` flushes the table, strips the marker block from pf.conf, reloads pf, and deletes the anchor file.
 
-`ActivateBlock(domains, primaryDNS)` resolves each domain to A and AAAA addresses (via `miekg/dns`, falling back to `net.LookupHost`), regenerates the anchor file, runs `pfctl -a distractions-free -f <anchor>` to load it, and then runs `pfctl -k <src> -k <ip>` per IP to kill any existing connections.
+`ActivateBlock(domains, primaryDNS)` resolves each domain to A and AAAA addresses (via `miekg/dns`, falling back to `net.LookupHost`), regenerates the anchor file, runs `pfctl -a sentinel -f <anchor>` to load it, and then runs `pfctl -k <src> -k <ip>` per IP to kill any existing connections.
 
-`DeactivateBlock()` flushes the table via `pfctl -a distractions-free -t blocked_ips -T flush`, tolerating "No such table" since the table may not exist on first run.
+`DeactivateBlock()` flushes the table via `pfctl -a sentinel -t blocked_ips -T flush`, tolerating "No such table" since the table may not exist on first run.
 
 ### Why preview functions are exported
 
@@ -448,8 +448,8 @@ A rule used to carry a single `Domain` string, which meant blocking five gaming 
 
 | OS | Path |
 |---|---|
-| macOS | `/Library/Application Support/DistractionsFree/config.json` |
-| Windows | `%PROGRAMDATA%\DistractionsFree\config.json` |
+| macOS | `/Library/Application Support/Sentinel/config.json` |
+| Windows | `%PROGRAMDATA%\Sentinel\config.json` |
 | Linux | `/etc/distractionsfree/config.json` |
 | `UseLocalConfig=true` | `./config.json` |
 
@@ -598,7 +598,7 @@ func (p *program) Stop(s service.Service) error {
 
 ## 11. Cleanup (`--clean`)
 
-`internal/cleanup/cleanup.go` plus `priv_unix.go` / `priv_windows.go`. The forensic recovery path: undo every system change distractions-free might have made, even if the service crashed mid-write.
+`internal/cleanup/cleanup.go` plus `priv_unix.go` / `priv_windows.go`. The forensic recovery path: undo every system change sentinel might have made, even if the service crashed mid-write.
 
 Each cleanup action is a `Step` with a status (`done`/`skipped`/`warn`/`error`) and an optional `Critical` flag. The summary is printed line-by-line at the end. Critical failures cause a non-zero exit code.
 
@@ -686,13 +686,13 @@ The hot path is the per-DNS-query read of `proxy.blockedDomains`; that's why it'
 
 ## 14. Security model
 
-Distractions-Free is **not** a security tool. It's a friction tool against your own future self. Treat it accordingly:
+Sentinel is **not** a security tool. It's a friction tool against your own future self. Treat it accordingly:
 
 - The dashboard binds `127.0.0.1` only. Network attackers cannot reach `:8040`.
 - The auth token in `X-Auth-Token` keeps random local processes from poking the API by accident, but anything running as your user can read `config.json` and impersonate the dashboard. Same for the PIN — it's client-side only.
 - The Manage-tab PIN is not a password. It's a friction layer designed to make you pause and think before disabling your own focus rules. Trivially bypassed by anyone who reads the JS.
 - The service runs as root (macOS launchd daemon, Windows Service). Anything that compromises the binary inherits root. Build releases via the GitHub Actions workflow; don't run a binary you didn't compile or download from a release tag.
-- `/etc/hosts` and `/etc/pf.conf` edits use atomic temp-file + rename. A crash mid-write cannot corrupt the file. Markers (`# distractions-free:begin`/`:end`) mean other tools that respect them won't trample our entries.
+- `/etc/hosts` and `/etc/pf.conf` edits use atomic temp-file + rename. A crash mid-write cannot corrupt the file. Markers (`# sentinel:begin`/`:end`) mean other tools that respect them won't trample our entries.
 - The `--clean` command is the canonical recovery path. It iterates every interface, does not assume a happy-path service stop succeeded, and exits non-zero if any critical step fails.
 
 ---
@@ -701,7 +701,7 @@ Distractions-Free is **not** a security tool. It's a friction tool against your 
 
 ### macOS
 
-- Service framework: `launchd`. The `kardianos/service` library writes a plist to `~/Library/LaunchAgents/com.github.distractions-free.plist` (or system equivalent depending on install context).
+- Service framework: `launchd`. The `kardianos/service` library writes a plist to `~/Library/LaunchAgents/com.github.sentinel.plist` (or system equivalent depending on install context).
 - `osascript` is invoked as the console user (resolved via `stat -f %Su /dev/console`) so notifications appear in the user's UI session and AppleScript can talk to Chrome/Safari. Running `osascript` as root produces a notification nobody can see.
 - `networksetup` is the only supported way to set system DNS — there's no clean API.
 - `dscacheutil -flushcache` + `killall -HUP mDNSResponder` is the canonical cache-flush incantation. Both are needed.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: help build build-all test clean release check-release
 
 VERSION ?= dev
-BINARY_NAME := distractions-free
+BINARY_NAME := sentinel
 
 help:
-	@echo "📦 Distractions-Free Build Commands"
+	@echo "📦 Sentinel Build Commands"
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 *Your schedule. Enforced.*
 
-[![Latest Release](https://img.shields.io/github/v/release/vsangava/distractions-free?label=release)](https://github.com/vsangava/distractions-free/releases/latest)
-[![Release Date](https://img.shields.io/github/release-date/vsangava/distractions-free)](https://github.com/vsangava/distractions-free/releases/latest)
-[![Build](https://img.shields.io/github/actions/workflow/status/vsangava/distractions-free/ci.yml?branch=main&label=build)](https://github.com/vsangava/distractions-free/actions/workflows/ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/vsangava/sentinel?label=release)](https://github.com/vsangava/sentinel/releases/latest)
+[![Release Date](https://img.shields.io/github/release-date/vsangava/sentinel)](https://github.com/vsangava/sentinel/releases/latest)
+[![Build](https://img.shields.io/github/actions/workflow/status/vsangava/sentinel/ci.yml?branch=main&label=build)](https://github.com/vsangava/sentinel/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/go-1.26.2-00ADD8?logo=go&logoColor=white)](https://go.dev/)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/distractions-free/releases/latest)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey)](https://github.com/vsangava/sentinel/releases/latest)
 
 Sentinel lets you set a schedule for the websites that are hardest to resist — social media, gaming, streaming — and enforces it without giving you (or anyone else) an easy way out. It runs silently in the background as a system service. Turning it off requires your admin password.
 
@@ -71,24 +71,24 @@ Browser extensions are easy to bypass — one click to disable, and kids know it
 
 ### 1. Download the binary
 
-**[→ Download from the latest release](https://github.com/vsangava/distractions-free/releases/latest)**
+**[→ Download from the latest release](https://github.com/vsangava/sentinel/releases/latest)**
 
 | Platform | File |
 |---|---|
-| macOS Apple Silicon | `distractions-free-macos-arm64` |
-| macOS Intel | `distractions-free-macos-amd64` |
-| Windows x86_64 | `distractions-free-windows-amd64.exe` |
+| macOS Apple Silicon | `sentinel-macos-arm64` |
+| macOS Intel | `sentinel-macos-amd64` |
+| Windows x86_64 | `sentinel-windows-amd64.exe` |
 
 On macOS, make it executable after downloading:
 ```bash
-chmod +x distractions-free-macos-*
+chmod +x sentinel-macos-*
 ```
 
 ### 2. Install and start the service
 
 ```bash
-sudo ./distractions-free install
-sudo ./distractions-free start
+sudo ./sentinel install
+sudo ./sentinel start
 ```
 
 That's it for most users. The service starts at login from this point on.
@@ -149,8 +149,8 @@ The daemon reads its configuration from a single JSON file:
 
 | OS | Path |
 |---|---|
-| macOS (service) | `/Library/Application Support/DistractionsFree/config.json` |
-| Windows (service) | `%PROGRAMDATA%\DistractionsFree\config.json` |
+| macOS (service) | `/Library/Application Support/Sentinel/config.json` |
+| Windows (service) | `%PROGRAMDATA%\Sentinel\config.json` |
 | Any (`--no-service`) | `./config.json` (working directory) |
 
 The file is created with defaults on first launch. The scheduler reloads it every minute — live edits take effect on the next tick, no restart required.
@@ -243,7 +243,7 @@ The default is `"hosts"`. Most users should leave it that way.
 
 ### `hosts` (default)
 
-Edits `/etc/hosts` (macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows). Blocked entries live between marker lines (`# distractions-free:begin` / `# distractions-free:end`) and are atomically rewritten — a crash mid-write cannot corrupt the file. Other entries are never touched.
+Edits `/etc/hosts` (macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows). Blocked entries live between marker lines (`# sentinel:begin` / `# sentinel:end`) and are atomically rewritten — a crash mid-write cannot corrupt the file. Other entries are never touched.
 
 **Best for:** most users. No port binding, no DNS reconfiguration, works in every browser and app.
 
@@ -270,8 +270,8 @@ Like `dns`, plus a `pf` (Packet Filter) anchor on macOS that drops outbound pack
 Edit `enforcement_mode` in `config.json` and restart the service, or use the shorthand:
 
 ```bash
-sudo ./distractions-free --strict   # writes "strict" to config and exits
-sudo ./distractions-free start      # restart to pick it up
+sudo ./sentinel --strict   # writes "strict" to config and exits
+sudo ./sentinel start      # restart to pick it up
 ```
 
 ---
@@ -281,16 +281,16 @@ sudo ./distractions-free start      # restart to pick it up
 The all-in-one `--clean` command undoes every system change the daemon made: stops the service, removes hosts entries, removes the pf anchor, resets DNS on every interface pointing at `127.0.0.1`, flushes the resolver cache, unregisters the service, removes the config directory, and verifies port 53 is free.
 
 ```bash
-sudo ./distractions-free --clean          # asks before deleting config
-sudo ./distractions-free --clean --yes    # deletes config without asking
+sudo ./sentinel --clean          # asks before deleting config
+sudo ./sentinel --clean --yes    # deletes config without asking
 ```
 
 If you'd rather drive the steps yourself:
 
 ```bash
-sudo ./distractions-free stop        # restores DNS/hosts changes
-sudo ./distractions-free uninstall   # removes the service registration
-sudo rm -rf "/Library/Application Support/DistractionsFree"
+sudo ./sentinel stop        # restores DNS/hosts changes
+sudo ./sentinel uninstall   # removes the service registration
+sudo rm -rf "/Library/Application Support/Sentinel"
 ```
 
 > ⚠️ In `dns`/`strict` mode, do not delete the binary while the service is running with system DNS pointed at `127.0.0.1`, or the machine will lose name resolution. `--clean` handles this correctly; manual removal does not.
@@ -300,9 +300,9 @@ sudo rm -rf "/Library/Application Support/DistractionsFree"
 ## Command-line reference
 
 ```
-distractions-free <subcommand>           # service management
-distractions-free [--flag]               # local / test mode
-sudo distractions-free --clean [--yes]   # forensic uninstall
+sentinel <subcommand>           # service management
+sentinel [--flag]               # local / test mode
+sudo sentinel --clean [--yes]   # forensic uninstall
 ```
 
 | Command / flag | Privileges | What it does | More |
@@ -344,8 +344,8 @@ All endpoints listen on `127.0.0.1:8040`. Every endpoint except the first requir
 Requires Go 1.21+ (the release pipeline uses 1.26.2).
 
 ```bash
-git clone https://github.com/vsangava/distractions-free.git
-cd distractions-free
+git clone https://github.com/vsangava/sentinel.git
+cd sentinel
 
 make build         # current OS only
 make build-all     # macOS arm64 + amd64 + Windows amd64
@@ -353,7 +353,7 @@ make build-all     # macOS arm64 + amd64 + Windows amd64
 
 | Target | What it does |
 |---|---|
-| `make build` | Build for current OS into `./distractions-free` |
+| `make build` | Build for current OS into `./sentinel` |
 | `make build-all` | Cross-compile macOS arm64, macOS amd64, and Windows amd64 |
 | `make test` | `go test ./...` |
 | `make release` | `test` + `build-all` + `verify-binaries` (pre-release sanity check) |
@@ -388,7 +388,7 @@ Three flags let you exercise the daemon without installing it as a service:
 ### `--test-query "<time>" <domain>`
 
 ```bash
-./distractions-free --test-query "2024-04-01 10:30" youtube.com
+./sentinel --test-query "2024-04-01 10:30" youtube.com
 ```
 
 Prints whether the domain would be blocked at that moment, the matching rule(s), and whether a 3-minute warning would fire. Uses `./config.json`. Time format: `YYYY-MM-DD HH:MM` (24-hour).
@@ -396,7 +396,7 @@ Prints whether the domain would be blocked at that moment, the matching rule(s),
 ### `--test-web`
 
 ```bash
-./distractions-free --test-web
+./sentinel --test-web
 # open http://localhost:8040
 ```
 
@@ -405,7 +405,7 @@ Runs the full dashboard against `./config.json` without installing the service. 
 ### `--test-applescript`
 
 ```bash
-./distractions-free --test-applescript
+./sentinel --test-applescript
 ```
 
 Generates the AppleScript used by the tab-closer and optionally executes it. macOS only. Test domains: `facebook.com` (close), `reddit.com` and `roblox.com` (warning — only fires if a tab is open).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ If you removed or stopped the service while it was in `dns` or `strict` mode and
 **Fix it in one command (requires sudo):**
 
 ```bash
-sudo ./distractions-free --clean --yes
+sudo ./sentinel --clean --yes
 ```
 
 That iterates every network interface, resets the ones pointing at `127.0.0.1`, flushes the resolver cache, and verifies port 53 is free. It also handles the case where you've already deleted the binary's config dir.
@@ -71,7 +71,7 @@ ipconfig /flushdns
 
 ```bash
 # Service registered & running?
-sudo ./distractions-free status
+sudo ./sentinel status
 
 # What does the live daemon think is blocked right now?
 TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
@@ -107,11 +107,11 @@ The daemon edits `/etc/hosts`. To see what it's currently writing:
 
 ```bash
 # macOS / Linux
-sed -n '/# distractions-free:begin/,/# distractions-free:end/p' /etc/hosts
+sed -n '/# sentinel:begin/,/# sentinel:end/p' /etc/hosts
 
 # Windows (PowerShell)
 Get-Content C:\Windows\System32\drivers\etc\hosts |
-  Select-String -Pattern "distractions-free:begin" -Context 0,100
+  Select-String -Pattern "sentinel:begin" -Context 0,100
 ```
 
 If the block isn't there during a scheduled window, the scheduler hasn't fired (check `/api/status` `last_evaluated`).
@@ -168,10 +168,10 @@ sudo pfctl -s info | head -3
 
 # Our anchor loaded?
 sudo pfctl -s Anchors
-# → distractions-free should appear
+# → sentinel should appear
 
 # What IPs are currently blocked at the firewall?
-sudo pfctl -a distractions-free -t blocked_ips -T show
+sudo pfctl -a sentinel -t blocked_ips -T show
 
 # Preview what strict mode would produce for current blocks (no root needed)
 TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
@@ -191,13 +191,13 @@ The 3-minute warning notification and the tab-closing only fire on macOS, only v
 
 ```bash
 # Test the script generation + execution by hand (no service install needed)
-./distractions-free --test-applescript
+./sentinel --test-applescript
 ```
 
 Common gotchas:
 
 - **Running as root via launchd, but no console user detected.** `osascript` invoked as root with no user context produces a notification nobody can see. The daemon detects the console user via `stat -f %Su /dev/console` and shells out via `su - <user> -c osascript ...`. If `/dev/console` returns `root` (no one logged in), notifications are silently skipped.
-- **macOS Automation permissions.** First run, macOS prompts: *"distractions-free wants to control 'Google Chrome'."* If you click Don't Allow, AppleScript silently fails forever after. Reset in System Settings → Privacy & Security → Automation.
+- **macOS Automation permissions.** First run, macOS prompts: *"sentinel wants to control 'Google Chrome'."* If you click Don't Allow, AppleScript silently fails forever after. Reset in System Settings → Privacy & Security → Automation.
 - **Browsers not running.** The warning script first checks for open tabs; if no Chrome or Safari window matches, the notification is suppressed by design.
 
 ---
@@ -210,28 +210,28 @@ The daemon logs to stdout/stderr; launchd routes that to the system log:
 
 ```bash
 # Live tail
-log stream --predicate 'process == "distractions-free"' --level debug
+log stream --predicate 'process == "sentinel"' --level debug
 
 # Last hour
-log show --predicate 'process == "distractions-free"' --last 1h
+log show --predicate 'process == "sentinel"' --last 1h
 
 # Just the scheduler ticks
-log show --predicate 'process == "distractions-free"' --last 1h | grep -E "scheduler|hosts|dns"
+log show --predicate 'process == "sentinel"' --last 1h | grep -E "scheduler|hosts|dns"
 ```
 
-If the service was installed via `kardianos/service` defaults, the launchd plist is at `~/Library/LaunchAgents/com.github.distractions-free.plist`:
+If the service was installed via `kardianos/service` defaults, the launchd plist is at `~/Library/LaunchAgents/com.github.sentinel.plist`:
 
 ```bash
-cat ~/Library/LaunchAgents/com.github.distractions-free.plist
-launchctl print system/com.github.distractions-free
+cat ~/Library/LaunchAgents/com.github.sentinel.plist
+launchctl print system/com.github.sentinel
 ```
 
 ### Windows
 
 ```powershell
-Get-EventLog -LogName Application -Source "DistractionsFree" -Newest 50
+Get-EventLog -LogName Application -Source "Sentinel" -Newest 50
 # Service status
-Get-Service "DistractionsFree"
+Get-Service "Sentinel"
 ```
 
 ### Anywhere
@@ -239,10 +239,10 @@ Get-Service "DistractionsFree"
 If launchd / Service Manager logs aren't useful, run the daemon in the foreground to see everything live:
 
 ```bash
-sudo ./distractions-free stop          # stop the service version
-sudo ./distractions-free run           # run with the supervisor (foreground)
+sudo ./sentinel stop          # stop the service version
+sudo ./sentinel run           # run with the supervisor (foreground)
 # or, even simpler, no privileges needed for hosts-mode rule evaluation:
-./distractions-free --no-service       # uses ./config.json
+./sentinel --no-service       # uses ./config.json
 ```
 
 `--no-service` is a fast way to validate that the rules and scheduler logic work — it skips system paths and won't install anything.
@@ -251,27 +251,27 @@ sudo ./distractions-free run           # run with the supervisor (foreground)
 
 ## 6. Manual install / start / stop / uninstall
 
-The normal happy path is `sudo ./distractions-free install && sudo ./distractions-free start`. If something goes wrong, here's how to verify each step independently.
+The normal happy path is `sudo ./sentinel install && sudo ./sentinel start`. If something goes wrong, here's how to verify each step independently.
 
 ```bash
-sudo ./distractions-free install
+sudo ./sentinel install
 # Verify on macOS:
-ls -la ~/Library/LaunchAgents/com.github.distractions-free.plist
-launchctl list | grep distractions-free
+ls -la ~/Library/LaunchAgents/com.github.sentinel.plist
+launchctl list | grep sentinel
 ```
 
 ```bash
-sudo ./distractions-free start
+sudo ./sentinel start
 # Verify:
-sudo ./distractions-free status         # Should print: running
-ps aux | grep distractions-free | grep -v grep
+sudo ./sentinel status         # Should print: running
+ps aux | grep sentinel | grep -v grep
 sudo lsof -i :53 -P -n                  # only relevant in dns/strict mode
 sudo lsof -i :8040 -P -n                # web dashboard
 curl -s http://localhost:8040/api/config | jq -r '.settings.enforcement_mode'
 ```
 
 ```bash
-sudo ./distractions-free stop
+sudo ./sentinel stop
 # Verify (mode-dependent):
 #   hosts: managed block removed from /etc/hosts
 #   dns:   networksetup -getdnsservers Wi-Fi → restored to upstream
@@ -279,10 +279,10 @@ sudo ./distractions-free stop
 ```
 
 ```bash
-sudo ./distractions-free uninstall
+sudo ./sentinel uninstall
 # Verify:
-ls ~/Library/LaunchAgents/com.github.distractions-free.plist  # should be gone
-launchctl list | grep distractions-free                       # should be empty
+ls ~/Library/LaunchAgents/com.github.sentinel.plist  # should be gone
+launchctl list | grep sentinel                       # should be empty
 ```
 
 ---
@@ -293,17 +293,17 @@ Three flags exist exactly so you can test the daemon's core logic without privil
 
 ```bash
 # Will youtube.com be blocked at this specific time per current ./config.json?
-./distractions-free --test-query "2024-04-01 10:30" youtube.com
+./sentinel --test-query "2024-04-01 10:30" youtube.com
 # Output includes: applicable rules, would-block status, and a real DNS response
 # from upstream so you can verify what the upstream resolver returns.
 
 # Run the full dashboard against ./config.json (no service install, no system changes).
 # All endpoints work, including hosts-preview and pf-preview.
-./distractions-free --test-web
+./sentinel --test-web
 # → http://localhost:8040
 
 # Generate (and optionally execute) the AppleScript that closes Chrome/Safari tabs.
-./distractions-free --test-applescript
+./sentinel --test-applescript
 ```
 
 `--test-query` and `--test-web` use `./config.json` in the working directory rather than the system path, so you can iterate on groups and rules without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new group shapes or schedule timings.
@@ -312,11 +312,11 @@ Three flags exist exactly so you can test the daemon's core logic without privil
 
 ## 8. The `--clean` recovery path
 
-`--clean` is the canonical "make it like distractions-free was never installed" command. Run it any time the system is in an unknown state — it does not assume `stop` succeeded, and every step is idempotent.
+`--clean` is the canonical "make it like sentinel was never installed" command. Run it any time the system is in an unknown state — it does not assume `stop` succeeded, and every step is idempotent.
 
 ```bash
-sudo ./distractions-free --clean         # interactive: prompts before deleting config dir
-sudo ./distractions-free --clean --yes   # non-interactive
+sudo ./sentinel --clean         # interactive: prompts before deleting config dir
+sudo ./sentinel --clean --yes   # non-interactive
 ```
 
 The output is one line per step:
@@ -379,31 +379,31 @@ This error only applies to `dns` and `strict` modes. In `hosts` mode the daemon 
 ### `service is already installed`
 
 ```bash
-sudo ./distractions-free uninstall
-sudo ./distractions-free install
+sudo ./sentinel uninstall
+sudo ./sentinel install
 ```
 
 If `uninstall` claims it isn't installed, the plist is dangling:
 
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.github.distractions-free.plist
-rm ~/Library/LaunchAgents/com.github.distractions-free.plist
-sudo ./distractions-free install
+launchctl unload ~/Library/LaunchAgents/com.github.sentinel.plist
+rm ~/Library/LaunchAgents/com.github.sentinel.plist
+sudo ./sentinel install
 ```
 
 ### `cannot uninstall while service is running`
 
 ```bash
-sudo ./distractions-free stop
-sudo ./distractions-free uninstall
+sudo ./sentinel stop
+sudo ./sentinel uninstall
 ```
 
 If `stop` hangs or fails, force it:
 
 ```bash
-sudo pkill -f "distractions-free"
-launchctl unload ~/Library/LaunchAgents/com.github.distractions-free.plist
-sudo ./distractions-free uninstall
+sudo pkill -f "sentinel"
+launchctl unload ~/Library/LaunchAgents/com.github.sentinel.plist
+sudo ./sentinel uninstall
 ```
 
 ### Web dashboard returns 401 unauthorized
@@ -425,10 +425,10 @@ If they're still not applied:
 
 ```bash
 # Validate JSON
-python3 -m json.tool < /Library/Application\ Support/DistractionsFree/config.json
+python3 -m json.tool < /Library/Application\ Support/Sentinel/config.json
 
 # Check the daemon's logs for parse errors
-log show --predicate 'process == "distractions-free"' --last 5m | grep -i config
+log show --predicate 'process == "sentinel"' --last 5m | grep -i config
 ```
 
 If the file is malformed, the daemon logs a warning and keeps using the previous in-memory copy — your changes won't apply until you fix the JSON.
@@ -450,10 +450,10 @@ The strict enforcer degrades to DNS-only when pf setup fails. Common causes:
 To start fresh:
 
 ```bash
-sudo ./distractions-free --clean --yes   # removes our anchor + pf.conf injection
+sudo ./sentinel --clean --yes   # removes our anchor + pf.conf injection
 # inspect /etc/pf.conf — should be back to its original state
-sudo ./distractions-free install
-sudo ./distractions-free start
+sudo ./sentinel install
+sudo ./sentinel start
 # logs should show "pf: anchor installed"
 ```
 
@@ -463,4 +463,4 @@ See [§4 macOS AppleScript path](#macos-applescript-path). The most common cause
 
 ### `--clean` says "could not create service handle"
 
-Usually means the binary you're running was built for a different OS. Check `file ./distractions-free` and rebuild for the current platform with `make build`.
+Usually means the binary you're running was built for a different OS. Check `file ./sentinel` and rebuild for the current platform with `make build`.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,8 +21,8 @@
         <h2>{{ site.description | default: site.github.project_tagline }}</h2>
 
         <section id="downloads">
-          <a href="https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-macos-arm64" class="btn">&#8595; macOS (Apple Silicon)</a>
-          <a href="https://github.com/vsangava/distractions-free/releases/latest/download/distractions-free-windows-amd64.exe" class="btn">&#8595; Windows (x64)</a>
+          <a href="https://github.com/vsangava/sentinel/releases/latest/download/sentinel-macos-arm64" class="btn">&#8595; macOS (Apple Silicon)</a>
+          <a href="https://github.com/vsangava/sentinel/releases/latest/download/sentinel-windows-amd64.exe" class="btn">&#8595; Windows (x64)</a>
           <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
         </section>
       </div>

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/kardianos/service"
-	"github.com/vsangava/distractions-free/internal/cleanup"
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/enforcer"
-	"github.com/vsangava/distractions-free/internal/proxy"
-	"github.com/vsangava/distractions-free/internal/scheduler"
-	"github.com/vsangava/distractions-free/internal/testcli"
-	"github.com/vsangava/distractions-free/internal/web"
+	"github.com/vsangava/sentinel/internal/cleanup"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/enforcer"
+	"github.com/vsangava/sentinel/internal/proxy"
+	"github.com/vsangava/sentinel/internal/scheduler"
+	"github.com/vsangava/sentinel/internal/testcli"
+	"github.com/vsangava/sentinel/internal/web"
 )
 
 func testAppleScript() {
@@ -39,7 +39,7 @@ func testAppleScript() {
 		warningScript := ""
 		openWarningDomains := scheduler.GetOpenBrowserDomains(warningDomains)
 		if len(openWarningDomains) > 0 {
-			warningScript = fmt.Sprintf(`display alert "Distractions-Free" message "Tabs for %s will close in 3 minutes." buttons {"OK"} giving up after 15`, strings.Join(openWarningDomains, ", "))
+			warningScript = fmt.Sprintf(`display alert "Sentinel" message "Tabs for %s will close in 3 minutes." buttons {"OK"} giving up after 15`, strings.Join(openWarningDomains, ", "))
 			log.Println("Executing warning script...")
 			if err := scheduler.GetScriptExecutor().ExecuteScript(warningScript); err != nil {
 				log.Printf("Warning script execution failed: %v", err)
@@ -107,17 +107,17 @@ func (p *program) Stop(s service.Service) error {
 }
 
 var svcConfig = &service.Config{
-	Name:        "DistractionsFree",
-	DisplayName: "Distractions Free DNS Proxy",
+	Name:        "Sentinel",
+	DisplayName: "Sentinel DNS Proxy",
 	Description: "Local DNS proxy for blocking distractions.",
 }
 
 func runClean(yes bool) {
 	if !cleanup.IsPrivileged() {
-		log.Fatal("--clean requires root/admin privileges. Run with: sudo ./distractions-free --clean")
+		log.Fatal("--clean requires root/admin privileges. Run with: sudo ./sentinel --clean")
 	}
 
-	fmt.Println("Cleaning all distractions-free system changes...")
+	fmt.Println("Cleaning all sentinel system changes...")
 	fmt.Println()
 
 	var steps []cleanup.Step
@@ -150,7 +150,7 @@ func runClean(yes bool) {
 	// Step 2 — Reset DNS on all network interfaces that point at 127.0.0.1.
 	addSteps(cleanup.ResetAllDNSInterfaces())
 
-	// Step 3 — Remove distractions-free managed block from /etc/hosts.
+	// Step 3 — Remove sentinel managed block from /etc/hosts.
 	addStep(cleanup.CleanHostsFile())
 
 	// Step 4 — Remove pf anchor from /etc/pf.conf (macOS strict mode).
@@ -187,12 +187,12 @@ func runClean(yes bool) {
 		fmt.Println("Some critical steps failed. Review the output above.")
 		os.Exit(1)
 	}
-	fmt.Println("System is clean. distractions-free has been fully removed.")
+	fmt.Println("System is clean. sentinel has been fully removed.")
 }
 
 func main() {
-	// --clean safely removes all system-level changes made by distractions-free.
-	// Usage: sudo ./distractions-free --clean [--yes]
+	// --clean safely removes all system-level changes made by sentinel.
+	// Usage: sudo ./sentinel --clean [--yes]
 	if len(os.Args) > 1 && os.Args[1] == "--clean" {
 		yes := len(os.Args) > 2 && os.Args[2] == "--yes"
 		runClean(yes)
@@ -243,8 +243,8 @@ func main() {
 	}
 
 	// --strict sets enforcement_mode to "strict" in config and exits.
-	// Usage: sudo ./distractions-free --strict
-	//        sudo ./distractions-free install && sudo ./distractions-free start
+	// Usage: sudo ./sentinel --strict
+	//        sudo ./sentinel install && sudo ./sentinel start
 	if len(os.Args) > 1 && os.Args[1] == "--strict" {
 		if err := config.LoadConfig(); err != nil {
 			log.Printf("Config warning (will use defaults): %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vsangava/distractions-free
+module github.com/vsangava/sentinel
 
 go 1.26.2
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,5 +1,5 @@
 // Package cleanup implements the --clean command: a forensic recovery path that
-// removes every system-level change distractions-free may have made, regardless
+// removes every system-level change sentinel may have made, regardless
 // of whether the service was stopped gracefully.
 package cleanup
 
@@ -12,9 +12,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/enforcer"
-	"github.com/vsangava/distractions-free/internal/pf"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/enforcer"
+	"github.com/vsangava/sentinel/internal/pf"
 )
 
 const (
@@ -149,7 +149,7 @@ func resetDNSInterfacesWindows() []Step {
 	return []Step{{Label: "Reset DNS interfaces", Status: StatusDone, Critical: true}}
 }
 
-// CleanHostsFile removes the distractions-free managed block from /etc/hosts.
+// CleanHostsFile removes the sentinel managed block from /etc/hosts.
 // Safe to call even if no block is present (idempotent).
 func CleanHostsFile() Step {
 	// NewHostsEnforcer needs only the hosts path, which it derives from runtime.GOOS.
@@ -166,7 +166,7 @@ func CleanPFAnchor() Step {
 	if runtime.GOOS != "darwin" {
 		return Step{Label: "Remove pf anchor", Status: StatusSkipped, Detail: "not applicable on " + runtime.GOOS}
 	}
-	if _, err := os.Stat("/etc/pf.anchors/distractions-free"); os.IsNotExist(err) {
+	if _, err := os.Stat("/etc/pf.anchors/sentinel"); os.IsNotExist(err) {
 		return Step{Label: "Remove pf anchor", Status: StatusSkipped, Detail: "was not installed"}
 	}
 	pf.RemoveAnchor()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,11 +79,11 @@ func GetConfigFilePath() (string, error) {
 	if UseLocalConfig {
 		dir = "."
 	} else if runtime.GOOS == "darwin" {
-		dir = "/Library/Application Support/DistractionsFree"
+		dir = "/Library/Application Support/Sentinel"
 	} else if runtime.GOOS == "windows" {
-		dir = filepath.Join(os.Getenv("PROGRAMDATA"), "DistractionsFree")
+		dir = filepath.Join(os.Getenv("PROGRAMDATA"), "Sentinel")
 	} else {
-		dir = "/etc/distractionsfree"
+		dir = "/etc/sentinel"
 	}
 	if dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -232,10 +232,10 @@ func ConfigDir() string {
 	}
 	switch runtime.GOOS {
 	case "darwin":
-		return "/Library/Application Support/DistractionsFree"
+		return "/Library/Application Support/Sentinel"
 	case "windows":
-		return filepath.Join(os.Getenv("PROGRAMDATA"), "DistractionsFree")
+		return filepath.Join(os.Getenv("PROGRAMDATA"), "Sentinel")
 	default:
-		return "/etc/distractionsfree"
+		return "/etc/sentinel"
 	}
 }

--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/proxy"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/proxy"
 )
 
 // DNSEnforcer preserves the original DNS-proxy behaviour: it maintains a

--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 // Enforcer is implemented by every blocking backend.

--- a/internal/enforcer/hosts.go
+++ b/internal/enforcer/hosts.go
@@ -8,12 +8,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 const (
-	blockBegin = "# distractions-free:begin"
-	blockEnd   = "# distractions-free:end"
+	blockBegin = "# sentinel:begin"
+	blockEnd   = "# sentinel:end"
 	blockingIP = "0.0.0.0"
 )
 

--- a/internal/enforcer/hosts_test.go
+++ b/internal/enforcer/hosts_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 func testHostsConfig() config.Config {

--- a/internal/enforcer/strict.go
+++ b/internal/enforcer/strict.go
@@ -3,8 +3,8 @@ package enforcer
 import (
 	"log"
 
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/pf"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/pf"
 )
 
 // StrictEnforcer composes DNS-proxy blocking with pf firewall blocking.

--- a/internal/pf/pf.go
+++ b/internal/pf/pf.go
@@ -18,13 +18,13 @@ import (
 )
 
 const (
-	anchorName = "distractions-free"
-	anchorFile = "/etc/pf.anchors/distractions-free"
+	anchorName = "sentinel"
+	anchorFile = "/etc/pf.anchors/sentinel"
 	pfConf     = "/etc/pf.conf"
-	markerBeg  = "# distractions-free:begin"
-	markerEnd  = "# distractions-free:end"
-	anchorLine = "anchor \"distractions-free\""
-	loadLine   = "load anchor \"distractions-free\" from \"/etc/pf.anchors/distractions-free\""
+	markerBeg  = "# sentinel:begin"
+	markerEnd  = "# sentinel:end"
+	anchorLine = "anchor \"sentinel\""
+	loadLine   = "load anchor \"sentinel\" from \"/etc/pf.anchors/sentinel\""
 	dnsTimeout = 3 * time.Second
 )
 
@@ -131,7 +131,7 @@ func InstallAnchor() error {
 	}
 
 	// Write a placeholder anchor file so pfctl can validate the config.
-	if err := os.WriteFile(anchorFile, []byte("# managed by distractions-free\n"), 0644); err != nil {
+	if err := os.WriteFile(anchorFile, []byte("# managed by sentinel\n"), 0644); err != nil {
 		return fmt.Errorf("pf: write anchor file: %w", err)
 	}
 

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 var (

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/enforcer"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/enforcer"
 )
 
 var activeBlocks = make(map[string]bool)
@@ -80,7 +80,7 @@ type MacOSAppleScriptGenerator struct{}
 
 func (g *MacOSAppleScriptGenerator) GenerateWarningScript(domains []string) string {
 	msg := fmt.Sprintf("Tabs for %s will close in 3 minutes.", strings.Join(domains, ", "))
-	return fmt.Sprintf(`display notification "%s" with title "Distractions-Free" subtitle "Upcoming Block" sound name "Basso"`, msg)
+	return fmt.Sprintf(`display notification "%s" with title "Sentinel" subtitle "Upcoming Block" sound name "Basso"`, msg)
 }
 
 func (g *MacOSAppleScriptGenerator) GenerateCloseTabsScript(domains []string) string {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 // helpers ────────────────────────────────────────────────────────────────────

--- a/internal/testcli/testcli.go
+++ b/internal/testcli/testcli.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/proxy"
-	"github.com/vsangava/distractions-free/internal/scheduler"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/proxy"
+	"github.com/vsangava/sentinel/internal/scheduler"
 )
 
 const timeFormat = "2006-01-02 15:04"

--- a/internal/testcli/testcli_test.go
+++ b/internal/testcli/testcli_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 func TestQueryBlocking_ValidTimeFormat(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,11 +10,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/vsangava/distractions-free/internal/config"
-	"github.com/vsangava/distractions-free/internal/enforcer"
-	"github.com/vsangava/distractions-free/internal/pf"
-	"github.com/vsangava/distractions-free/internal/scheduler"
-	"github.com/vsangava/distractions-free/internal/testcli"
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/enforcer"
+	"github.com/vsangava/sentinel/internal/pf"
+	"github.com/vsangava/sentinel/internal/scheduler"
+	"github.com/vsangava/sentinel/internal/testcli"
 )
 
 const maxPauseMinutes = 240 // 4 hours

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vsangava/distractions-free/internal/config"
+	"github.com/vsangava/sentinel/internal/config"
 )
 
 func TestConfigHandler_ReturnsJSON(t *testing.T) {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Distractions-Free</title>
+    <title>Sentinel</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -438,7 +438,7 @@
 <body>
 <div class="container">
     <div class="app-header">
-        <h1>Distractions-Free</h1>
+        <h1>Sentinel</h1>
         <p>Schedule-based focus enforcement</p>
     </div>
 
@@ -776,7 +776,7 @@ async function fetchHostsPreview(cfg, panelId, codeId, metaId) {
         if (entries.length === 0) {
             document.getElementById(codeId).textContent = '# No domains in a block window right now.\n# /etc/hosts would have no managed entries.';
         } else {
-            var lines = ['# distractions-free:begin'].concat(entries).concat(['# distractions-free:end', '',
+            var lines = ['# sentinel:begin'].concat(entries).concat(['# sentinel:end', '',
                 '# ' + (data.blocked_domains||[]).length + ' domain(s) blocked · ' + entries.length + ' host entries']);
             document.getElementById(codeId).textContent = lines.join('\n');
         }


### PR DESCRIPTION
## Summary

- Renames the binary from `distractions-free` to `sentinel` across all build targets
- Updates the Go module path from `github.com/vsangava/distractions-free` to `github.com/vsangava/sentinel`
- Renames all system-level identifiers: service name (`Sentinel`), config paths (`/Library/Application Support/Sentinel`, `%PROGRAMDATA%\Sentinel`), pf anchor (`/etc/pf.anchors/sentinel`), and hosts file markers (`# sentinel:begin/end`)
- Updates all docs (README, DESIGN, TROUBLESHOOTING, CLAUDE.md), the web dashboard UI, GitHub Actions release workflow, and GitHub Pages download links

## Gotchas

- **GitHub repo must be renamed manually** in repo Settings → General before merging, otherwise the module path in `go.mod` (`github.com/vsangava/sentinel`) won't match the actual repo URL. After renaming, update the local remote: `git remote set-url origin https://github.com/vsangava/sentinel`
- **Existing installs are not auto-migrated.** Any machine running the old binary will have its config at `/Library/Application Support/DistractionsFree` and a pf anchor named `distractions-free`. The new binary will not find or clean those up — users upgrading from an old install should run `sudo ./distractions-free --clean` with the old binary first, then install the new one.
- **Hosts file markers change.** If an existing `/etc/hosts` contains `# distractions-free:begin/end` blocks, the new binary will not recognise or manage them. Again, `--clean` with the old binary handles this before upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)