### PR TITLE
feat: add macOS Intel binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,11 @@ jobs:
             goos: darwin
             goarch: arm64
             output_name: sentinel-macos-arm64
-          # Windows build
+          # CGO_ENABLED=0 means pure Go — cross-compile Intel from Ubuntu, no macOS runner needed
+          - os: ubuntu-latest
+            goos: darwin
+            goarch: amd64
+            output_name: sentinel-macos-amd64
           - os: windows-latest
             goos: windows
             goarch: amd64

--- a/docs/index.html
+++ b/docs/index.html
@@ -609,7 +609,7 @@
           </span>
         </a>
         <div class="flex items-center gap-5 text-sm text-slate-500">
-          <a href="https://github.com/vsangava/sentinel/releases/latest" target="_blank" rel="noopener"
+          <a href="https://github.com/vsangava/sentinel/releases/latest/download/sentinel-macos-amd64"
              class="flex items-center gap-1.5 hover:text-slate-300 transition-colors">
             <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
             macOS Intel
@@ -670,8 +670,7 @@
               </a>
             </li>
             <li>
-              <a href="https://github.com/vsangava/sentinel/releases/latest"
-                 target="_blank" rel="noopener"
+              <a href="https://github.com/vsangava/sentinel/releases/latest/download/sentinel-macos-amd64"
                  class="text-slate-500 hover:text-slate-300 text-sm transition-colors flex items-center gap-2">
                 <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
                 macOS Intel


### PR DESCRIPTION
## What

Adds `sentinel-macos-amd64` to the GitHub Actions release workflow so Intel Mac users get a direct binary download.

## Why this works without a macOS Intel runner

`CGO_ENABLED: 0` is already set, meaning the build is pure Go with no C toolchain dependency. Go's cross-compilation handles `GOOS=darwin GOARCH=amd64` from any platform. The new matrix entry uses `ubuntu-latest` — faster, cheaper, and no macOS runner minutes consumed.

```yaml
- os: ubuntu-latest
  goos: darwin
  goarch: amd64
  output_name: sentinel-macos-amd64
```

## Also

Updates the two macOS Intel download links in the landing page from `/releases/latest` (the release page, used as a fallback when no binary existed) to the direct file download URL `sentinel-macos-amd64`.