### PR TITLE
feat: auto-detect upstream DNS and auto-configure system DNS on startup

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -371,7 +371,7 @@ These only apply to `dns` and `strict` modes. In `hosts` mode the daemon never b
 
 **`permission denied`** — port 53 is privileged; run with `sudo`.
 
-**`address already in use`** — another process is already listening on port 53. Find it:
+**`address already in use`** — another process is already listening on port 53. Sentinel logs the name of the conflicting process automatically. You can also find it manually:
 
 ```bash
 sudo lsof -i :53 -P -n
@@ -405,6 +405,8 @@ You can also set a backup in case your local resolver is down:
 "primary_dns": "127.0.0.1:5300",
 "backup_dns":  "8.8.8.8:53"
 ```
+
+> **Note:** If your `primary_dns` was still at the factory default (`8.8.8.8:53`) when Sentinel first started in `dns` or `strict` mode, Sentinel auto-detected your previous system DNS and saved it automatically. In that case this step may already be done — check the web UI or config.json before editing.
 
 **Step 3 — Restart Sentinel.**
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"time"
@@ -135,11 +136,30 @@ func isPortConflict(err error) bool {
 func logDNSStartupError(err error) {
 	if isPortConflict(err) {
 		log.Printf("FATAL: cannot bind DNS proxy to 127.0.0.1:53 — port already in use")
+		if proc := port53HolderName(); proc != "" {
+			log.Printf("       Port 53 is held by: %s", proc)
+		}
 		log.Printf("       Find what holds it: sudo lsof -i :53 -P -n")
 		log.Printf("       See TROUBLESHOOTING.md §9 for AdGuard Home and other DNS service coexistence.")
 	} else {
 		log.Printf("FATAL: DNS server stopped unexpectedly: %v", err)
 	}
+}
+
+// port53HolderName returns the name of the process currently holding port 53,
+// or "" if it cannot be determined. Uses lsof's -F (field) output for reliable
+// parsing without depending on column widths.
+func port53HolderName() string {
+	out, err := exec.Command("lsof", "-i", ":53", "-P", "-n", "-F", "c").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "c") {
+			return strings.TrimPrefix(line, "c")
+		}
+	}
+	return ""
 }
 
 func runSetup() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -191,6 +192,33 @@ func GetConfig() Config {
 	mu.RLock()
 	defer mu.RUnlock()
 	return AppConfig
+}
+
+const factoryPrimaryDNS = "8.8.8.8:53"
+
+// AutoSetPrimaryDNS updates primary_dns only when it still holds the factory
+// default. This lets the first dns/strict mode startup capture whatever DNS
+// the user had before Sentinel, without overwriting deliberate user settings.
+func AutoSetPrimaryDNS(server string) {
+	path, err := GetConfigFilePath()
+	if err != nil {
+		return
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if AppConfig.Settings.PrimaryDNS != factoryPrimaryDNS {
+		return
+	}
+	AppConfig.Settings.PrimaryDNS = server
+	data, err := json.MarshalIndent(AppConfig, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		log.Printf("config: could not save auto-detected upstream DNS: %v", err)
+		return
+	}
+	log.Printf("config: auto-detected upstream DNS %s → saved as primary_dns", server)
 }
 
 // ConfigDir returns the OS-specific config directory path without creating it.

--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -3,6 +3,7 @@ package enforcer
 import (
 	"bufio"
 	"log"
+	"net"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -27,7 +28,80 @@ func NewDNSEnforcer(cfg config.Config) *DNSEnforcer {
 
 func (e *DNSEnforcer) Setup() error {
 	proxy.UpdateBlockedDomains(make(map[string]bool))
+	if runtime.GOOS == "darwin" {
+		e.configureSystemDNS()
+	}
 	return nil
+}
+
+// configureSystemDNS detects the current upstream DNS before taking over port 53,
+// saves it as primary_dns if the config is still at factory default, then points
+// every active network interface at the local DNS proxy (127.0.0.1).
+func (e *DNSEnforcer) configureSystemDNS() {
+	if upstream := detectSystemDNS(); upstream != "" {
+		config.AutoSetPrimaryDNS(upstream)
+	}
+	out, err := exec.Command("networksetup", "-listallnetworkservices").Output()
+	if err != nil {
+		exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "127.0.0.1").Run()
+		flushDNSCache()
+		return
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "An asterisk") || strings.TrimSpace(line) == "" {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(line, "*"))
+		exec.Command("networksetup", "-setdnsservers", name, "127.0.0.1").Run()
+	}
+	flushDNSCache()
+}
+
+// detectSystemDNS returns the first non-loopback DNS server currently configured
+// on the system, in host:port form. Returns "" if none can be determined.
+// It first tries manually configured servers; if none, falls back to DHCP-assigned
+// DNS from scutil.
+func detectSystemDNS() string {
+	out, err := exec.Command("networksetup", "-listallnetworkservices").Output()
+	if err == nil {
+		sc := bufio.NewScanner(strings.NewReader(string(out)))
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.HasPrefix(line, "An asterisk") || strings.TrimSpace(line) == "" {
+				continue
+			}
+			name := strings.TrimSpace(strings.TrimPrefix(line, "*"))
+			dnsOut, err := exec.Command("networksetup", "-getdnsservers", name).Output()
+			if err != nil {
+				continue
+			}
+			for _, srv := range strings.Split(strings.TrimSpace(string(dnsOut)), "\n") {
+				srv = strings.TrimSpace(srv)
+				if net.ParseIP(srv) != nil && !strings.HasPrefix(srv, "127.") {
+					return srv + ":53"
+				}
+			}
+		}
+	}
+	// Fall back to DHCP-assigned DNS via scutil.
+	scOut, err := exec.Command("scutil", "--dns").Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(scOut), "\n") {
+		if strings.Contains(line, "nameserver[0]") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				srv := strings.TrimSpace(parts[1])
+				if net.ParseIP(srv) != nil && !strings.HasPrefix(srv, "127.") {
+					return srv + ":53"
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func (e *DNSEnforcer) Teardown() error {


### PR DESCRIPTION
## What

Two quality-of-life improvements for `dns` and `strict` mode setup, plus a better port-conflict error message.

### 1. System DNS is now configured automatically on startup

Previously, users had to manually run:

```bash
networksetup -setdnsservers Wi-Fi 127.0.0.1
```

after installing in `dns`/`strict` mode. `DNSEnforcer.Setup()` now does this automatically across every active network interface, making `Setup()` and `Teardown()` symmetric — `Setup` points the OS at Sentinel, `Teardown` resets it to `Empty` (DHCP).

### 2. Previous upstream DNS is auto-detected and saved

Before switching the OS DNS to `127.0.0.1`, `Setup()` reads what was already configured:

1. Checks each interface via `networksetup -getdnsservers` for manually-configured servers.
2. Falls back to `scutil --dns` for DHCP-assigned nameservers.

If a non-loopback server is found **and** `primary_dns` is still at the factory default (`8.8.8.8:53`), it saves the detected server as `primary_dns`. This fires only once — subsequent restarts leave user-customised values untouched.

### 3. Port-53 conflict error names the offending process

`logDNSStartupError` now calls `lsof -F c -i :53` to identify the process holding the port and logs it directly:

```
FATAL: cannot bind DNS proxy to 127.0.0.1:53 — port already in use
       Port 53 is held by: AdGuardHome
       Find what holds it: sudo lsof -i :53 -P -n
```

## Why

The manual `networksetup` step was the most common setup mistake reported, and the `primary_dns` edit was invisible to users who skipped TROUBLESHOOTING.md. The generic "address already in use" error gave no actionable direction.

## Gotchas

- **Root requirement unchanged.** `networksetup` and `scutil` require root, but `dns`/`strict` mode already requires root to bind port 53.
- **Auto-detection is one-shot.** It checks `primary_dns == "8.8.8.8:53"` before writing. Once a user (or a previous auto-detect) has customised it, restarts never overwrite it.
- **AdGuard co-existence still requires Step 2.** If `backup_dns` is on a non-standard port (e.g. `127.0.0.1:5300`), the OS-level fallback is omitted and the user must still manually update `primary_dns` after moving AdGuard. TROUBLESHOOTING.md §9 now notes that Step 2 may already be done automatically and to check before editing.
- **`hosts` mode is unaffected.** `configureSystemDNS()` is guarded by `runtime.GOOS == "darwin"` and only called from `DNSEnforcer.Setup()`, which is only reached in `dns`/`strict` mode.

## Testing

```bash
make test                          # all existing tests pass
./sentinel --local                 # local run: check logs for "auto-detected upstream DNS"
sudo lsof -i :53                   # verify nothing else on 53, then test port-conflict log
```