### PR TITLE
fix: reset DNS on all network interfaces during teardown

### DIFF
--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -1,9 +1,11 @@
 package enforcer
 
 import (
+	"bufio"
 	"log"
 	"os/exec"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/vsangava/sentinel/internal/config"
@@ -32,13 +34,29 @@ func (e *DNSEnforcer) Teardown() error {
 	if err := e.DeactivateAll(); err != nil {
 		log.Printf("dns teardown: %v", err)
 	}
-	// Restore system DNS — currently resets Wi-Fi only.
-	// Full multi-interface cleanup is tracked in issue #12.
-	if runtime.GOOS == "darwin" {
-		exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "Empty").Run()
+	// Restore system DNS on every interface that points at 127.0.0.1.
+	switch runtime.GOOS {
+	case "darwin":
+		out, err := exec.Command("networksetup", "-listallnetworkservices").Output()
+		if err == nil {
+			sc := bufio.NewScanner(strings.NewReader(string(out)))
+			for sc.Scan() {
+				line := sc.Text()
+				if strings.HasPrefix(line, "An asterisk") || strings.TrimSpace(line) == "" {
+					continue
+				}
+				name := strings.TrimSpace(strings.TrimPrefix(line, "*"))
+				dnsOut, _ := exec.Command("networksetup", "-getdnsservers", name).Output()
+				if strings.Contains(string(dnsOut), "127.0.0.1") {
+					exec.Command("networksetup", "-setdnsservers", name, "Empty").Run()
+				}
+			}
+		} else {
+			exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "Empty").Run()
+		}
 		exec.Command("dscacheutil", "-flushcache").Run()
 		exec.Command("killall", "-HUP", "mDNSResponder").Run()
-	} else if runtime.GOOS == "windows" {
+	case "windows":
 		exec.Command("powershell", "-Command",
 			"Set-DnsClientServerAddress -InterfaceAlias 'Wi-Fi' -ResetServerAddresses").Run()
 	}


### PR DESCRIPTION
## What

Replaces the hard-coded `networksetup -setdnsservers Wi-Fi Empty` in `DNSEnforcer.Teardown()` with a full enumeration of all network services.

## Why

When the daemon stops, it must restore system DNS on every interface it previously reconfigured. The old code only reset the `Wi-Fi` interface. On machines using Ethernet, a VPN tunnel (`utun0`, `utun1`, …), or USB tethering, DNS remained pointed at `127.0.0.1:53` after the daemon exited — causing a total loss of name resolution with no obvious cause.

## How

1. Run `networksetup -listallnetworkservices` to enumerate every network service.
2. For each service, check its current DNS servers with `networksetup -getdnsservers`.
3. Reset only the interfaces that are pointing at `127.0.0.1` — leaving any interfaces with user-configured DNS untouched.
4. Fall back to the previous Wi-Fi-only reset if the enumeration command itself fails.

The macOS DNS cache flush (`dscacheutil`, `mDNSResponder`) runs unconditionally after the resets, as before.

## Gotchas

- **Circular import constraint**: `cleanup.ResetAllDNSInterfaces()` already implements this logic correctly, but `cleanup` imports `enforcer`, making a reverse call impossible. The enumeration logic is intentionally inlined here rather than extracted into a shared package — the code is short enough that a new package would add more indirection than value.
- **Windows unchanged**: Windows teardown still resets the hard-coded `Wi-Fi` alias. Multi-interface Windows support is tracked in issue #52 and will be fixed there.
- **Scope**: only `DNSEnforcer` is modified. `StrictEnforcer.Teardown()` delegates to `dns.Teardown()`, so it inherits this fix automatically.

Closes #41