### PR TITLE
fix: graceful error handling — port 53 conflict & broken status command (#64)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -57,7 +57,7 @@ ipconfig /flushdns
 |---|---|---|
 | Blocked sites still load | Wrong mode for your setup, or current time isn't in a block window | [§4 Mode-specific diagnostics](#4-mode-specific-diagnostics) |
 | All DNS broken (nothing resolves) | DNS-mode service stopped without restoring system DNS | [§1](#1-if-your-internet-is-broken--read-this-first) |
-| Service won't start: `permission denied` on port 53 | Running without sudo, or another process holds port 53 | [§9](#9-common-errors) |
+| Service won't start: `permission denied` or `address already in use` on port 53 | Missing sudo, or another DNS service (AdGuard Home, dnsmasq…) holds port 53 | [§9 Port 53 errors](#port-53-errors-permission-denied--address-already-in-use) |
 | Service installed but `start` does nothing | Service framework is silent about startup failures — check logs | [§5 Reading logs](#5-reading-logs) |
 | Tabs aren't being closed | Not running as console user, AppleScript permissions, browser not running | [§4 macOS AppleScript path](#macos-applescript-path) |
 | Web dashboard returns 401 unauthorized | Auth token mismatch — UI didn't bootstrap | [§9](#9-common-errors) |
@@ -365,16 +365,54 @@ networksetup -setdnsservers "Wi-Fi" Empty
 
 ## 9. Common errors
 
-### `listen udp 127.0.0.1:53: permission denied`
+### Port 53 errors (`permission denied` / `address already in use`)
 
-Port 53 is privileged. Run with `sudo`. If you *are* using sudo, something else holds the port:
+These only apply to `dns` and `strict` modes. In `hosts` mode the daemon never binds port 53.
+
+**`permission denied`** — port 53 is privileged; run with `sudo`.
+
+**`address already in use`** — another process is already listening on port 53. Find it:
 
 ```bash
 sudo lsof -i :53 -P -n
-sudo kill <PID>           # only if you know what it is
 ```
 
-This error only applies to `dns` and `strict` modes. In `hosts` mode the daemon doesn't bind any port (besides 8040 for the dashboard, which is unprivileged).
+Common culprits: AdGuard Home, Pi-hole, systemd-resolved, dnsmasq, or another Sentinel instance. Decide whether to stop it or let Sentinel share upstream with it (see below).
+
+#### Running Sentinel alongside AdGuard Home (or any other local DNS service)
+
+Sentinel needs to own port 53 to intercept queries. The other service must move to a different port so Sentinel can forward to it as upstream.
+
+**Step 1 — Move the other service off port 53.**
+
+*AdGuard Home:* Settings → DNS Settings → "DNS server configuration" → change the plain DNS port (default 53) to something like **5300**. Save and apply. AdGuard continues filtering ads/tracking; it just listens on a different port.
+
+*Pi-hole / dnsmasq:* edit the service's config to bind to a non-standard port (e.g. 5300), then restart it.
+
+**Step 2 — Point Sentinel's upstream at the other service.**
+
+```bash
+# Open the web UI and change primary_dns to 127.0.0.1:5300
+open http://localhost:8040
+# — or edit config.json directly —
+sudo nano /Library/Application\ Support/Sentinel/config.json
+# set "primary_dns": "127.0.0.1:5300"
+```
+
+You can also set a backup in case your local resolver is down:
+
+```json
+"primary_dns": "127.0.0.1:5300",
+"backup_dns":  "8.8.8.8:53"
+```
+
+**Step 3 — Restart Sentinel.**
+
+```bash
+sudo sentinel restart
+```
+
+Sentinel now owns port 53 (blocking distracting sites by returning `0.0.0.0`) and forwards all other queries to AdGuard Home, which continues its own ad/tracker filtering.
 
 ### `service is already installed`
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"runtime"
 	"strings"
@@ -91,7 +92,10 @@ func (p *program) run() {
 
 	if mode == "dns" || mode == "strict" {
 		// DNS server blocks until stopped; keep this as the last call.
-		proxy.StartDNSServer()
+		if err := proxy.StartDNSServer(); err != nil {
+			logDNSStartupError(err)
+			os.Exit(1)
+		}
 	} else {
 		// Hosts mode: no port binding needed; park the goroutine.
 		select {}
@@ -111,6 +115,31 @@ var svcConfig = &service.Config{
 	Name:        "Sentinel",
 	DisplayName: "Sentinel DNS Proxy",
 	Description: "Local DNS proxy for blocking distractions.",
+}
+
+// isPortConflict reports whether err indicates that the bind address is already in use.
+func isPortConflict(err error) bool {
+	if opErr, ok := err.(*net.OpError); ok {
+		// On Linux/macOS the inner error is syscall.EADDRINUSE.
+		// Checking the OpError type is enough — if binding failed, the port is taken.
+		if opErr.Op == "listen" || opErr.Op == "dial" {
+			return true
+		}
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "address already in use") ||       // Linux / macOS
+		strings.Contains(msg, "Only one usage of each socket") // Windows
+}
+
+// logDNSStartupError logs a human-readable diagnostic for DNS server start failures.
+func logDNSStartupError(err error) {
+	if isPortConflict(err) {
+		log.Printf("FATAL: cannot bind DNS proxy to 127.0.0.1:53 — port already in use")
+		log.Printf("       Find what holds it: sudo lsof -i :53 -P -n")
+		log.Printf("       See TROUBLESHOOTING.md §9 for AdGuard Home and other DNS service coexistence.")
+	} else {
+		log.Printf("FATAL: DNS server stopped unexpectedly: %v", err)
+	}
 }
 
 func runSetup() {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -349,6 +349,22 @@ func main() {
 	}
 
 	if len(os.Args) > 1 {
+		// "status" is not a standard kardianos/service Control action — handle separately.
+		if os.Args[1] == "status" {
+			st, err := s.Status()
+			if err != nil {
+				log.Fatalf("Failed to get service status: %v", err)
+			}
+			switch st {
+			case service.StatusRunning:
+				fmt.Println("Sentinel is running.")
+			case service.StatusStopped:
+				fmt.Println("Sentinel is stopped.")
+			default:
+				fmt.Println("Sentinel status: unknown (service may not be installed).")
+			}
+			return
+		}
 		err = service.Control(s, os.Args[1])
 		if err != nil {
 			log.Fatalf("Failed to %s: %v", os.Args[1], err)

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -90,15 +90,24 @@ func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
 	w.WriteMsg(m)
 }
 
-func StartDNSServer() {
+// StartDNSServer binds to 127.0.0.1:53 and serves until StopDNSServer is called.
+// It returns an error if the listener cannot be started (e.g. port already in use).
+// A nil return means the server exited cleanly after a Shutdown call.
+func StartDNSServer() error {
 	UpdateBlockedDomains(make(map[string]bool))
 	dns.HandleFunc(".", handleDNSRequest)
 
 	dnsServer = &dns.Server{Addr: "127.0.0.1:53", Net: "udp"}
 	log.Printf("Starting local DNS proxy on 127.0.0.1:53...")
 	if err := dnsServer.ListenAndServe(); err != nil {
-		log.Fatalf("Failed to start DNS server: %s", err.Error())
+		// Swallow the "use of closed network connection" error that the miekg/dns
+		// library surfaces when Shutdown() closes the UDP listener normally.
+		if strings.Contains(err.Error(), "use of closed network connection") {
+			return nil
+		}
+		return err
 	}
+	return nil
 }
 
 func StopDNSServer() {


### PR DESCRIPTION
## Summary

Fixes #64 — two separate bugs addressed in two commits.

---

### Bug 1 — DNS startup fails silently with no actionable hint

**Root cause:** `StartDNSServer()` called `log.Fatalf` on any listen error. When AdGuard Home (or any other DNS service) already owned port 53, the only output was a raw error string — no indication of what was conflicting or how to fix it. The service then exited and launchd restarted it in a tight loop.

**Fix (commit 1):**

- `StartDNSServer()` now **returns an error** instead of `log.Fatalf`. The `"use of closed network connection"` error from the miekg/dns library on a clean `Shutdown()` call is swallowed (normal stop path, not a crash).
- `p.run()` calls `logDNSStartupError()`, which detects EADDRINUSE / Windows equivalents via `*net.OpError` type-checking and string fallbacks, then logs a brief pointer to the docs:

```
FATAL: cannot bind DNS proxy to 127.0.0.1:53 — port already in use
       Find what holds it: sudo lsof -i :53 -P -n
       See TROUBLESHOOTING.md §9 for AdGuard Home and other DNS service coexistence.
```

- `TROUBLESHOOTING.md §9` is expanded with the full detail: the existing "permission denied" entry now also covers "address already in use", plus a new step-by-step subsection for running Sentinel alongside AdGuard Home (or any local DNS service) — move the other service off port 53, configure Sentinel's `primary_dns` to forward there, restart.

---

### Bug 2 — `sentinel status` fails with "Unknown action status"

**Root cause:** `service.Control(s, "status")` is not a recognised action in the `kardianos/service` library (only `start/stop/restart/install/uninstall` are). The library returned `"Unknown action status"` verbatim.

**Fix (commit 2):** Intercept `"status"` before the generic `Control()` dispatch and call `s.Status()` instead, which queries the OS service manager (launchd on macOS, SCM on Windows). Output:

```
Sentinel is running.
Sentinel is stopped.
Sentinel status: unknown (service may not be installed).
```

## Gotchas

- `isPortConflict()` checks for `*net.OpError` with `Op == "listen"` or `"dial"` (covers both UDP `ListenPacket` and TCP paths) plus string-based fallbacks for edge cases where error wrapping differs by OS.
- `StartDNSServer` is now blocking-and-returns-error. Any future caller must handle the returned error.

## Test plan

- [ ] `go test ./...` passes
- [ ] `sudo sentinel status` prints `Sentinel is running.` or `Sentinel is stopped.`
- [ ] Starting Sentinel in dns mode when port 53 is held by AdGuard Home logs the brief three-line hint and exits cleanly (no restart loop)
- [ ] Normal `sudo sentinel stop` does not log a DNS server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)