### PR TITLE
feat: add dns_failure_mode config option for crash behaviour control

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The default config ships with three groups. `games` and `videos` are blocked dur
 
 - **`settings.enforcement_mode`** — `"hosts"` (default), `"dns"`, or `"strict"`. See [Enforcement modes](#enforcement-modes).
 - **`settings.primary_dns` / `backup_dns`** — upstream resolvers used in `dns`/`strict` mode. Ignored in `hosts` mode.
+- **`settings.dns_failure_mode`** — `"open"` (default) or `"closed"`. Controls what happens if Sentinel stops unexpectedly while in `dns`/`strict` mode. `"open"`: the OS DNS is set to `127.0.0.1 <backup_dns_host>`, so if Sentinel crashes the machine falls through to `backup_dns` and stays online (blocking lapses until launchd restarts the service). `"closed"`: only `127.0.0.1` is set — DNS fails entirely while Sentinel is down, making a crash unbypassable. Requires `backup_dns` to be a non-loopback IP on port 53; if it isn't, `"open"` silently behaves like `"closed"` and logs a warning. Ignored in `hosts` mode.
 - **`settings.auth_token`** — auto-generated on first launch. The web UI sends this in `X-Auth-Token` for every mutating API call.
 - **`groups`** — named lists of domains that rules are bound to. In `hosts` mode, common prefixes (`www.`, `m.`, `mobile.`, `app.`) are blocked automatically. In `dns` mode, subdomain matching is suffix-based (`a.b.example.com` is blocked if `example.com` is in the group).
 - **`rules[].group`** — must match a key in `groups`.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -416,6 +416,27 @@ sudo sentinel restart
 
 Sentinel now owns port 53 (blocking distracting sites by returning `0.0.0.0`) and forwards all other queries to AdGuard Home, which continues its own ad/tracker filtering.
 
+#### What happens if Sentinel crashes or is killed?
+
+In `dns`/`strict` mode the OS sends all DNS through Sentinel. If it stops unexpectedly, behaviour depends on `dns_failure_mode` in `config.json`:
+
+| `dns_failure_mode` | Sentinel down | Sentinel restarted by launchd |
+|--------------------|--------------|-------------------------------|
+| `"open"` (default) | Machine falls back to `backup_dns` — internet works, blocking lapses | Sentinel takes over again within seconds |
+| `"closed"` | DNS resolution fails entirely — no internet until Sentinel is back | Same |
+
+**`"open"`** is the default. It requires `backup_dns` to be a non-loopback IP on port 53 (e.g. `1.1.1.1:53`). If you have pointed `backup_dns` at a local resolver on a non-standard port (e.g. `127.0.0.1:5300` for AdGuard), Sentinel cannot use it as an OS-level fallback and will log a warning; it will operate fail-closed in that case regardless of the setting.
+
+**`"closed"`** is appropriate when you need the blocking to be unbypassable — a crash means no internet rather than unfiltered internet. Be aware that a motivated user could potentially trigger a crash to temporarily lift blocks.
+
+To change the setting:
+
+```bash
+sudo nano /Library/Application\ Support/Sentinel/config.json
+# set "dns_failure_mode": "closed"
+sudo sentinel restart
+```
+
 ### `service is already installed`
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Settings struct {
 	BackupDNS       string `json:"backup_dns"`
 	AuthToken       string `json:"auth_token"`
 	EnforcementMode string `json:"enforcement_mode,omitempty"`
+	DNSFailureMode  string `json:"dns_failure_mode,omitempty"`
 }
 
 // GetEnforcementMode returns the validated enforcement mode, defaulting to "hosts"
@@ -45,6 +46,20 @@ func (s Settings) GetEnforcementMode() string {
 		return s.EnforcementMode
 	default:
 		return "hosts"
+	}
+}
+
+// GetDNSFailureMode returns the validated DNS failure mode, defaulting to "open"
+// when the field is absent or unrecognised. "open" means the OS DNS config
+// includes backup_dns as a system-level fallback so the machine stays online if
+// Sentinel crashes; "closed" means only 127.0.0.1 is set and DNS fails entirely
+// if Sentinel is not running.
+func (s Settings) GetDNSFailureMode() string {
+	switch s.DNSFailureMode {
+	case "open", "closed":
+		return s.DNSFailureMode
+	default:
+		return "open"
 	}
 }
 

