### PR TITLE
fix: expand browser tab closing to Arc and Brave

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -132,6 +132,46 @@ func (g *MacOSAppleScriptGenerator) GenerateCloseTabsScript(domains []string) st
 				end repeat
 			end tell
 		end if
+
+		if application "Arc" is running then
+			tell application "Arc"
+				set tabsToClose to {}
+				repeat with w in windows
+					repeat with t in tabs of w
+						set tabURL to URL of t
+						repeat with d in domainsToBlock
+							if tabURL contains d then
+								set end of tabsToClose to t
+								exit repeat
+							end if
+						end repeat
+					end repeat
+				end repeat
+				repeat with t in tabsToClose
+					close t
+				end repeat
+			end tell
+		end if
+
+		if application "Brave Browser" is running then
+			tell application "Brave Browser"
+				set tabsToClose to {}
+				repeat with w in windows
+					repeat with t in tabs of w
+						set tabURL to URL of t
+						repeat with d in domainsToBlock
+							if tabURL contains d then
+								set end of tabsToClose to t
+								exit repeat
+							end if
+						end repeat
+					end repeat
+				end repeat
+				repeat with t in tabsToClose
+					close t
+				end repeat
+			end tell
+		end if
 	`, domainListStr)
 }
 
@@ -453,6 +493,40 @@ func getOpenBrowserDomains(domains []string) []string {
 
 		if application "Safari" is running then
 			tell application "Safari"
+				repeat with w in windows
+					repeat with t in tabs of w
+						set tabURL to URL of t
+						repeat with d in domainsToCheck
+							if tabURL contains d then
+								if matchedDomains does not contain d then
+									set end of matchedDomains to d
+								end if
+							end if
+						end repeat
+					end repeat
+				end repeat
+			end tell
+		end if
+
+		if application "Arc" is running then
+			tell application "Arc"
+				repeat with w in windows
+					repeat with t in tabs of w
+						set tabURL to URL of t
+						repeat with d in domainsToCheck
+							if tabURL contains d then
+								if matchedDomains does not contain d then
+									set end of matchedDomains to d
+								end if
+							end if
+						end repeat
+					end repeat
+				end repeat
+			end tell
+		end if
+
+		if application "Brave Browser" is running then
+			tell application "Brave Browser"
 				repeat with w in windows
 					repeat with t in tabs of w
 						set tabURL to URL of t

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -662,5 +663,16 @@ func TestCheckWarningDomainsAtTime_OvernightSlot_NoWarningInMorning(t *testing.T
 
 	if len(warnings) != 0 {
 		t.Errorf("expected no warning at 07:57 Tuesday (morning-end of overnight slot has no warning); got %v", warnings)
+	}
+}
+
+func TestGenerateCloseTabsScript_IncludesArcAndBrave(t *testing.T) {
+	g := &MacOSAppleScriptGenerator{}
+	script := g.GenerateCloseTabsScript([]string{"youtube.com"})
+
+	for _, app := range []string{"Google Chrome", "Safari", "Arc", "Brave Browser"} {
+		if !strings.Contains(script, app) {
+			t.Errorf("GenerateCloseTabsScript: expected block for %q but not found in script", app)
+		}
 	}
 }


### PR DESCRIPTION
## What

Adds Arc and Brave Browser to the AppleScript-based tab-closing and open-domain-detection logic.

## Why

The existing implementation covered only Chrome and Safari. Arc and Brave have significant market share among developer and power users — exactly the audience likely to run Sentinel. Tabs in these browsers were left open when a block started, which defeats the automatic tab-closing feature.

## How

Both Arc and Brave expose the same AppleScript dictionary as Google Chrome (they share the Chromium `com.apple.application-scripting` suite), so the fix is purely additive — no new logic, just two more `tell application` blocks with identical structure:

- **`GenerateCloseTabsScript()`** — two new blocks appended after Safari, one for `"Arc"` and one for `"Brave Browser"`.
- **`getOpenBrowserDomains()`** — two matching blocks so the pre-close warning also reflects tabs open in Arc/Brave.

**Tests**: added `TestGenerateCloseTabsScript_IncludesArcAndBrave` which asserts all four browser names appear in the generated script.

## Gotchas

- The application name for Brave is `"Brave Browser"` (with a space), not `"Brave"` — this matches what macOS reports in `ps` and what the AppleScript runtime expects.
- Firefox uses a completely different AppleScript model and is intentionally left for a separate issue.

Closes #43