### PR TITLE
refactor: rename CLI args for consistency and clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ go test ./internal/proxy -v
 
 The binary has four flags for development testing — none require root or service installation:
 
-- `--no-service` — runs DNS proxy, scheduler, and web UI using local `./config.json` (not system path)
+- `--local` — runs DNS proxy, scheduler, and web UI using local `./config.json` (not system path)
 - `--test-query "2024-04-01 10:30" youtube.com` — evaluates blocking at a specific time and queries real upstream DNS
 - `--test-web` — starts the web dashboard at `http://localhost:8040`
 - `--test-applescript` — generates and optionally executes tab-closing/notification AppleScript
@@ -71,7 +71,7 @@ AppleScript execution uses `AppleScriptGenerator` and `ScriptExecutor` interface
 | OS | Path |
 |---|---|
 | macOS (service) | `/Library/Application Support/Sentinel/config.json` |
-| `--no-service` | `./config.json` (working directory) |
+| `--local` | `./config.json` (working directory) |
 
 Config is re-read every scheduler tick — live edits take effect within 60 seconds, no restart needed.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,7 +14,7 @@ This document describes how the daemon is built. It complements [README.md](./RE
 8. [Configuration](#8-configuration)
 9. [Web server & HTTP API](#9-web-server--http-api)
 10. [Process lifecycle](#10-process-lifecycle)
-11. [Cleanup (`--clean`)](#11-cleanup---clean)
+11. [Cleanup (`clean`)](#11-cleanup-clean)
 12. [Testability strategy](#12-testability-strategy)
 13. [Concurrency model](#13-concurrency-model)
 14. [Security model](#14-security-model)
@@ -123,7 +123,7 @@ internal/
   scheduler/scheduler.go         # 1-min ticker, diff computation, AppleScript
   proxy/dns.go                   # DNS server, GetDNSResponse pure function
   pf/pf.go                       # pf anchor management (macOS, root)
-  cleanup/cleanup.go             # --clean implementation: per-step, idempotent
+  cleanup/cleanup.go             # clean implementation: per-step, idempotent
   cleanup/priv_unix.go           # IsPrivileged() — Geteuid()==0
   cleanup/priv_windows.go        # IsPrivileged() — token IsMember Administrators
   testcli/testcli.go             # --test-query CLI + GetQueryResult struct
@@ -201,7 +201,7 @@ The `GenerateHostsEntries(domains []string) []string` function is exported so th
 
 Maintains an in-memory `blocked map[string]bool` and pushes updates to the `proxy` package via `proxy.UpdateBlockedDomains(snapshot)` on every Activate/Deactivate. The DNS server itself is started by `cmd/app/main.go`, not by the enforcer — this separation matters because the server is the thing that blocks the goroutine forever, and `main.go` needs to control that.
 
-`Teardown` resets the system DNS to its previous state. **Caveat:** the current implementation only resets the `Wi-Fi` interface on macOS (and `Wi-Fi` on Windows). Multi-interface cleanup is delegated to the `--clean` command (see `internal/cleanup/cleanup.go`), which iterates every interface that points at `127.0.0.1`. Tracked in issue #12.
+`Teardown` resets the system DNS to its previous state. **Caveat:** the current implementation only resets the `Wi-Fi` interface on macOS (and `Wi-Fi` on Windows). Multi-interface cleanup is delegated to the `clean` command (see `internal/cleanup/cleanup.go`), which iterates every interface that points at `127.0.0.1`. Tracked in issue #12.
 
 ### `StrictEnforcer` (`strict.go`)
 
@@ -453,7 +453,7 @@ A rule used to carry a single `Domain` string, which meant blocking five gaming 
 | Linux | `/etc/distractionsfree/config.json` |
 | `UseLocalConfig=true` | `./config.json` |
 
-`UseLocalConfig` is a package-level boolean set by `--no-service`, `--test-web`, and `--test-query` so they can run against a working-directory config without touching system paths.
+`UseLocalConfig` is a package-level boolean set by `--local`, `--test-web`, and `--test-query` so they can run against a working-directory config without touching system paths.
 
 ### Bootstrap
 
@@ -481,7 +481,7 @@ The scheduler calls `LoadConfig()` once per tick. `web.ConfigHandler` also calls
 `internal/web/server.go`. Listens on `127.0.0.1:8040`. Two entry points:
 
 - `StartWebServer()` — used in service mode; same routes, called by `main.go`.
-- `StartTestWebServer()` — used in `--test-web`; loads config from working dir, otherwise identical.
+- `StartTestWebServer()` — used in `--test-web` mode; loads config from working dir, otherwise identical.
 
 ### Routes
 
@@ -536,14 +536,15 @@ The auth token is preserved across updates regardless of what the client posts �
 ### CLI dispatch order
 
 ```
-1. --clean [--yes]           → cleanup.* steps, exit
-2. --test-web                → web.StartTestWebServer (UseLocalConfig=true)
-3. --test-query <t> <d>      → testcli.QueryBlocking, exit
-4. --test-applescript        → run AppleScript demo, exit
-5. --no-service              → run program.run() in foreground (UseLocalConfig=true)
-6. --strict                  → config.SetEnforcementMode("strict") + SaveConfig, exit
-7. install/uninstall/start/stop/status/run → service.Control(s, arg)
-8. (no args)                 → s.Run() — service supervisor mode
+1. setup                         → copy binary, service install + start, exit
+2. clean [--yes]                 → cleanup.* steps, exit
+3. --test-web                    → web.StartTestWebServer (UseLocalConfig=true)
+4. --test-query <t> <d>          → testcli.QueryBlocking, exit
+5. --test-applescript            → run AppleScript demo, exit
+6. --local                       → run program.run() in foreground (UseLocalConfig=true)
+7. --set-mode <mode>             → config.SetEnforcementMode(mode) + SaveConfig, exit
+8. install/uninstall/start/stop/status/run → service.Control(s, arg)
+9. (no args)                     → s.Run() — service supervisor mode
 ```
 
 ### Service start path
@@ -592,11 +593,11 @@ func (p *program) Stop(s service.Service) error {
 - `DNSEnforcer.Teardown` → reset Wi-Fi DNS, flush DNS cache.
 - `StrictEnforcer.Teardown` → DNS teardown + `pf.RemoveAnchor`.
 
-`DNSEnforcer.Teardown` only resets the `Wi-Fi` interface today (issue #12). For multi-interface cleanup, use `--clean`.
+`DNSEnforcer.Teardown` only resets the `Wi-Fi` interface today (issue #12). For multi-interface cleanup, use `clean`.
 
 ---
 
-## 11. Cleanup (`--clean`)
+## 11. Cleanup (`clean`)
 
 `internal/cleanup/cleanup.go` plus `priv_unix.go` / `priv_windows.go`. The forensic recovery path: undo every system change sentinel might have made, even if the service crashed mid-write.
 
@@ -652,7 +653,7 @@ What's **not** tested by the suite (validated by hand on a real macOS box):
 - `osascript` invocations against running Chrome/Safari.
 - launchd / Windows Service Manager registration.
 
-The `--test-web`, `--test-query`, and `--test-applescript` CLI flags exist exactly to exercise these by-hand paths interactively.
+The `--test-web`, `--test-query`, and `--test-applescript` flags exist exactly to exercise these by-hand paths interactively.
 
 ### AppleScript test seam
 
@@ -693,7 +694,7 @@ Sentinel is **not** a security tool. It's a friction tool against your own futur
 - The Manage-tab PIN is not a password. It's a friction layer designed to make you pause and think before disabling your own focus rules. Trivially bypassed by anyone who reads the JS.
 - The service runs as root (macOS launchd daemon, Windows Service). Anything that compromises the binary inherits root. Build releases via the GitHub Actions workflow; don't run a binary you didn't compile or download from a release tag.
 - `/etc/hosts` and `/etc/pf.conf` edits use atomic temp-file + rename. A crash mid-write cannot corrupt the file. Markers (`# sentinel:begin`/`:end`) mean other tools that respect them won't trample our entries.
-- The `--clean` command is the canonical recovery path. It iterates every interface, does not assume a happy-path service stop succeeded, and exits non-zero if any critical step fails.
+- The `clean` command is the canonical recovery path. It iterates every interface, does not assume a happy-path service stop succeeded, and exits non-zero if any critical step fails.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,11 @@ check-release: release
 
 # Build and install service locally (developer use only)
 dev-install: build
-	sudo ./sentinel --setup
+	sudo ./sentinel setup
 
 # Uninstall and clean up the service (developer use only)
 dev-uninstall:
-	sudo /usr/local/bin/sentinel --clean --confirm
+	sudo /usr/local/bin/sentinel clean --yes
 
 # Verify binaries exist and have content
 verify-binaries:

--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ sudo bash install.sh
 
 ```bash
 chmod +x sentinel-macos-arm64          # or sentinel-macos-amd64 on Intel
-sudo ./sentinel-macos-arm64 --setup
+sudo ./sentinel-macos-arm64 setup
 ```
 
-`--setup` copies the binary to `/usr/local/bin/sentinel`, registers the service with launchd, and starts it. You can delete the downloaded file afterwards.
+`setup` copies the binary to `/usr/local/bin/sentinel`, registers the service with launchd, and starts it. You can delete the downloaded file afterwards.
 
 ### Verify
 
@@ -160,7 +160,7 @@ The daemon reads its configuration from a single JSON file:
 |---|---|
 | macOS (service) | `/Library/Application Support/Sentinel/config.json` |
 | Windows (service) | `%PROGRAMDATA%\Sentinel\config.json` |
-| Any (`--no-service`) | `./config.json` (working directory) |
+| Any (`--local`) | `./config.json` (working directory) |
 
 The file is created with defaults on first launch. The scheduler reloads it every minute — live edits take effect on the next tick, no restart required.
 
@@ -293,19 +293,19 @@ Like `dns`, plus a `pf` (Packet Filter) anchor on macOS that drops outbound pack
 Edit `enforcement_mode` in `config.json` and restart the service, or use the shorthand:
 
 ```bash
-sudo ./sentinel --strict   # writes "strict" to config and exits
-sudo ./sentinel start      # restart to pick it up
+sudo ./sentinel --set-mode strict   # writes "strict" to config and exits
+sudo ./sentinel start               # restart to pick it up
 ```
 
 ---
 
 ## Uninstall & cleanup
 
-The all-in-one `--clean` command undoes every system change the daemon made: stops the service, removes hosts entries, removes the pf anchor, resets DNS on every interface pointing at `127.0.0.1`, flushes the resolver cache, unregisters the service, removes the config directory, and verifies port 53 is free.
+The all-in-one `clean` command undoes every system change the daemon made: stops the service, removes hosts entries, removes the pf anchor, resets DNS on every interface pointing at `127.0.0.1`, flushes the resolver cache, unregisters the service, removes the config directory, and verifies port 53 is free.
 
 ```bash
-sudo sentinel --clean             # asks before deleting config
-sudo sentinel --clean --confirm   # deletes config without asking
+sudo sentinel clean         # asks before deleting config
+sudo sentinel clean --yes   # deletes config without asking
 ```
 
 If you'd rather drive the steps yourself:
@@ -316,31 +316,31 @@ sudo ./sentinel uninstall   # removes the service registration
 sudo rm -rf "/Library/Application Support/Sentinel"
 ```
 
-> ⚠️ In `dns`/`strict` mode, do not delete the binary while the service is running with system DNS pointed at `127.0.0.1`, or the machine will lose name resolution. `--clean` handles this correctly; manual removal does not.
+> ⚠️ In `dns`/`strict` mode, do not delete the binary while the service is running with system DNS pointed at `127.0.0.1`, or the machine will lose name resolution. `clean` handles this correctly; manual removal does not.
 
 ---
 
 ## Command-line reference
 
 ```
-sentinel <subcommand>                    # service management
-sentinel [--flag]                        # local / test mode
-sudo sentinel --setup                    # install + start in one command
-sudo sentinel --clean [--confirm|--yes]  # forensic uninstall
+sentinel <subcommand>           # service management
+sentinel [--flag]               # local / test mode
+sudo sentinel setup             # install + start in one command
+sudo sentinel clean [--yes]     # forensic uninstall
 ```
 
 | Command / flag | Privileges | What it does | More |
 |---|---|---|---|
-| `--setup` | sudo | Copy binary to `/usr/local/bin/sentinel`, register service, and start it (macOS: copies; Windows: install+start only) | [Install](#install) |
+| `setup` | sudo | Copy binary to `/usr/local/bin/sentinel`, register service, and start it (macOS: copies; Windows: install+start only) | [Install](#install) |
 | `install` | sudo | Register the system service (launchd / Windows Service) | [Install](#install) |
 | `uninstall` | sudo | Remove the service registration | [Uninstall](#uninstall--cleanup) |
 | `start` | sudo | Start the service in the background | [Install](#install) |
 | `stop` | sudo | Stop the service; clears hosts entries / restores DNS | [Uninstall](#uninstall--cleanup) |
 | `status` | sudo | Print whether the service is running | — |
 | `run` | sudo | Run as if launched by the service supervisor (foreground) | — |
-| `--no-service` | none | Run the daemon in the foreground using `./config.json` | [Test utilities](#test-utilities) |
-| `--strict` | sudo | Set `enforcement_mode` to `"strict"` in config and exit | [Switching modes](#switching-modes) |
-| `--clean [--confirm\|--yes]` | sudo | Undo every system change; use before deleting the binary | [Uninstall](#uninstall--cleanup) |
+| `clean [--yes]` | sudo | Undo every system change; use before deleting the binary | [Uninstall](#uninstall--cleanup) |
+| `--local` | none | Run the daemon in the foreground using `./config.json` | [Test utilities](#test-utilities) |
+| `--set-mode <mode>` | sudo | Set `enforcement_mode` in config and exit (modes: `hosts`, `dns`, `strict`) | [Switching modes](#switching-modes) |
 | `--test-query "<YYYY-MM-DD HH:MM>" <domain>` | none | Check whether a domain would be blocked at a specific time | [Test utilities](#test-utilities) |
 | `--test-web` | none | Start the dashboard standalone without installing the service | [Test utilities](#test-utilities) |
 | `--test-applescript` | none | Generate and optionally run the tab-closing AppleScript (macOS) | [Test utilities](#test-utilities) |
@@ -383,7 +383,7 @@ make build-all     # macOS arm64 + amd64 + Windows amd64
 | `make test` | `go test ./...` |
 | `make release` | `test` + `build-all` + `verify-binaries` (pre-release sanity check) |
 | `make clean` | Remove built binaries |
-| `make dev-install` | Build and install the service locally (`build` + `--setup`); requires sudo |
+| `make dev-install` | Build and install the service locally (`build` + `setup`); requires sudo |
 | `make dev-uninstall` | Uninstall and fully clean up the service; requires sudo |
 
 ## Running tests
@@ -410,7 +410,7 @@ What the test suite does **not** cover (validated by hand — requires root and 
 
 ## Test utilities
 
-Three flags let you exercise the daemon without installing it as a service:
+Three flags let you exercise the daemon without installing it as a service. (`--local` is a fourth — it runs the full daemon using `./config.json`.)
 
 ### `--test-query "<time>" <domain>`
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -11,7 +11,7 @@ This document is for when something is wrong. If you're just installing for the 
 5. [Reading logs](#5-reading-logs)
 6. [Manual install / start / stop / uninstall](#6-manual-install--start--stop--uninstall)
 7. [Verifying behaviour without installing the service](#7-verifying-behaviour-without-installing-the-service)
-8. [The `--clean` recovery path](#8-the---clean-recovery-path)
+8. [The `clean` recovery path](#8-the-clean-recovery-path)
 9. [Common errors](#9-common-errors)
 
 ---
@@ -23,7 +23,7 @@ If you removed or stopped the service while it was in `dns` or `strict` mode and
 **Fix it in one command (requires sudo):**
 
 ```bash
-sudo ./sentinel --clean --yes
+sudo ./sentinel clean --yes
 ```
 
 That iterates every network interface, resets the ones pointing at `127.0.0.1`, flushes the resolver cache, and verifies port 53 is free. It also handles the case where you've already deleted the binary's config dir.
@@ -63,7 +63,7 @@ ipconfig /flushdns
 | Web dashboard returns 401 unauthorized | Auth token mismatch — UI didn't bootstrap | [§9](#9-common-errors) |
 | Config edits aren't taking effect | Bad JSON, or you didn't wait 60 seconds | [§9](#9-common-errors) |
 | `/api/pause` returns 400 | `minutes` outside 1–240 range | — |
-| `--clean` reports critical failures | A step couldn't undo something — output tells you which | [§8 The --clean recovery path](#8-the---clean-recovery-path) |
+| `clean` reports critical failures | A step couldn't undo something — output tells you which | [§8 The clean recovery path](#8-the-clean-recovery-path) |
 
 ---
 
@@ -242,10 +242,10 @@ If launchd / Service Manager logs aren't useful, run the daemon in the foregroun
 sudo ./sentinel stop          # stop the service version
 sudo ./sentinel run           # run with the supervisor (foreground)
 # or, even simpler, no privileges needed for hosts-mode rule evaluation:
-./sentinel --no-service       # uses ./config.json
+./sentinel --local            # uses ./config.json
 ```
 
-`--no-service` is a fast way to validate that the rules and scheduler logic work — it skips system paths and won't install anything.
+`--local` is a fast way to validate that the rules and scheduler logic work — it skips system paths and won't install anything.
 
 ---
 
@@ -310,13 +310,13 @@ Three flags exist exactly so you can test the daemon's core logic without privil
 
 ---
 
-## 8. The `--clean` recovery path
+## 8. The `clean` recovery path
 
-`--clean` is the canonical "make it like sentinel was never installed" command. Run it any time the system is in an unknown state — it does not assume `stop` succeeded, and every step is idempotent.
+`clean` is the canonical "make it like sentinel was never installed" command. Run it any time the system is in an unknown state — it does not assume `stop` succeeded, and every step is idempotent.
 
 ```bash
-sudo ./sentinel --clean         # interactive: prompts before deleting config dir
-sudo ./sentinel --clean --yes   # non-interactive
+sudo ./sentinel clean         # interactive: prompts before deleting config dir
+sudo ./sentinel clean --yes   # non-interactive
 ```
 
 The output is one line per step:
@@ -342,7 +342,7 @@ Status meanings:
 | `[✓]` done | Step completed successfully |
 | `[—]` skipped | Step was a no-op (already in the desired state, or not applicable on this OS) |
 | `[!]` warn | Non-critical failure; cleanup continues |
-| `[✗]` error | Critical failure; if any are present `--clean` exits non-zero |
+| `[✗]` error | Critical failure; if any are present `clean` exits non-zero |
 
 If `Port 53 is free` reports a warning, something unrelated is holding the port:
 
@@ -450,7 +450,7 @@ The strict enforcer degrades to DNS-only when pf setup fails. Common causes:
 To start fresh:
 
 ```bash
-sudo ./sentinel --clean --yes   # removes our anchor + pf.conf injection
+sudo ./sentinel clean --yes   # removes our anchor + pf.conf injection
 # inspect /etc/pf.conf — should be back to its original state
 sudo ./sentinel install
 sudo ./sentinel start
@@ -461,6 +461,6 @@ sudo ./sentinel start
 
 See [§4 macOS AppleScript path](#macos-applescript-path). The most common cause is denied automation permissions for Chrome/Safari — fix in System Settings → Privacy & Security → Automation.
 
-### `--clean` says "could not create service handle"
+### `clean` says "could not create service handle"
 
 Usually means the binary you're running was built for a different OS. Check `file ./sentinel` and rebuild for the current platform with `make build`.

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -115,42 +115,42 @@ var svcConfig = &service.Config{
 
 func runSetup() {
 	if !cleanup.IsPrivileged() {
-		log.Fatal("--setup requires root/admin privileges. Run with: sudo ./sentinel --setup")
+		log.Fatal("setup requires root/admin privileges. Run with: sudo ./sentinel setup")
 	}
 
 	prg := &program{}
 	s, err := service.New(prg, svcConfig)
 	if err != nil {
-		log.Fatalf("--setup: could not create service handle: %v", err)
+		log.Fatalf("setup: could not create service handle: %v", err)
 	}
 
 	if runtime.GOOS == "darwin" {
 		dest := "/usr/local/bin/sentinel"
 		if _, err := os.Stat(dest); err == nil {
-			log.Fatalf("Sentinel is already installed at %s. Run 'sudo sentinel --clean' to remove it first.", dest)
+			log.Fatalf("Sentinel is already installed at %s. Run 'sudo sentinel clean' to remove it first.", dest)
 		}
 		src, err := os.Executable()
 		if err != nil {
-			log.Fatalf("--setup: could not resolve binary path: %v", err)
+			log.Fatalf("setup: could not resolve binary path: %v", err)
 		}
 		data, err := os.ReadFile(src)
 		if err != nil {
-			log.Fatalf("--setup: could not read binary: %v", err)
+			log.Fatalf("setup: could not read binary: %v", err)
 		}
 		if err := os.MkdirAll("/usr/local/bin", 0755); err != nil {
-			log.Fatalf("--setup: could not create /usr/local/bin: %v", err)
+			log.Fatalf("setup: could not create /usr/local/bin: %v", err)
 		}
 		if err := os.WriteFile(dest, data, 0755); err != nil {
-			log.Fatalf("--setup: could not write binary to %s: %v", dest, err)
+			log.Fatalf("setup: could not write binary to %s: %v", dest, err)
 		}
 		fmt.Printf("Installed binary → %s\n", dest)
 	}
 
 	if err := service.Control(s, "install"); err != nil {
-		log.Fatalf("--setup: service install failed: %v", err)
+		log.Fatalf("setup: service install failed: %v", err)
 	}
 	if err := service.Control(s, "start"); err != nil {
-		log.Fatalf("--setup: service start failed: %v", err)
+		log.Fatalf("setup: service start failed: %v", err)
 	}
 
 	fmt.Println("Sentinel installed and running.")
@@ -159,7 +159,7 @@ func runSetup() {
 
 func runClean(yes bool) {
 	if !cleanup.IsPrivileged() {
-		log.Fatal("--clean requires root/admin privileges. Run with: sudo ./sentinel --clean")
+		log.Fatal("clean requires root/admin privileges. Run with: sudo ./sentinel clean")
 	}
 
 	fmt.Println("Cleaning all sentinel system changes...")
@@ -236,17 +236,17 @@ func runClean(yes bool) {
 }
 
 func main() {
-	// --setup installs the binary to /usr/local/bin (macOS), registers the service, and starts it.
-	// Usage: sudo ./sentinel --setup
-	if len(os.Args) > 1 && os.Args[1] == "--setup" {
+	// setup installs the binary to /usr/local/bin (macOS), registers the service, and starts it.
+	// Usage: sudo ./sentinel setup
+	if len(os.Args) > 1 && os.Args[1] == "setup" {
 		runSetup()
 		return
 	}
 
-	// --clean safely removes all system-level changes made by sentinel.
-	// Usage: sudo ./sentinel --clean [--confirm|--yes]
-	if len(os.Args) > 1 && os.Args[1] == "--clean" {
-		yes := len(os.Args) > 2 && (os.Args[2] == "--yes" || os.Args[2] == "--confirm")
+	// clean safely removes all system-level changes made by sentinel.
+	// Usage: sudo ./sentinel clean [--yes]
+	if len(os.Args) > 1 && os.Args[1] == "clean" {
+		yes := len(os.Args) > 2 && os.Args[2] == "--yes"
 		runClean(yes)
 		return
 	}
@@ -287,25 +287,29 @@ func main() {
 	}
 
 	// Run as regular program without service
-	if len(os.Args) > 1 && os.Args[1] == "--no-service" {
+	if len(os.Args) > 1 && os.Args[1] == "--local" {
 		config.UseLocalConfig = true
 		prg := &program{}
 		prg.run()
 		return
 	}
 
-	// --strict sets enforcement_mode to "strict" in config and exits.
-	// Usage: sudo ./sentinel --strict
+	// --set-mode sets enforcement_mode in config and exits.
+	// Usage: sudo ./sentinel --set-mode strict
 	//        sudo ./sentinel install && sudo ./sentinel start
-	if len(os.Args) > 1 && os.Args[1] == "--strict" {
+	if len(os.Args) > 1 && os.Args[1] == "--set-mode" {
+		if len(os.Args) < 3 {
+			log.Fatalf("Usage: %s --set-mode <mode>\nValid modes: hosts, dns, strict\n", os.Args[0])
+		}
+		mode := os.Args[2]
 		if err := config.LoadConfig(); err != nil {
 			log.Printf("Config warning (will use defaults): %v", err)
 		}
-		config.SetEnforcementMode("strict")
+		config.SetEnforcementMode(mode)
 		if err := config.SaveConfig(); err != nil {
 			log.Fatalf("Failed to save config: %v", err)
 		}
-		log.Println("Enforcement mode set to 'strict'. Restart the service to apply.")
+		log.Printf("Enforcement mode set to '%s'. Restart the service to apply.", mode)
 		return
 	}
 


### PR DESCRIPTION
## What

Renames several CLI arguments to improve consistency and clarity.

| Old | New | Reason |
|---|---|---|
| `--setup` | `setup` | It's a lifecycle subcommand, not a flag — consistent with `install`, `start`, `stop`, `uninstall` |
| `--clean` | `clean` | Same as above |
| `--clean --confirm` | `clean --yes` | Drop the redundant alias; `--yes` is the universal convention (apt, brew, npm) |
| `--no-service` | `--local` | Positive name — describes what it does (use local config, run in foreground) rather than what it skips |
| `--strict` | `--set-mode <mode>` | Makes write-and-exit semantics explicit; now accepts any mode value (`hosts`, `dns`, `strict`), not just `strict` |

The `--test-*` flags are unchanged — they're consistently named and genuinely optional flags rather than subcommands.

## Why

The previous interface mixed two paradigms without clear rules: bare words (`install`, `start`, `stop`) for service lifecycle, and `--flags` for everything else, including lifecycle-like operations (`--setup`, `--clean`). This made it non-obvious whether `--install` or `--start` would work. The new split is:
- **Subcommands** (no `--`): things that perform a single lifecycle action — `setup`, `clean`, `install`, `uninstall`, `start`, `stop`, `status`, `run`
- **Flags** (with `--`): things that are genuinely optional modifiers or dev-mode triggers — `--local`, `--set-mode`, `--test-*`

## Gotchas

- **Breaking change**: any script or alias using `--setup`, `--clean`, `--confirm`, `--no-service`, or `--strict` will need updating. The Makefile's `dev-install` and `dev-uninstall` targets are updated in this PR.
- `--set-mode` no longer hard-codes `strict` — it now passes the value directly to `SetEnforcementMode`, so invalid mode strings are accepted at the CLI and only caught at runtime by the enforcer. Validation could be added later if needed.

## Files changed

- `cmd/app/main.go` — all `os.Args` comparisons and error strings
- `Makefile` — `dev-install` and `dev-uninstall` targets
- `CLAUDE.md`, `README.md`, `DESIGN.md`, `TROUBLESHOOTING.md` — all documentation references

🤖 Generated with [Claude Code](https://claude.com/claude-code)