### PR TITLE
fix: release and install process issues (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
+          go-version-file: go.mod
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
+          go-version-file: go.mod
 
       - name: Build Binary
         run: go build -o ${{ matrix.output_name }} ./cmd/app

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -5,11 +5,33 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/vsangava/sentinel/internal/config"
 )
+
+func TestMain(m *testing.M) {
+	// Use local config so tests don't attempt to create/read the system config
+	// directory (/Library/Application Support/Sentinel on macOS), which requires
+	// root and fails in CI runners.
+	config.UseLocalConfig = true
+	dir, _ := os.Getwd()
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			os.Chdir(dir) //nolint:errcheck
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	os.Exit(m.Run())
+}
 
 func TestConfigHandler_ReturnsJSON(t *testing.T) {
 	// Create a test request and response recorder
@@ -348,11 +370,11 @@ func TestConfigHandler_ValidJSONAfterMarshal(t *testing.T) {
 // zero). This is the --test-web mode scenario: the user edits config in the browser
 // textarea and expects Status to reflect the same config as test-query.
 func TestStatusHandler_UsesPostedConfig(t *testing.T) {
-	now := time.Now()
-	day := now.Weekday().String()
-	start := now.Add(-1 * time.Hour).Format("15:04")
-	end := now.Add(1 * time.Hour).Format("15:04")
+	day := time.Now().Weekday().String()
 
+	// Use a wide window spanning most of the day so the test is not sensitive to
+	// the time-of-day it runs. A now±1h window would produce an overnight slot near
+	// midnight that the scheduler correctly refuses to mark as "currently active".
 	blocked := config.Config{
 		Settings: config.Settings{PrimaryDNS: "8.8.8.8:53", BackupDNS: "1.1.1.1:53"},
 		Groups:   map[string][]string{"video": {"youtube.com"}},
@@ -361,7 +383,7 @@ func TestStatusHandler_UsesPostedConfig(t *testing.T) {
 				Group:    "video",
 				IsActive: true,
 				Schedules: map[string][]config.TimeSlot{
-					day: {{Start: start, End: end}},
+					day: {{Start: "00:01", End: "23:59"}},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes #63 — the GitHub release workflow was broken for two reasons, plus a pre-existing flaky test is cleaned up.

---

### Root cause 1 — Windows runner: Go setup fails

**`setup-go@v4` cannot install recent Go versions on Windows.**  
When `go-version: '1.26.2'` is requested, the action tries to download and extract `go-1.26.2-win32-x64.zip`.  `setup-go@v4` was published before Go 1.26 existed and its Windows URL/extraction path breaks on newer patch versions.

**Fix:** Upgrade to `actions/setup-go@v5` in both `ci.yml` and `release.yml`, and switch from a hardcoded `go-version: '1.26.2'` to `go-version-file: go.mod`.  This reads the version from `go.mod` automatically — no workflow update needed when Go is bumped in future.

---

### Root cause 2 — macOS runner: permission warning on every test

**`ConfigHandler` calls `config.LoadConfig()` on every request**, which internally calls `os.MkdirAll("/Library/Application Support/Sentinel", 0755)`.  The macOS GitHub Actions runner is unprivileged, so every invocation logged:

```
config reload warning: mkdir /Library/Application Support/Sentinel: permission denied
```

This produced ~20 lines of noise per CI run (once per web-package test that exercised `ConfigHandler`).  Tests did not fail — the handler continued with a zero-valued config — but the output polluted CI logs and obscured real failures.

**Fix:** Add `TestMain` to `internal/web/` that sets `config.UseLocalConfig = true` and `chdir`s to the module root (same pattern as `internal/testcli/`).  Tests now resolve `./config.json` locally and never touch the system config directory.

---

### Bonus: flaky test fixed (pre-existing)

`TestStatusHandler_UsesPostedConfig` built a schedule window of `now - 1h` → `now + 1h`.  When the test runs between 23:00 and 01:00, this window spans midnight (e.g. `23:15` → `01:15`), which the scheduler treats as an **overnight slot** whose evening side starts at `23:15`.  At `00:15`, the current time is *before* `23:15` in the stripped-time comparison, so the domain is correctly **not** considered blocked — causing the test to fail roughly 2 hours out of every 24.

**Fix:** Replace the dynamic `±1h` window with a stable `00:01–23:59` slot that covers any time of day without crossing midnight.

## Test plan

- [ ] `go test ./...` passes cleanly on macOS without any `config reload warning` output
- [ ] Release workflow completes on all three matrix targets (macos-latest arm64, ubuntu-latest → darwin/amd64, windows-latest)
- [ ] `TestStatusHandler_UsesPostedConfig` passes when run at any hour of the day

🤖 Generated with [Claude Code](https://claude.com/claude-code)