### PR TITLE
fix: complete and promote pf strict enforcement mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,31 +262,33 @@ The pause window is written to `config.json` as `pause.until` and cleared automa
 
 ## Enforcement modes
 
-The default is `"hosts"`. Most users should leave it that way.
+Three modes are available. **`strict` is recommended on macOS** — it combines DNS-proxy blocking with kernel-level firewall rules so no app can route around it.
 
-### `hosts` (default)
+### `strict` ⭐ recommended on macOS
 
-Edits `/etc/hosts` (macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows). Blocked entries live between marker lines (`# sentinel:begin` / `# sentinel:end`) and are atomically rewritten — a crash mid-write cannot corrupt the file. Other entries are never touched.
+Runs a local DNS proxy on `127.0.0.1:53` **and** installs a `pf` (Packet Filter) anchor that drops outbound packets to the resolved IPs at the kernel level. On every scheduler tick the enforcer re-resolves all blocked domains and rewrites the firewall table from scratch, so CDN IP rotation doesn't create gaps in coverage.
 
-**Best for:** most users. No port binding, no DNS reconfiguration, works in every browser and app.
+**Best for:** macOS users who want the strongest blocking. Works against apps that hard-code their own DNS resolver (some VPNs, browsers in DoH mode) because the firewall blocks the IPs directly, not just the names.
 
