### PR TITLE
fix: block AAAA (IPv6) records for blocked domains

### DIFF
--- a/internal/enforcer/hosts.go
+++ b/internal/enforcer/hosts.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	blockBegin = "# sentinel:begin"
-	blockEnd   = "# sentinel:end"
-	blockingIP = "0.0.0.0"
+	blockBegin  = "# sentinel:begin"
+	blockEnd    = "# sentinel:end"
+	blockingIP  = "0.0.0.0"
+	blockingIP6 = "::1"
 )
 
 // subdomainPrefixes are prepended to each blocked domain because /etc/hosts
@@ -31,6 +32,7 @@ func GenerateHostsEntries(domains []string) []string {
 	for _, domain := range domains {
 		for _, prefix := range subdomainPrefixes {
 			entries = append(entries, blockingIP+" "+prefix+domain)
+			entries = append(entries, blockingIP6+" "+prefix+domain)
 		}
 	}
 	return entries
@@ -74,9 +76,11 @@ func (e *HostsEnforcer) Activate(domains []string) error {
 	var newEntries []string
 	for _, domain := range domains {
 		for _, prefix := range subdomainPrefixes {
-			entry := blockingIP + " " + prefix + domain
-			if !existing[entry] {
-				newEntries = append(newEntries, entry)
+			for _, ip := range []string{blockingIP, blockingIP6} {
+				entry := ip + " " + prefix + domain
+				if !existing[entry] {
+					newEntries = append(newEntries, entry)
+				}
 			}
 		}
 	}
@@ -105,7 +109,9 @@ func (e *HostsEnforcer) Deactivate(domains []string) error {
 	toRemove := make(map[string]bool)
 	for _, domain := range domains {
 		for _, prefix := range subdomainPrefixes {
-			toRemove[blockingIP+" "+prefix+domain] = true
+			for _, ip := range []string{blockingIP, blockingIP6} {
+				toRemove[ip+" "+prefix+domain] = true
+			}
 		}
 	}
 

--- a/internal/enforcer/hosts_test.go
+++ b/internal/enforcer/hosts_test.go
@@ -43,6 +43,9 @@ func TestHostsEnforcer_ActivateAddsEntries(t *testing.T) {
 		"0.0.0.0 youtube.com",
 		"0.0.0.0 www.youtube.com",
 		"0.0.0.0 m.youtube.com",
+		"::1 youtube.com",
+		"::1 www.youtube.com",
+		"::1 m.youtube.com",
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("expected %q in hosts file\n%s", want, content)
@@ -60,7 +63,10 @@ func TestHostsEnforcer_ActivateIsIdempotent(t *testing.T) {
 
 	content := readFile(t, e.hostsPath)
 	if got := strings.Count(content, "0.0.0.0 youtube.com"); got != 1 {
-		t.Errorf("expected exactly 1 entry for youtube.com, got %d\n%s", got, content)
+		t.Errorf("expected exactly 1 IPv4 entry for youtube.com, got %d\n%s", got, content)
+	}
+	if got := strings.Count(content, "::1 youtube.com"); got != 1 {
+		t.Errorf("expected exactly 1 IPv6 entry for youtube.com, got %d\n%s", got, content)
 	}
 }
 
@@ -74,7 +80,10 @@ func TestHostsEnforcer_DeactivateRemovesEntries(t *testing.T) {
 
 	content := readFile(t, e.hostsPath)
 	if strings.Contains(content, "0.0.0.0 youtube.com") {
-		t.Errorf("youtube.com should be removed after Deactivate\n%s", content)
+		t.Errorf("IPv4 entry for youtube.com should be removed after Deactivate\n%s", content)
+	}
+	if strings.Contains(content, "::1 youtube.com") {
+		t.Errorf("IPv6 entry for youtube.com should be removed after Deactivate\n%s", content)
 	}
 	if !strings.Contains(content, "127.0.0.1 localhost") {
 		t.Error("original entries must be preserved")
@@ -106,7 +115,10 @@ func TestHostsEnforcer_DeactivateAllClearsBlock(t *testing.T) {
 
 	content := readFile(t, e.hostsPath)
 	if strings.Contains(content, "0.0.0.0") {
-		t.Errorf("all block entries should be removed\n%s", content)
+		t.Errorf("all IPv4 block entries should be removed\n%s", content)
+	}
+	if strings.Contains(content, "::1 youtube.com") || strings.Contains(content, "::1 facebook.com") {
+		t.Errorf("all IPv6 block entries should be removed\n%s", content)
 	}
 	if strings.Contains(content, blockBegin) || strings.Contains(content, blockEnd) {
 		t.Errorf("block markers should be removed\n%s", content)
@@ -143,5 +155,26 @@ func TestHostsEnforcer_DeactivateAllOnEmptyFile(t *testing.T) {
 	// DeactivateAll on a file with no managed block should be a no-op.
 	if err := e.DeactivateAll(); err != nil {
 		t.Fatalf("DeactivateAll on clean file: %v", err)
+	}
+}
+
+func TestGenerateHostsEntries_IncludesIPv6(t *testing.T) {
+	entries := GenerateHostsEntries([]string{"example.com"})
+
+	wantIPv4 := "0.0.0.0 example.com"
+	wantIPv6 := "::1 example.com"
+	wantIPv4www := "0.0.0.0 www.example.com"
+	wantIPv6www := "::1 www.example.com"
+
+	got := strings.Join(entries, "\n")
+	for _, want := range []string{wantIPv4, wantIPv6, wantIPv4www, wantIPv6www} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in generated entries:\n%s", want, got)
+		}
+	}
+
+	// Each subdomain variant should produce exactly 2 entries (IPv4 + IPv6).
+	if len(entries) != len(subdomainPrefixes)*2 {
+		t.Errorf("expected %d entries (2 per prefix), got %d", len(subdomainPrefixes)*2, len(entries))
 	}
 }

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -48,10 +48,17 @@ func GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, primaryDNS, 
 	q := r.Question[0]
 	domain := strings.TrimSuffix(q.Name, ".")
 
-	if IsDomainBlocked(domain, blockedDomainsList) && q.Qtype == dns.TypeA {
-		rr, _ := dns.NewRR(q.Name + " 60 IN A 0.0.0.0")
-		m.Answer = append(m.Answer, rr)
-		return m, nil
+	if IsDomainBlocked(domain, blockedDomainsList) {
+		switch q.Qtype {
+		case dns.TypeA:
+			rr, _ := dns.NewRR(q.Name + " 60 IN A 0.0.0.0")
+			m.Answer = append(m.Answer, rr)
+			return m, nil
+		case dns.TypeAAAA:
+			rr, _ := dns.NewRR(q.Name + " 60 IN AAAA ::")
+			m.Answer = append(m.Answer, rr)
+			return m, nil
+		}
 	}
 
 	// Forward to upstream DNS

--- a/internal/proxy/dns_test.go
+++ b/internal/proxy/dns_test.go
@@ -88,28 +88,52 @@ func TestGetDNSResponse_EmptyQuestion(t *testing.T) {
 	}
 }
 
-func TestGetDNSResponse_NonATypeQueryBlocked(t *testing.T) {
+func TestGetDNSResponse_BlockedDomainAAAAReturnsZeroIPv6(t *testing.T) {
 	blockedDomains := map[string]bool{
 		"reddit.com": true,
 	}
 
-	// Query for AAAA record (IPv6) of blocked domain
 	msg := new(dns.Msg)
 	msg.SetQuestion("reddit.com.", dns.TypeAAAA)
 
 	response, err := GetDNSResponse(msg, blockedDomains, "8.8.8.8:53", "1.1.1.1:53")
-
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Non-A queries for blocked domains should still forward (not block)
-	// This tests that we only block A records for blocked domains
-	if len(response.Answer) > 0 {
-		if a, ok := response.Answer[0].(*dns.AAAA); ok {
-			// Got a valid AAAA response, which is correct behavior
-			if a.AAAA.String() == "::" {
-				t.Errorf("unexpected :: response for AAAA query")
+	if len(response.Answer) == 0 {
+		t.Fatal("expected answer record for blocked AAAA query")
+	}
+
+	aaaa, ok := response.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatalf("expected AAAA record, got %T", response.Answer[0])
+	}
+	if aaaa.AAAA.String() != "::" {
+		t.Errorf("expected :: for blocked AAAA query, got %s", aaaa.AAAA.String())
+	}
+}
+
+func TestGetDNSResponse_AllowedDomainAAAAForwarded(t *testing.T) {
+	blockedDomains := map[string]bool{
+		"reddit.com": true,
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("google.com.", dns.TypeAAAA)
+
+	response, err := GetDNSResponse(msg, blockedDomains, "8.8.8.8:53", "1.1.1.1:53")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response == nil {
+		t.Fatal("expected response, got nil")
+	}
+	// Must not return the blocking sentinel address.
+	for _, rr := range response.Answer {
+		if aaaa, ok := rr.(*dns.AAAA); ok {
+			if aaaa.AAAA.String() == "::" {
+				t.Errorf("allowed domain got blocking response :: for AAAA")
 			}
 		}
 	}


### PR DESCRIPTION
## What

Extends DNS proxy blocking and hosts-file blocking to cover AAAA (IPv6) queries, not just A (IPv4).

## Why

Modern browsers and macOS issue AAAA lookups before A lookups when IPv6 connectivity is available. The previous implementation only intercepted `TypeA` queries, so a browser that received a real AAAA answer could connect directly over IPv6 — bypassing the block completely.

## How

**DNS proxy (`internal/proxy/dns.go`)**
- Replaced the single `TypeA`-only condition with a `switch` on `q.Qtype`.
- `TypeA` → returns `0.0.0.0` (unchanged).
- `TypeAAAA` → returns `::` (the IPv6 unspecified address — same semantic as `0.0.0.0` for IPv4).
- All other query types (MX, CNAME, TXT, …) are still forwarded upstream unchanged.

**Hosts enforcer (`internal/enforcer/hosts.go`)**
- Added `blockingIP6 = "::1"` constant.
- `GenerateHostsEntries`, `Activate`, and `Deactivate` now emit/remove an `::1 <prefix><domain>` entry alongside every `0.0.0.0 <prefix><domain>` entry.
- `DeactivateAll` removes the whole managed block section, so IPv6 entries are cleaned up without any extra logic.

**Tests**
- `proxy/dns_test.go`: renamed and rewrote `TestGetDNSResponse_NonATypeQueryBlocked` (which documented the old wrong behaviour) to `TestGetDNSResponse_BlockedDomainAAAAReturnsZeroIPv6`; added `TestGetDNSResponse_AllowedDomainAAAAForwarded` to verify non-blocked AAAA queries still resolve normally.
- `enforcer/hosts_test.go`: updated `ActivateAddsEntries`, `ActivateIsIdempotent`, `DeactivateRemovesEntries`, and `DeactivateAllClearsBlock` to assert on both IPv4 and IPv6 entries; added `TestGenerateHostsEntries_IncludesIPv6` for the pure preview function.

## Gotchas

- The hosts enforcer uses `::1` (loopback) while the DNS proxy uses `::` (unspecified). This matches the convention used by popular blocklists: hosts files traditionally map to loopback, DNS block responses return the unspecified address.
- Existing hosts files that only have `0.0.0.0` entries (written by an older version) will have IPv6 entries added on the next `Activate` call — idempotency is preserved since `parseExistingBlocks` skips entries already present.

Closes #42