--- a/internal/config/default_config.json
+++ b/internal/config/default_config.json
@@ -2,7 +2,8 @@
   "settings": {
     "primary_dns": "8.8.8.8:53",
     "backup_dns": "1.1.1.1:53",
-    "enforcement_mode": "hosts"
+    "enforcement_mode": "hosts",
+    "dns_failure_mode": "open"
   },
   "groups": {
     "games": [

--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -36,14 +36,28 @@ func (e *DNSEnforcer) Setup() error {
 
 // configureSystemDNS detects the current upstream DNS before taking over port 53,
 // saves it as primary_dns if the config is still at factory default, then points
-// every active network interface at the local DNS proxy (127.0.0.1).
+// every active network interface at the local DNS proxy. When dns_failure_mode is
+// "open" (the default), backup_dns is included as a second OS-level server so the
+// machine stays online if Sentinel crashes; "closed" sets only 127.0.0.1.
 func (e *DNSEnforcer) configureSystemDNS() {
 	if upstream := detectSystemDNS(); upstream != "" {
 		config.AutoSetPrimaryDNS(upstream)
 	}
+
+	cfg := config.GetConfig()
+	servers := []string{"127.0.0.1"}
+	if cfg.Settings.GetDNSFailureMode() == "open" {
+		if fallback := backupDNSHost(cfg.Settings.BackupDNS); fallback != "" {
+			servers = append(servers, fallback)
+		} else {
+			log.Printf("dns: dns_failure_mode is \"open\" but backup_dns (%s) cannot be used as OS-level fallback (must be a non-loopback IP on port 53); operating fail-closed", cfg.Settings.BackupDNS)
+		}
+	}
+
 	out, err := exec.Command("networksetup", "-listallnetworkservices").Output()
 	if err != nil {
-		exec.Command("networksetup", "-setdnsservers", "Wi-Fi", "127.0.0.1").Run()
+		args := append([]string{"-setdnsservers", "Wi-Fi"}, servers...)
+		exec.Command("networksetup", args...).Run()
 		flushDNSCache()
 		return
 	}
@@ -54,9 +68,27 @@ func (e *DNSEnforcer) configureSystemDNS() {
 			continue
 		}
 		name := strings.TrimSpace(strings.TrimPrefix(line, "*"))
-		exec.Command("networksetup", "-setdnsservers", name, "127.0.0.1").Run()
+		args := append([]string{"-setdnsservers", name}, servers...)
+		exec.Command("networksetup", args...).Run()
 	}
 	flushDNSCache()
+}
+
+// backupDNSHost extracts a usable OS-level fallback host from a host:port DNS
+// address. Returns "" if the address is on a non-standard port (the OS always
+// queries port 53), if the host is loopback, or if parsing fails.
+func backupDNSHost(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return ""
+	}
+	if port != "53" {
+		return ""
+	}
+	if net.ParseIP(host) == nil || strings.HasPrefix(host, "127.") {
+		return ""
+	}
+	return host
 }
 
 // detectSystemDNS returns the first non-loopback DNS server currently configured


### PR DESCRIPTION
## What

Adds a `dns_failure_mode` setting (`"open"` / `"closed"`) that controls what happens to the machine's internet connectivity if Sentinel stops unexpectedly while in `dns` or `strict` mode.

## Background

In `dns`/`strict` mode, the OS routes all DNS through Sentinel at `127.0.0.1:53`. A graceful stop (via `sentinel stop` or `restart`) calls `Teardown()`, which resets the system DNS back to DHCP — no issue. But a crash, `kill -9`, or power loss skips `Teardown()`, leaving the OS pointed at `127.0.0.1:53` with nothing listening. The machine loses DNS resolution entirely until launchd restarts the service.

## The new setting

| `dns_failure_mode` | OS DNS set to | If Sentinel crashes |
|--------------------|--------------|---------------------|
| `"open"` (default) | `127.0.0.1 <backup_dns_host>` | Machine falls back to `backup_dns` — internet works, blocking lapses |
| `"closed"` | `127.0.0.1` only | DNS fails completely — no internet, no bypass |

**`"open"` is the default** because keeping the machine online is the safer outcome for most users. launchd typically restarts the service within seconds, so the blocking gap is small. **`"closed"` is opt-in** for parental control or strict enforcement scenarios where unfiltered internet is worse than no internet.

## Implementation

- `Settings.DNSFailureMode` + `GetDNSFailureMode()` in `config.go`, following the same absent/unrecognised-field defaulting pattern as `GetEnforcementMode()` — existing configs gain `"open"` without a migration step.
- `backupDNSHost()` in `dns.go` validates that the backup address is a non-loopback IP on **port 53** before including it in the OS DNS config. The OS resolver always contacts port 53; if `backup_dns` is on a custom port (e.g. `127.0.0.1:5300` for a co-located AdGuard), it cannot be used as a system fallback. In that case Sentinel logs a warning and operates fail-closed regardless of the setting.
- `configureSystemDNS()` builds the server list (`["127.0.0.1"]` or `["127.0.0.1", "<backup_host>"]`) and passes it to `networksetup -setdnsservers` for each active interface.
- `default_config.json` now explicitly includes `"dns_failure_mode": "open"` so the field is visible and editable in the web UI on new installs.

## Gotchas

- **AdGuard co-existence caveat.** If a user has followed TROUBLESHOOTING.md §9 and set `backup_dns` to `127.0.0.1:5300` (AdGuard on a custom port), `backupDNSHost()` returns `""` — the port is non-standard and the address is loopback. Sentinel logs: `dns_failure_mode is "open" but backup_dns (127.0.0.1:5300) cannot be used as OS-level fallback`. The machine operates fail-closed in this configuration regardless of the setting. This is documented in TROUBLESHOOTING.md.
- **`hosts` mode is unaffected.** `configureSystemDNS()` is only called from `DNSEnforcer.Setup()`.
- **No migration needed.** `GetDNSFailureMode()` returns `"open"` for any unrecognised or absent value.

## Docs

- `README.md` field reference updated with `dns_failure_mode` description.
- `TROUBLESHOOTING.md` §9 gets a new "What happens if Sentinel crashes?" subsection with a behaviour table and instructions for switching to `"closed"`.

## Testing

```bash
make test
# verify default_config.json has the new field
cat internal/config/default_config.json | jq '.settings.dns_failure_mode'
# verify networksetup call includes fallback (needs root + darwin):
# sudo ./sentinel --local  → check logs for "127.0.0.1 1.1.1.1" in networksetup args
```