-**Limitation:** no wildcards — only a static prefix list (`www.`, `m.`, `mobile.`, `app.`), so very deep CDN subdomains aren't covered.
+**macOS only.** If pf setup fails (e.g. missing root), the enforcer degrades to DNS-only and logs a warning.
+
+**Requires:** pointing your OS DNS at `127.0.0.1` (see [Install](#install) advanced note).
 
 ### `dns`
 
-Runs a local DNS proxy on `127.0.0.1:53`. Blocked domains return `0.0.0.0`; everything else forwards to `primary_dns` (failover to `backup_dns`).
+Runs a local DNS proxy on `127.0.0.1:53`. Blocked domains return `0.0.0.0` (A) and `::` (AAAA); everything else forwards to `primary_dns` (failover to `backup_dns`).
 
-**Best for:** users who need wildcard subdomain blocking — any `*.example.com` subdomain is blocked if `example.com` is in the group.
+**Best for:** users who need wildcard subdomain blocking — any `*.example.com` subdomain is blocked if `example.com` is in the group — but don't need firewall-layer enforcement.
 
-**Requires:** pointing your OS DNS at `127.0.0.1` (see [Install](#install) advanced note). Apps that hard-code their own resolver (some VPNs, some browsers in DoH mode) bypass it.
+**Requires:** pointing your OS DNS at `127.0.0.1` (see [Install](#install) advanced note). Apps that hard-code their own resolver bypass it.
 
-### `strict`
+### `hosts` (default, cross-platform)
 
-Like `dns`, plus a `pf` (Packet Filter) anchor on macOS that drops outbound packets to the resolved IPs at the kernel level. Each tick the enforcer resolves blocked domains to A/AAAA addresses and rewrites the firewall table.
+Edits `/etc/hosts` (macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows). Blocked entries live between marker lines (`# sentinel:begin` / `# sentinel:end`) and are atomically rewritten — a crash mid-write cannot corrupt the file. Other entries are never touched.
 
-**Best for:** situations where DNS-level blocking isn't enough — e.g., apps that ignore the system resolver entirely.
+**Best for:** Windows users, or macOS users who prefer the simplest setup with no port binding or DNS reconfiguration.
 
-**macOS only.** CDN-heavy sites rotate IPs, so only the resolved subset is blocked. If pf setup fails, the enforcer degrades to DNS-only and logs a warning.
+**Limitation:** no wildcards — only a static prefix list (`www.`, `m.`, `mobile.`, `app.`), so very deep CDN subdomains aren't covered.
 
 ### Switching modes
 

--- a/internal/enforcer/strict.go
+++ b/internal/enforcer/strict.go
@@ -39,7 +39,18 @@ func (e *StrictEnforcer) Activate(domains []string) error {
 	if err := e.dns.Activate(domains); err != nil {
 		return err
 	}
-	pf.ActivateBlock(domains, e.cfg.Settings.PrimaryDNS)
+	// Re-resolve ALL currently blocked domains on every activation, not just the
+	// newly added ones. CDN-backed sites rotate IPs frequently; refreshing from
+	// scratch each tick evicts stale addresses that would otherwise linger in the
+	// pf table until the block ends.
+	e.dns.mu.Lock()
+	allDomains := make([]string, 0, len(e.dns.blocked))
+	for d := range e.dns.blocked {
+		allDomains = append(allDomains, d)
+	}
+	e.dns.mu.Unlock()
+	pf.DeactivateBlock()
+	pf.ActivateBlock(allDomains, e.cfg.Settings.PrimaryDNS)
 	return nil
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -95,7 +95,22 @@
         }
         .mode-badge.hosts  { background: #28a745; }
         .mode-badge.dns    { background: #007bff; }
-        .mode-badge.strict { background: #dc3545; }
+        .mode-badge.strict { background: #764ba2; }
+
+        /* Mode selector widget */
+        .mode-options { display: flex; flex-direction: column; gap: 10px; margin-top: 10px; }
+        .mode-option {
+            display: flex; align-items: flex-start; gap: 12px;
+            padding: 12px 14px; border: 2px solid #e9ecef; border-radius: 10px;
+            cursor: pointer; transition: border-color 0.15s, background 0.15s;
+        }
+        .mode-option:hover { border-color: #667eea; background: #f8f9ff; }
+        .mode-option.selected { border-color: #667eea; background: #f0f2ff; }
+        .mode-option input[type=radio] { margin-top: 3px; accent-color: #667eea; flex-shrink: 0; }
+        .mode-option-body { flex: 1; }
+        .mode-option-title { font-size: 14px; font-weight: 600; color: #212529; display: flex; align-items: center; gap: 6px; }
+        .mode-option-desc  { font-size: 12px; color: #6c757d; margin-top: 3px; line-height: 1.4; }
+        .mode-recommended  { font-size: 10px; font-weight: 700; color: white; background: #764ba2; padding: 2px 7px; border-radius: 10px; }
 
         .active-badge {
             display: inline-block;
@@ -573,6 +588,42 @@
         <!-- Manage content (hidden until PIN accepted) -->
         <div id="manageContent" style="display:none;">
             <div class="section">
+                <div class="section-title">Enforcement Mode</div>
+                <div class="mode-options" id="modeOptions">
+                    <label class="mode-option" id="modeOpt-strict">
+                        <input type="radio" name="enforcementMode" value="strict">
+                        <div class="mode-option-body">
+                            <div class="mode-option-title">
+                                Strict (DNS + Firewall)
+                                <span class="mode-recommended">Recommended on macOS</span>
+                            </div>
+                            <div class="mode-option-desc">DNS proxy + pf firewall anchor. Blocks at the kernel level — works even against apps that bypass the system resolver. Re-resolves IPs every minute to handle CDN rotation. macOS only.</div>
+                        </div>
+                    </label>
+                    <label class="mode-option" id="modeOpt-dns">
+                        <input type="radio" name="enforcementMode" value="dns">
+                        <div class="mode-option-body">
+                            <div class="mode-option-title">DNS Proxy</div>
+                            <div class="mode-option-desc">Local DNS proxy on 127.0.0.1:53. Wildcard subdomain blocking for any *.example.com. Apps that hard-code their own DNS resolver can bypass it.</div>
+                        </div>
+                    </label>
+                    <label class="mode-option" id="modeOpt-hosts">
+                        <input type="radio" name="enforcementMode" value="hosts">
+                        <div class="mode-option-body">
+                            <div class="mode-option-title">Standard (hosts file)</div>
+                            <div class="mode-option-desc">Edits /etc/hosts. No port binding or DNS reconfiguration required. Cross-platform. Limited to a fixed set of subdomain prefixes (www., m., mobile., app.).</div>
+                        </div>
+                    </label>
+                </div>
+                <div style="margin-top:12px;">
+                    <button onclick="saveEnforcementMode()">Apply mode</button>
+                </div>
+                <div id="modeMsg"></div>
+            </div>
+
+            <hr class="section-divider">
+
+            <div class="section">
                 <div class="section-title">Update Config</div>
                 <div class="form-group">
                     <textarea id="manageConfig"></textarea>
@@ -667,9 +718,47 @@ async function loadConfig() {
         document.getElementById('manageConfig').value = JSON.stringify(cfg, null, 2);
         validateField('testConfig',   'testConfigStatus');
         validateField('manageConfig', 'manageConfigStatus');
+        populateModeSelector(cfg);
     } catch (e) {
         liveConfig = EXAMPLE_CONFIG;
         testConfig = EXAMPLE_CONFIG;
+    }
+}
+
+function populateModeSelector(cfg) {
+    var current = (cfg && cfg.settings && cfg.settings.enforcement_mode) || 'hosts';
+    document.querySelectorAll('#modeOptions input[type=radio]').forEach(function(radio) {
+        radio.checked = (radio.value === current);
+        var opt = radio.closest('.mode-option');
+        if (opt) opt.classList.toggle('selected', radio.checked);
+    });
+    document.querySelectorAll('#modeOptions .mode-option').forEach(function(opt) {
+        opt.addEventListener('click', function() {
+            document.querySelectorAll('#modeOptions .mode-option').forEach(function(o) { o.classList.remove('selected'); });
+            opt.classList.add('selected');
+        });
+    });
+}
+
+async function saveEnforcementMode() {
+    var sel = document.querySelector('#modeOptions input[type=radio]:checked');
+    if (!sel) { showBanner('modeMsg', 'error', 'Select a mode first'); return; }
+    var newMode = sel.value;
+    var cfg = JSON.parse(JSON.stringify(liveConfig));
+    if (!cfg.settings) cfg.settings = {};
+    cfg.settings.enforcement_mode = newMode;
+    try {
+        var res = await fetch('/api/config/update', {
+            method: 'POST',
+            headers: {'X-Auth-Token': authToken, 'Content-Type': 'application/json'},
+            body: JSON.stringify(cfg)
+        });
+        var data = await res.json();
+        if (!res.ok) { showBanner('modeMsg', 'error', data.error || 'Save failed'); return; }
+        showBanner('modeMsg', 'success', 'Mode set to "' + newMode + '" — restart the service to apply');
+        await loadConfig();
+    } catch(e) {
+        showBanner('modeMsg', 'error', 'Error: ' + e.message);
     }
 }
 


### PR DESCRIPTION
## What

Three gaps in strict mode (DNS proxy + pf firewall) are closed in this PR:
1. **IP churn** — pf table now refreshes on every scheduler tick, not just on first activation.
2. **Multi-interface teardown** — inherited fix from #41 (strict delegates to DNS enforcer).
3. **Promotion** — strict mode is now surfaced as the recommended option in the README and dashboard.

## Why

**IP churn:** CDN-backed sites (YouTube, Reddit, Twitter, etc.) rotate IP addresses constantly. The old `Activate()` only called `pf.ActivateBlock(newDomains, ...)` with the newly-added domains, so the pf table accumulated stale IPs but never evicted them. Once a CDN rotated to a new IP, traffic flowed freely despite the block still being "active."

**Promotion:** Strict mode is the strongest blocking option on macOS but was buried in the README after hosts and dns, described only as "for situations where DNS-level blocking isn't enough." It should be the default recommendation so users get the most effective enforcement without having to discover it.

## How

**`internal/enforcer/strict.go` — `Activate()`**
After `e.dns.Activate(domains)` adds the new domains to the DNS-blocked set, the method now:
1. Reads the full `e.dns.blocked` map (under the existing mutex).
2. Calls `pf.DeactivateBlock()` to flush the current table.
3. Calls `pf.ActivateBlock(allDomains, ...)` with the complete set.

This guarantees that on every scheduler tick, the pf table contains only currently-valid IPs for currently-blocked domains.

**`README.md`**
- Strict mode moved to the top of the enforcement modes section with a ⭐ recommended marker.
- Description updated to clearly state it supersedes dns mode and explain the per-tick IP refresh.
- hosts mode repositioned as the cross-platform/Windows fallback.

**`internal/web/static/index.html`**
- New "Enforcement Mode" section added to the Manage tab (gated behind the existing PIN).
- Radio-button selector for hosts / dns / strict, with a "Recommended on macOS" badge on strict.
- "Apply mode" button POSTs the updated config to `/api/config/update` using the existing auth token — no new API endpoints needed.
- `loadConfig()` calls the new `populateModeSelector()` helper to keep the widget in sync with the live config.

## Gotchas

- **Restart required for mode change:** changing `enforcement_mode` via the dashboard writes to `config.json` but the running service doesn't hot-reload the enforcer type — only rules and schedules are live-reloaded. The success banner says "restart the service to apply."
- **pf requires root:** if `pf.InstallAnchor()` fails (no root, non-macOS), the enforcer already degrades to DNS-only. The promotion in the README and dashboard doesn't change that behaviour.
- **Deactivate still incremental:** only `Activate` is changed to do a full table refresh. `Deactivate` rebuilds the table from the remaining DNS set, which is equivalent.

Closes #47