### PR TITLE
feat: support cross-midnight time ranges in block schedules

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -169,6 +169,11 @@ func GetStatus() (blocked map[string]bool, lastEval time.Time) {
 	return cp, lastEvalTime
 }
 
+// isOvernightSlot reports whether a slot crosses midnight (End is before Start).
+func isOvernightSlot(slotStart, slotEnd time.Time) bool {
+	return slotEnd.Before(slotStart)
+}
+
 // EvaluateRulesAtTime evaluates blocking rules at a specific time and returns blocked domains.
 // Returns an empty map immediately if the config has an active pause window.
 // This is the testable function that doesn't depend on time.Now().
@@ -178,6 +183,7 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 	}
 
 	currentDay := t.Weekday().String()
+	yesterdayDay := t.AddDate(0, 0, -1).Weekday().String()
 	now := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
 
 	newBlocked := make(map[string]bool)
@@ -190,6 +196,8 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 		if len(domains) == 0 {
 			continue
 		}
+
+		// Today's slots
 		if slots, exists := rule.Schedules[currentDay]; exists {
 			for _, slot := range slots {
 				slotStart, errS := time.Parse("15:04", slot.Start)
@@ -197,7 +205,34 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 				if errS != nil || errE != nil {
 					continue
 				}
-				if (now.Equal(slotStart) || now.After(slotStart)) && now.Before(slotEnd) {
+				if isOvernightSlot(slotStart, slotEnd) {
+					// Evening portion of an overnight slot: blocks from Start until midnight
+					if now.Equal(slotStart) || now.After(slotStart) {
+						for _, d := range domains {
+							newBlocked[d] = true
+						}
+						break
+					}
+				} else {
+					if (now.Equal(slotStart) || now.After(slotStart)) && now.Before(slotEnd) {
+						for _, d := range domains {
+							newBlocked[d] = true
+						}
+						break
+					}
+				}
+			}
+		}
+
+		// Yesterday's overnight slots — morning continuation past midnight
+		if slots, exists := rule.Schedules[yesterdayDay]; exists {
+			for _, slot := range slots {
+				slotStart, errS := time.Parse("15:04", slot.Start)
+				slotEnd, errE := time.Parse("15:04", slot.End)
+				if errS != nil || errE != nil {
+					continue
+				}
+				if isOvernightSlot(slotStart, slotEnd) && now.Before(slotEnd) {
 					for _, d := range domains {
 						newBlocked[d] = true
 					}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -476,3 +476,191 @@ func TestEvaluateRulesAtTime_EdgeCaseMinuteAfterEnd(t *testing.T) {
 		t.Errorf("expected reddit.com to NOT be blocked at 15:01, got %v", result)
 	}
 }
+
+// Overnight slot tests — April 1 2024 is Monday, April 2 is Tuesday, March 31 is Sunday.
+
+func TestEvaluateRulesAtTime_OvernightSlot_EveningBlocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 1, 22, 0, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if !result["example.com"] {
+		t.Errorf("expected example.com blocked at 22:00 Monday (evening side of overnight slot)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_MorningBlocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 2, 7, 0, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if !result["example.com"] {
+		t.Errorf("expected example.com blocked at 07:00 Tuesday (morning side of Monday overnight slot)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_ExactStart_Blocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 1, 21, 30, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if !result["example.com"] {
+		t.Errorf("expected example.com blocked at exact start 21:30 Monday")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_JustBeforeEnd_Blocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 2, 7, 59, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if !result["example.com"] {
+		t.Errorf("expected example.com blocked at 07:59 Tuesday (one minute before overnight End)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_ExactEnd_NotBlocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 2, 8, 0, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["example.com"] {
+		t.Errorf("expected example.com NOT blocked at exact end 08:00 Tuesday")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_AfterEnd_NotBlocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 2, 8, 1, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["example.com"] {
+		t.Errorf("expected example.com NOT blocked at 08:01 Tuesday (after overnight End)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_BeforeStart_NotBlocked(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	testTime := time.Date(2024, time.April, 1, 21, 29, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["example.com"] {
+		t.Errorf("expected example.com NOT blocked at 21:29 Monday (one minute before overnight Start)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_SundayToMonday(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Sunday": {{Start: "22:00", End: "07:00"}},
+	})
+
+	// Monday 06:30 — morning continuation of Sunday's overnight slot
+	testTime := time.Date(2024, time.April, 1, 6, 30, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+	if !result["example.com"] {
+		t.Errorf("expected example.com blocked at 06:30 Monday (morning side of Sunday→Monday overnight slot)")
+	}
+
+	// Monday 07:00 — exact End, must not be blocked
+	testTimeEnd := time.Date(2024, time.April, 1, 7, 0, 0, 0, time.UTC)
+	resultEnd := EvaluateRulesAtTime(testTimeEnd, cfg)
+	if resultEnd["example.com"] {
+		t.Errorf("expected example.com NOT blocked at exact end 07:00 Monday (Sunday→Monday slot)")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_MorningNotBlockedWithoutYesterdaySchedule(t *testing.T) {
+	// Monday has a normal daytime slot only — no overnight slot
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "09:00", End: "17:00"}},
+	})
+
+	// Tuesday 07:00 — yesterday's slot is same-day and must not trigger the overnight path
+	testTime := time.Date(2024, time.April, 2, 7, 0, 0, 0, time.UTC)
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["example.com"] {
+		t.Errorf("expected example.com NOT blocked at 07:00 Tuesday when Monday only has a daytime slot")
+	}
+}
+
+func TestEvaluateRulesAtTime_OvernightSlot_CoexistsWithSameDaySlot(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {
+			{Start: "09:00", End: "12:00"},
+			{Start: "21:30", End: "08:00"},
+		},
+	})
+
+	cases := []struct {
+		hour, min, day int
+		blocked        bool
+		label          string
+	}{
+		{10, 0, 1, true, "10:00 Monday (daytime slot)"},
+		{13, 0, 1, false, "13:00 Monday (gap between slots)"},
+		{22, 0, 1, true, "22:00 Monday (evening overnight)"},
+		{7, 0, 2, true, "07:00 Tuesday (morning overnight)"},
+		{8, 1, 2, false, "08:01 Tuesday (after overnight end)"},
+	}
+
+	for _, c := range cases {
+		testTime := time.Date(2024, time.April, c.day, c.hour, c.min, 0, 0, time.UTC)
+		result := EvaluateRulesAtTime(testTime, cfg)
+		if c.blocked && !result["example.com"] {
+			t.Errorf("expected example.com BLOCKED at %s", c.label)
+		}
+		if !c.blocked && result["example.com"] {
+			t.Errorf("expected example.com NOT BLOCKED at %s", c.label)
+		}
+	}
+}
+
+func TestCheckWarningDomainsAtTime_OvernightSlot_WarningFires(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	// Monday 21:27 — 3 minutes before slot Start
+	testTime := time.Date(2024, time.April, 1, 21, 27, 0, 0, time.UTC)
+	warnings := CheckWarningDomainsAtTime(testTime, cfg)
+
+	if len(warnings) == 0 {
+		t.Errorf("expected warning for example.com at 21:27 Monday (3 min before overnight slot Start)")
+	}
+}
+
+func TestCheckWarningDomainsAtTime_OvernightSlot_NoWarningInMorning(t *testing.T) {
+	cfg := singleGroup("example.com", true, map[string][]config.TimeSlot{
+		"Monday": {{Start: "21:30", End: "08:00"}},
+	})
+
+	// Tuesday 07:57 — 3 min before 08:00, but 08:00 is an End time, not a Start
+	testTime := time.Date(2024, time.April, 2, 7, 57, 0, 0, time.UTC)
+	warnings := CheckWarningDomainsAtTime(testTime, cfg)
+
+	if len(warnings) != 0 {
+		t.Errorf("expected no warning at 07:57 Tuesday (morning-end of overnight slot has no warning); got %v", warnings)
+	}
+}


### PR DESCRIPTION
## What

Adds support for overnight/cross-midnight time ranges so users can write a single slot like `"21:30-08:00"` instead of splitting it into two entries (`21:30-23:59` and `00:00-08:00`).

## Why

The two-slot workaround is unintuitive and error-prone — it's easy to forget the second entry or get the boundary minute wrong. A natural overnight range (`21:30-08:00`) should just work.

## How

The change is entirely within `EvaluateRulesAtTime` in `internal/scheduler/scheduler.go`:

- Added `isOvernightSlot(slotStart, slotEnd time.Time) bool` helper — detects when `End < Start`.
- For **today's slots**: overnight slots block when `now >= Start` (evening side through midnight). Same-day slots use the unchanged logic.
- For **yesterday's overnight slots**: a new lookup block checks whether an overnight slot defined on the previous day still covers the current morning time (`now < End`). Uses `t.AddDate(0, 0, -1)` for correct weekday rollover (including Sunday→Monday).

`CheckWarningDomainsAtTime` is **not changed** — warnings fire at `slot.Start` on the scheduled day, so a Monday `21:30-08:00` slot already warns at 21:27 Monday correctly.

## Backwards compatibility

All existing same-day slots have `End > Start`, so `isOvernightSlot` returns false for them and the original code path is followed. No config schema changes.

## Gotchas

- The morning continuation is keyed to **yesterday's day name** in the schedule. A user who wants overnight blocking must define the slot on the *start* day (e.g. Monday for a Mon-night→Tue-morning block).
- End time is exclusive (consistent with same-day slots): `21:30-08:00` unblocks exactly at 08:00, not 08:01.
- No warning fires near the End time in the morning — warnings only cover block *starts*.

## Tests

12 new test cases in `scheduler_test.go` covering: evening side, morning side, exact start/end boundaries, gap before start, gap after end, Sunday→Monday weekday rollover, coexistence with a same-day slot on the same rule, and warning behaviour.

All 29 tests pass (`17` existing + `12` new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)