### PR TITLE
fix: Windows DNS mode multi-interface teardown

### DIFF
--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -58,7 +58,7 @@ func (e *DNSEnforcer) Teardown() error {
 		exec.Command("killall", "-HUP", "mDNSResponder").Run()
 	case "windows":
 		exec.Command("powershell", "-Command",
-			"Set-DnsClientServerAddress -InterfaceAlias 'Wi-Fi' -ResetServerAddresses").Run()
+			`Get-DnsClientServerAddress | Where-Object { $_.ServerAddresses -contains "127.0.0.1" } | ForEach-Object { Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ResetServerAddresses }`).Run()
 	}
 	return nil
 }


### PR DESCRIPTION
## What

Replaces the hard-coded `Set-DnsClientServerAddress -InterfaceAlias 'Wi-Fi' -ResetServerAddresses` in `DNSEnforcer.Teardown()` with a PowerShell one-liner that enumerates all adapters and resets only those pointing at `127.0.0.1`.

## Why

The old command only worked if the active network adapter was named exactly `Wi-Fi`. On Windows machines using Ethernet (`Ethernet`, `Local Area Connection`), VPN adapters (`TAP-Windows`, `WireGuard`, etc.), USB tethering, or any NIC with a localised or custom name, teardown silently did nothing — leaving DNS permanently pointed at `127.0.0.1:53` after the daemon exited. The machine lost all name resolution with no obvious cause.

## How

```powershell
Get-DnsClientServerAddress |
  Where-Object { $_.ServerAddresses -contains "127.0.0.1" } |
  ForEach-Object { Set-DnsClientServerAddress -InterfaceIndex $_.InterfaceIndex -ResetServerAddresses }
```

This is the same PowerShell used by `cleanup.resetDNSInterfacesWindows()` (which powers `sentinel clean`). The `Where-Object` filter ensures only interfaces that Sentinel configured are touched — adapters with user-set DNS or DHCP DNS are left untouched.

## Gotchas

- **Circular import constraint** (same as #41): `cleanup.ResetAllDNSInterfaces()` already has this logic, but `cleanup` imports `enforcer`, making a reverse call impossible. The PowerShell is inlined directly — it's a single line and a new package would be pure overhead.
- **Scope**: only `DNSEnforcer.Teardown()` is changed. `StrictEnforcer.Teardown()` delegates to `dns.Teardown()`, so it inherits this fix automatically.
- **Cross-compile verified**: `make build-all` produces valid binaries for macOS arm64, macOS amd64, and Windows amd64.

Prerequisites: #41 (macOS multi-interface teardown — already merged).

Closes #52