### PR TITLE
feat: simplify install/uninstall UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,18 @@ jobs:
           files: ${{ matrix.output_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-installer:
+    name: Attach install.sh to Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Upload install.sh to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: install.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-all test clean release check-release
+.PHONY: help build build-all test clean release check-release dev-install dev-uninstall
 
 VERSION ?= dev
 BINARY_NAME := sentinel
@@ -15,6 +15,10 @@ help:
 	@echo "  release            Pre-release check: build all + test + verify binaries"
 	@echo "  clean              Remove built binaries"
 	@echo "  check-release      Same as 'release' (alias)"
+	@echo ""
+	@echo "Developer install targets:"
+	@echo "  dev-install        Build and install the service locally (requires sudo)"
+	@echo "  dev-uninstall      Uninstall and clean up the service (requires sudo)"
 	@echo ""
 	@echo "Example release workflow:"
 	@echo "  make release"
@@ -70,6 +74,14 @@ release: test build-all verify-binaries
 
 # Alias for release
 check-release: release
+
+# Build and install service locally (developer use only)
+dev-install: build
+	sudo ./sentinel --setup
+
+# Uninstall and clean up the service (developer use only)
+dev-uninstall:
+	sudo /usr/local/bin/sentinel --clean --confirm
 
 # Verify binaries exist and have content
 verify-binaries:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,23 @@ Browser extensions are easy to bypass — one click to disable, and kids know it
 
 ## Install
 
-### 1. Download the binary
+### Option A — One-liner (recommended)
+
+```bash
+curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh | sudo bash
+```
+
+The script detects your Mac's architecture, downloads the right binary, removes the macOS quarantine flag, installs it to `/usr/local/bin/sentinel`, registers the service, and starts it.
+
+Prefer to inspect before running?
+
+```bash
+curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh -o install.sh
+less install.sh
+sudo bash install.sh
+```
+
+### Option B — Manual (two commands)
 
 **[→ Download from the latest release](https://github.com/vsangava/sentinel/releases/latest)**
 
@@ -79,21 +95,14 @@ Browser extensions are easy to bypass — one click to disable, and kids know it
 | macOS Intel | `sentinel-macos-amd64` |
 | Windows x86_64 | `sentinel-windows-amd64.exe` |
 
-On macOS, make it executable after downloading:
 ```bash
-chmod +x sentinel-macos-*
+chmod +x sentinel-macos-arm64          # or sentinel-macos-amd64 on Intel
+sudo ./sentinel-macos-arm64 --setup
 ```
 
-### 2. Install and start the service
+`--setup` copies the binary to `/usr/local/bin/sentinel`, registers the service with launchd, and starts it. You can delete the downloaded file afterwards.
 
-```bash
-sudo ./sentinel install
-sudo ./sentinel start
-```
-
-That's it for most users. The service starts at login from this point on.
-
-### 3. Verify
+### Verify
 
 Open `http://localhost:8040` — the dashboard should load. It comes pre-loaded with sample rules for `games`, `videos`, and `social` groups. Edit the config to match your needs ([Configuration](#configuration)).
 
@@ -295,8 +304,8 @@ sudo ./sentinel start      # restart to pick it up
 The all-in-one `--clean` command undoes every system change the daemon made: stops the service, removes hosts entries, removes the pf anchor, resets DNS on every interface pointing at `127.0.0.1`, flushes the resolver cache, unregisters the service, removes the config directory, and verifies port 53 is free.
 
 ```bash
-sudo ./sentinel --clean          # asks before deleting config
-sudo ./sentinel --clean --yes    # deletes config without asking
+sudo sentinel --clean             # asks before deleting config
+sudo sentinel --clean --confirm   # deletes config without asking
 ```
 
 If you'd rather drive the steps yourself:
@@ -314,13 +323,15 @@ sudo rm -rf "/Library/Application Support/Sentinel"
 ## Command-line reference
 
 ```
-sentinel <subcommand>           # service management
-sentinel [--flag]               # local / test mode
-sudo sentinel --clean [--yes]   # forensic uninstall
+sentinel <subcommand>                    # service management
+sentinel [--flag]                        # local / test mode
+sudo sentinel --setup                    # install + start in one command
+sudo sentinel --clean [--confirm|--yes]  # forensic uninstall
 ```
 
 | Command / flag | Privileges | What it does | More |
 |---|---|---|---|
+| `--setup` | sudo | Copy binary to `/usr/local/bin/sentinel`, register service, and start it (macOS: copies; Windows: install+start only) | [Install](#install) |
 | `install` | sudo | Register the system service (launchd / Windows Service) | [Install](#install) |
 | `uninstall` | sudo | Remove the service registration | [Uninstall](#uninstall--cleanup) |
 | `start` | sudo | Start the service in the background | [Install](#install) |
@@ -329,7 +340,7 @@ sudo sentinel --clean [--yes]   # forensic uninstall
 | `run` | sudo | Run as if launched by the service supervisor (foreground) | — |
 | `--no-service` | none | Run the daemon in the foreground using `./config.json` | [Test utilities](#test-utilities) |
 | `--strict` | sudo | Set `enforcement_mode` to `"strict"` in config and exit | [Switching modes](#switching-modes) |
-| `--clean [--yes]` | sudo | Undo every system change; use before deleting the binary | [Uninstall](#uninstall--cleanup) |
+| `--clean [--confirm\|--yes]` | sudo | Undo every system change; use before deleting the binary | [Uninstall](#uninstall--cleanup) |
 | `--test-query "<YYYY-MM-DD HH:MM>" <domain>` | none | Check whether a domain would be blocked at a specific time | [Test utilities](#test-utilities) |
 | `--test-web` | none | Start the dashboard standalone without installing the service | [Test utilities](#test-utilities) |
 | `--test-applescript` | none | Generate and optionally run the tab-closing AppleScript (macOS) | [Test utilities](#test-utilities) |
@@ -372,6 +383,8 @@ make build-all     # macOS arm64 + amd64 + Windows amd64
 | `make test` | `go test ./...` |
 | `make release` | `test` + `build-all` + `verify-binaries` (pre-release sanity check) |
 | `make clean` | Remove built binaries |
+| `make dev-install` | Build and install the service locally (`build` + `--setup`); requires sudo |
+| `make dev-uninstall` | Uninstall and fully clean up the service; requires sudo |
 
 ## Running tests
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -112,6 +113,50 @@ var svcConfig = &service.Config{
 	Description: "Local DNS proxy for blocking distractions.",
 }
 
+func runSetup() {
+	if !cleanup.IsPrivileged() {
+		log.Fatal("--setup requires root/admin privileges. Run with: sudo ./sentinel --setup")
+	}
+
+	prg := &program{}
+	s, err := service.New(prg, svcConfig)
+	if err != nil {
+		log.Fatalf("--setup: could not create service handle: %v", err)
+	}
+
+	if runtime.GOOS == "darwin" {
+		dest := "/usr/local/bin/sentinel"
+		if _, err := os.Stat(dest); err == nil {
+			log.Fatalf("Sentinel is already installed at %s. Run 'sudo sentinel --clean' to remove it first.", dest)
+		}
+		src, err := os.Executable()
+		if err != nil {
+			log.Fatalf("--setup: could not resolve binary path: %v", err)
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			log.Fatalf("--setup: could not read binary: %v", err)
+		}
+		if err := os.MkdirAll("/usr/local/bin", 0755); err != nil {
+			log.Fatalf("--setup: could not create /usr/local/bin: %v", err)
+		}
+		if err := os.WriteFile(dest, data, 0755); err != nil {
+			log.Fatalf("--setup: could not write binary to %s: %v", dest, err)
+		}
+		fmt.Printf("Installed binary → %s\n", dest)
+	}
+
+	if err := service.Control(s, "install"); err != nil {
+		log.Fatalf("--setup: service install failed: %v", err)
+	}
+	if err := service.Control(s, "start"); err != nil {
+		log.Fatalf("--setup: service start failed: %v", err)
+	}
+
+	fmt.Println("Sentinel installed and running.")
+	fmt.Println("Open http://localhost:8040 to configure.")
+}
+
 func runClean(yes bool) {
 	if !cleanup.IsPrivileged() {
 		log.Fatal("--clean requires root/admin privileges. Run with: sudo ./sentinel --clean")
@@ -191,10 +236,17 @@ func runClean(yes bool) {
 }
 
 func main() {
+	// --setup installs the binary to /usr/local/bin (macOS), registers the service, and starts it.
+	// Usage: sudo ./sentinel --setup
+	if len(os.Args) > 1 && os.Args[1] == "--setup" {
+		runSetup()
+		return
+	}
+
 	// --clean safely removes all system-level changes made by sentinel.
-	// Usage: sudo ./sentinel --clean [--yes]
+	// Usage: sudo ./sentinel --clean [--confirm|--yes]
 	if len(os.Args) > 1 && os.Args[1] == "--clean" {
-		yes := len(os.Args) > 2 && os.Args[2] == "--yes"
+		yes := len(os.Args) > 2 && (os.Args[2] == "--yes" || os.Args[2] == "--confirm")
 		runClean(yes)
 		return
 	}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This installer only supports macOS. Download the Windows binary from:"
+  echo "https://github.com/vsangava/sentinel/releases/latest"
+  exit 1
+fi
+
+ARCH=$(uname -m)
+case "$ARCH" in
+  arm64)  BINARY="sentinel-macos-arm64" ;;
+  x86_64) BINARY="sentinel-macos-amd64" ;;
+  *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+echo "Fetching latest release info..."
+URL=$(curl -fsSL https://api.github.com/repos/vsangava/sentinel/releases/latest \
+  | grep browser_download_url \
+  | grep "\"$BINARY\"" \
+  | cut -d'"' -f4)
+
+if [[ -z "$URL" ]]; then
+  echo "Could not find a release asset for $BINARY. Check https://github.com/vsangava/sentinel/releases/latest"
+  exit 1
+fi
+
+echo "Downloading $BINARY..."
+TMP=$(mktemp)
+curl -fsSL -o "$TMP" "$URL"
+
+# Remove Gatekeeper quarantine flag (no-op if not set).
+xattr -d com.apple.quarantine "$TMP" 2>/dev/null || true
+
+chmod +x "$TMP"
+
+echo "Installing..."
+sudo "$TMP" --setup
+
+rm -f "$TMP"


### PR DESCRIPTION
## What

Reduces the install sequence from three commands to one (or two at most), and adds a shell installer for a true one-liner experience.

**Before:**
```bash
chmod +x sentinel-macos-arm64
sudo ./sentinel install
sudo ./sentinel start
```

**After (manual):**
```bash
chmod +x sentinel-macos-arm64
sudo ./sentinel-macos-arm64 --setup
```

**After (one-liner):**
```bash
curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh | sudo bash
```

## Changes

### `--setup` flag (`cmd/app/main.go`)
New `runSetup()` function that:
1. Guards with `cleanup.IsPrivileged()` (same pattern as `--clean`)
2. On macOS: copies the binary from `os.Executable()` to `/usr/local/bin/sentinel` (exits with a clear message if already installed)
3. Calls `service.Control(s, "install")` then `service.Control(s, "start")`
4. On Windows: skips the binary copy, just does install+start

### `--confirm` alias for `--clean` (`cmd/app/main.go`)
One-line change. `--yes` continues to work as a silent alias. README now promotes `--confirm` as the canonical form since it's more self-explanatory.

### `install.sh`
Shell installer for end-users downloading from GitHub Releases. Detects architecture, fetches the latest release URL from the GitHub API, downloads to a temp file, strips the macOS Gatekeeper quarantine xattr, runs `--setup`, then removes the temp file. Fails fast on any error (`set -euo pipefail`).

### Makefile
Two new developer targets:
- `make dev-install` — `build` + `sudo ./sentinel --setup`
- `make dev-uninstall` — `sudo /usr/local/bin/sentinel --clean --confirm` (calls the installed path so it works even after `make clean`)

### Release workflow (`.github/workflows/release.yml`)
New `release-installer` job that attaches `install.sh` to the GitHub release, making the one-liner URL resolve correctly.

### README
- Rewrites Install section to lead with the one-liner, with the manual two-command path as Option B
- Updates Uninstall section to use `--confirm`
- Adds `--setup` row to command reference table
- Adds `dev-install` / `dev-uninstall` to Makefile targets table

## Gotchas

- `os.Executable()` is used (not `os.Args[0]`) for the binary source path — this handles the case where the user runs `./sentinel-macos-arm64` (the resolved path, not the argv[0] alias)
- `--setup` exits 1 if `/usr/local/bin/sentinel` already exists, rather than silently overwriting — prevents accidentally clobbering a running installation
- The quarantine xattr strip in `install.sh` is a no-op if the bit isn't set (curl downloads don't get it, but Finder downloads do) — `|| true` handles the non-zero exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)