### PR TITLE
feat: Pomodoro focus session with lock-down mode (issues #45 + #57)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,11 +68,22 @@ type PauseWindow struct {
 	Until time.Time `json:"until"`
 }
 
+// PomodoroSession tracks an active Pomodoro cycle.
+// Phase is "work" or "break". There is no auto-restart; each work session
+// must be started explicitly by the user.
+type PomodoroSession struct {
+	Phase        string    `json:"phase"`
+	PhaseEndsAt  time.Time `json:"phase_ends_at"`
+	WorkMinutes  int       `json:"work_minutes"`
+	BreakMinutes int       `json:"break_minutes"`
+}
+
 type Config struct {
 	Settings Settings            `json:"settings"`
 	Groups   map[string][]string `json:"groups"`
 	Rules    []Rule              `json:"rules"`
 	Pause    *PauseWindow        `json:"pause,omitempty"`
+	Pomodoro *PomodoroSession    `json:"pomodoro,omitempty"`
 }
 
 // IsPaused reports whether all blocking rules are suspended at time t.
@@ -173,6 +184,47 @@ func ClearPause() {
 	mu.Lock()
 	defer mu.Unlock()
 	AppConfig.Pause = nil
+}
+
+// IsLockedByPomodoro reports whether the Pomodoro work phase is active at t.
+func (c Config) IsLockedByPomodoro(t time.Time) bool {
+	return c.Pomodoro != nil && c.Pomodoro.Phase == "work" && t.Before(c.Pomodoro.PhaseEndsAt)
+}
+
+// StartPomodoro begins a new Pomodoro work session.
+// Call SaveConfig to persist.
+func StartPomodoro(workMin, breakMin int) {
+	mu.Lock()
+	defer mu.Unlock()
+	AppConfig.Pomodoro = &PomodoroSession{
+		Phase:        "work",
+		PhaseEndsAt:  time.Now().Add(time.Duration(workMin) * time.Minute),
+		WorkMinutes:  workMin,
+		BreakMinutes: breakMin,
+	}
+}
+
+// AdvancePomodoroPhase transitions the work phase to break.
+// Must only be called when the current phase is "work" and has just expired.
+// Call SaveConfig to persist.
+func AdvancePomodoroPhase() {
+	mu.Lock()
+	defer mu.Unlock()
+	if AppConfig.Pomodoro == nil || AppConfig.Pomodoro.Phase != "work" {
+		return
+	}
+	AppConfig.Pomodoro.Phase = "break"
+	AppConfig.Pomodoro.PhaseEndsAt = time.Now().Add(
+		time.Duration(AppConfig.Pomodoro.BreakMinutes) * time.Minute,
+	)
+}
+
+// ClearPomodoro removes any active Pomodoro session.
+// Call SaveConfig to persist.
+func ClearPomodoro() {
+	mu.Lock()
+	defer mu.Unlock()
+	AppConfig.Pomodoro = nil
 }
 
 // SaveConfig writes the current in-memory config to disk.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsLockedByPomodoro_WorkPhaseInFuture(t *testing.T) {
+	cfg := Config{
+		Pomodoro: &PomodoroSession{
+			Phase:       "work",
+			PhaseEndsAt: time.Now().Add(10 * time.Minute),
+		},
+	}
+	if !cfg.IsLockedByPomodoro(time.Now()) {
+		t.Error("expected locked during active work phase")
+	}
+}
+
+func TestIsLockedByPomodoro_WorkPhaseExpired(t *testing.T) {
+	cfg := Config{
+		Pomodoro: &PomodoroSession{
+			Phase:       "work",
+			PhaseEndsAt: time.Now().Add(-1 * time.Second),
+		},
+	}
+	if cfg.IsLockedByPomodoro(time.Now()) {
+		t.Error("expected not locked when work phase has expired")
+	}
+}
+
+func TestIsLockedByPomodoro_BreakPhase(t *testing.T) {
+	cfg := Config{
+		Pomodoro: &PomodoroSession{
+			Phase:       "break",
+			PhaseEndsAt: time.Now().Add(5 * time.Minute),
+		},
+	}
+	if cfg.IsLockedByPomodoro(time.Now()) {
+		t.Error("expected not locked during break phase")
+	}
+}
+
+func TestIsLockedByPomodoro_NilPomodoro(t *testing.T) {
+	cfg := Config{}
+	if cfg.IsLockedByPomodoro(time.Now()) {
+		t.Error("expected not locked when no session exists")
+	}
+}
+
+func TestStartPomodoro_SetsCorrectPhase(t *testing.T) {
+	t.Cleanup(func() { AppConfig.Pomodoro = nil })
+
+	before := time.Now()
+	StartPomodoro(25, 5)
+	after := time.Now()
+
+	p := AppConfig.Pomodoro
+	if p == nil {
+		t.Fatal("expected Pomodoro to be set")
+	}
+	if p.Phase != "work" {
+		t.Errorf("expected phase=work, got %q", p.Phase)
+	}
+	if p.WorkMinutes != 25 {
+		t.Errorf("expected work_minutes=25, got %d", p.WorkMinutes)
+	}
+	if p.BreakMinutes != 5 {
+		t.Errorf("expected break_minutes=5, got %d", p.BreakMinutes)
+	}
+	expectedMin := before.Add(24 * time.Minute)
+	expectedMax := after.Add(26 * time.Minute)
+	if p.PhaseEndsAt.Before(expectedMin) || p.PhaseEndsAt.After(expectedMax) {
+		t.Errorf("PhaseEndsAt %v outside expected range [%v, %v]", p.PhaseEndsAt, expectedMin, expectedMax)
+	}
+}
+
+func TestAdvancePomodoroPhase_WorkToBreak(t *testing.T) {
+	t.Cleanup(func() { AppConfig.Pomodoro = nil })
+
+	AppConfig.Pomodoro = &PomodoroSession{
+		Phase:        "work",
+		PhaseEndsAt:  time.Now().Add(-1 * time.Second),
+		WorkMinutes:  25,
+		BreakMinutes: 5,
+	}
+
+	before := time.Now()
+	AdvancePomodoroPhase()
+	after := time.Now()
+
+	p := AppConfig.Pomodoro
+	if p.Phase != "break" {
+		t.Errorf("expected phase=break, got %q", p.Phase)
+	}
+	expectedMin := before.Add(4 * time.Minute)
+	expectedMax := after.Add(6 * time.Minute)
+	if p.PhaseEndsAt.Before(expectedMin) || p.PhaseEndsAt.After(expectedMax) {
+		t.Errorf("break PhaseEndsAt %v outside expected range", p.PhaseEndsAt)
+	}
+}
+
+func TestAdvancePomodoroPhase_NoopWhenNil(t *testing.T) {
+	t.Cleanup(func() { AppConfig.Pomodoro = nil })
+	AppConfig.Pomodoro = nil
+	AdvancePomodoroPhase() // must not panic
+}
+
+func TestClearPomodoro(t *testing.T) {
+	AppConfig.Pomodoro = &PomodoroSession{Phase: "work"}
+	ClearPomodoro()
+	if AppConfig.Pomodoro != nil {
+		t.Error("expected Pomodoro to be nil after ClearPomodoro")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -224,6 +224,21 @@ func EvaluateRulesAtTime(t time.Time, cfg config.Config) map[string]bool {
 		return make(map[string]bool)
 	}
 
+	// During a Pomodoro work phase, activate ALL rules with IsActive=true,
+	// bypassing their schedule windows entirely for stricter blocking.
+	if cfg.IsLockedByPomodoro(t) {
+		forced := make(map[string]bool)
+		for _, rule := range cfg.Rules {
+			if !rule.IsActive {
+				continue
+			}
+			for _, domain := range cfg.ResolveGroup(rule.Group) {
+				forced[domain] = true
+			}
+		}
+		return forced
+	}
+
 	currentDay := t.Weekday().String()
 	yesterdayDay := t.AddDate(0, 0, -1).Weekday().String()
 	now := time.Date(0, 1, 1, t.Hour(), t.Minute(), 0, 0, time.UTC)
@@ -368,6 +383,29 @@ func evaluateRules() {
 			log.Printf("scheduler: clear expired pause: %v", err)
 		}
 		cfg = config.GetConfig()
+	}
+
+	// Handle Pomodoro phase transitions.
+	if cfg.Pomodoro != nil && !now.Before(cfg.Pomodoro.PhaseEndsAt) {
+		switch cfg.Pomodoro.Phase {
+		case "work":
+			breakMin := cfg.Pomodoro.BreakMinutes
+			config.AdvancePomodoroPhase()
+			if err := config.SaveConfig(); err != nil {
+				log.Printf("scheduler: save pomodoro break phase: %v", err)
+			}
+			cfg = config.GetConfig()
+			sendPomodoroNotification("Sentinel — Break time!",
+				fmt.Sprintf("Take a %d-minute break.", breakMin))
+		case "break":
+			config.ClearPomodoro()
+			if err := config.SaveConfig(); err != nil {
+				log.Printf("scheduler: clear pomodoro session: %v", err)
+			}
+			cfg = config.GetConfig()
+			sendPomodoroNotification("Sentinel — Ready?",
+				"Break over. Start a new focus session when ready.")
+		}
 	}
 
 	newBlocked := EvaluateRulesAtTime(now, cfg)
@@ -651,5 +689,12 @@ func closeMacOSTabs(domains []string) {
 	script := scriptGenerator.GenerateCloseTabsScript(domains)
 	scriptExecutor.LogScript(script)
 	scriptExecutor.ExecuteScript(script)
+}
+
+func sendPomodoroNotification(title, message string) {
+	script := fmt.Sprintf(`display notification %q with title %q sound name "Ping"`, message, title)
+	if err := scriptExecutor.ExecuteScript(script); err != nil {
+		log.Printf("scheduler: pomodoro notification: %v", err)
+	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -676,3 +676,74 @@ func TestGenerateCloseTabsScript_IncludesArcAndBrave(t *testing.T) {
 		}
 	}
 }
+
+// ── Pomodoro override tests ───────────────────────────────────────────────────
+
+func pomodoroConfig() config.Config {
+	return config.Config{
+		Groups: map[string][]string{
+			"active":   {"active.com"},
+			"inactive": {"inactive.com"},
+		},
+		Rules: []config.Rule{
+			{Group: "active", IsActive: true, Schedules: map[string][]config.TimeSlot{
+				// Monday 02:00–03:00 — deliberately outside any test time we use
+				"Monday": {{Start: "02:00", End: "03:00"}},
+			}},
+			{Group: "inactive", IsActive: false, Schedules: map[string][]config.TimeSlot{
+				"Monday": {{Start: "00:00", End: "23:59"}},
+			}},
+		},
+	}
+}
+
+func TestEvaluateRulesAtTime_PomodoroWorkPhase_BlocksAllActiveRules(t *testing.T) {
+	testTime := time.Date(2024, time.April, 1, 12, 0, 0, 0, time.UTC) // Monday noon
+	cfg := pomodoroConfig()
+	cfg.Pomodoro = &config.PomodoroSession{
+		Phase:       "work",
+		PhaseEndsAt: testTime.Add(10 * time.Minute),
+	}
+
+	// Time is outside all schedule slots — should still be blocked during work phase
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if !result["active.com"] {
+		t.Error("expected active.com to be blocked during Pomodoro work phase")
+	}
+	if result["inactive.com"] {
+		t.Error("expected inactive.com NOT blocked (rule is inactive)")
+	}
+}
+
+func TestEvaluateRulesAtTime_PomodoroBreakPhase_UsesSchedule(t *testing.T) {
+	testTime := time.Date(2024, time.April, 1, 12, 0, 0, 0, time.UTC)
+	cfg := pomodoroConfig()
+	cfg.Pomodoro = &config.PomodoroSession{
+		Phase:       "break",
+		PhaseEndsAt: testTime.Add(5 * time.Minute),
+	}
+
+	// Monday noon — outside the 02:00–03:00 schedule window
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["active.com"] {
+		t.Error("expected active.com NOT blocked during break phase (out of schedule)")
+	}
+}
+
+func TestEvaluateRulesAtTime_PomodoroWorkExpired_FallsThrough(t *testing.T) {
+	testTime := time.Date(2024, time.April, 1, 12, 0, 0, 0, time.UTC)
+
+	cfg := pomodoroConfig()
+	cfg.Pomodoro = &config.PomodoroSession{
+		Phase:       "work",
+		PhaseEndsAt: testTime.Add(-1 * time.Second), // expired before testTime
+	}
+
+	result := EvaluateRulesAtTime(testTime, cfg)
+
+	if result["active.com"] {
+		t.Error("expected active.com NOT blocked after work phase expires (out of schedule)")
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"log"
 	"net/http"
@@ -19,6 +20,13 @@ import (
 )
 
 const maxPauseMinutes = 240 // 4 hours
+
+const (
+	minPomodoroWork  = 1
+	maxPomodoroWork  = 120
+	minPomodoroBreak = 1
+	maxPomodoroBreak = 60
+)
 
 //go:embed static/*
 var webFiles embed.FS
@@ -141,6 +149,11 @@ func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Preserve the existing auth token — callers cannot replace it via this endpoint.
 	existing := config.GetConfig()
+	if existing.IsLockedByPomodoro(time.Now()) {
+		w.WriteHeader(http.StatusLocked)
+		json.NewEncoder(w).Encode(map[string]string{"error": "config changes are locked during a Pomodoro work session"})
+		return
+	}
 	cfg.Settings.AuthToken = existing.Settings.AuthToken
 
 	data, _ := json.MarshalIndent(cfg, "", "  ")
@@ -172,14 +185,24 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		lastEval = time.Now()
 	}
 	cfg := config.GetConfig()
+	now := time.Now()
 	resp := map[string]any{
 		"blocked_domains":  blocked,
 		"last_evaluated":   lastEval,
 		"enforcement_mode": cfg.Settings.GetEnforcementMode(),
-		"paused":           cfg.IsPaused(time.Now()),
+		"paused":           cfg.IsPaused(now),
 	}
 	if cfg.Pause != nil {
 		resp["paused_until"] = cfg.Pause.Until.Format(time.RFC3339)
+	}
+	if cfg.Pomodoro != nil {
+		resp["pomodoro"] = map[string]any{
+			"phase":         cfg.Pomodoro.Phase,
+			"phase_ends_at": cfg.Pomodoro.PhaseEndsAt.Format(time.RFC3339),
+			"work_minutes":  cfg.Pomodoro.WorkMinutes,
+			"break_minutes": cfg.Pomodoro.BreakMinutes,
+			"locked":        cfg.IsLockedByPomodoro(now),
+		}
 	}
 	json.NewEncoder(w).Encode(resp)
 }
@@ -188,6 +211,12 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 // Body: {"minutes": N} where N must be between 1 and maxPauseMinutes.
 func PauseHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+
+	if cfg := config.GetConfig(); cfg.IsLockedByPomodoro(time.Now()) {
+		w.WriteHeader(http.StatusLocked)
+		json.NewEncoder(w).Encode(map[string]string{"error": "blocking is locked during a Pomodoro work session"})
+		return
+	}
 
 	var body struct {
 		Minutes int `json:"minutes"`
@@ -228,6 +257,71 @@ func ResumeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// PomodoroStartHandler handles POST /api/pomodoro/start.
+// Body: {"work_minutes": N, "break_minutes": M}
+func PomodoroStartHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var body struct {
+		WorkMinutes  int `json:"work_minutes"`
+		BreakMinutes int `json:"break_minutes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if body.WorkMinutes < minPomodoroWork || body.WorkMinutes > maxPomodoroWork {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": fmt.Sprintf("work_minutes must be between %d and %d", minPomodoroWork, maxPomodoroWork),
+		})
+		return
+	}
+	if body.BreakMinutes < minPomodoroBreak || body.BreakMinutes > maxPomodoroBreak {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": fmt.Sprintf("break_minutes must be between %d and %d", minPomodoroBreak, maxPomodoroBreak),
+		})
+		return
+	}
+
+	config.StartPomodoro(body.WorkMinutes, body.BreakMinutes)
+	if err := config.SaveConfig(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to save config: " + err.Error()})
+		return
+	}
+
+	cfg := config.GetConfig()
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":        "ok",
+		"phase":         cfg.Pomodoro.Phase,
+		"phase_ends_at": cfg.Pomodoro.PhaseEndsAt.Format(time.RFC3339),
+	})
+}
+
+// PomodoroStopHandler handles DELETE /api/pomodoro.
+// Returns 423 if currently in work phase (lock-down active).
+func PomodoroStopHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	cfg := config.GetConfig()
+	if cfg.IsLockedByPomodoro(time.Now()) {
+		w.WriteHeader(http.StatusLocked)
+		json.NewEncoder(w).Encode(map[string]string{"error": "cannot stop session during a work phase"})
+		return
+	}
+
+	config.ClearPomodoro()
+	if err := config.SaveConfig(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to save config: " + err.Error()})
+		return
+	}
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
@@ -442,6 +536,20 @@ func StartWebServer() {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
 	}))
+	mux.HandleFunc("/api/pomodoro/start", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		PomodoroStartHandler(w, r)
+	}))
+	mux.HandleFunc("/api/pomodoro", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		PomodoroStopHandler(w, r)
+	}))
 	mux.HandleFunc("/api/events", authMiddleware(EventsHandler))
 
 	log.Println("Web server starting on http://localhost:8040")
@@ -478,6 +586,20 @@ func StartTestWebServer() {
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}
+	}))
+	mux.HandleFunc("/api/pomodoro/start", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		PomodoroStartHandler(w, r)
+	}))
+	mux.HandleFunc("/api/pomodoro", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		PomodoroStopHandler(w, r)
 	}))
 	mux.HandleFunc("/api/events", authMiddleware(EventsHandler))
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -465,3 +465,162 @@ func BenchmarkConfigHandler(b *testing.B) {
 		handler.ServeHTTP(rr, req)
 	}
 }
+
+// ── Pomodoro handler tests ────────────────────────────────────────────────────
+
+func authRequest(method, path string, body []byte) *http.Request {
+	var req *http.Request
+	if body != nil {
+		req, _ = http.NewRequest(method, path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, _ = http.NewRequest(method, path, nil)
+	}
+	// Use the in-memory auth token
+	req.Header.Set("X-Auth-Token", config.AppConfig.Settings.AuthToken)
+	return req
+}
+
+func setWorkPhase(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { config.AppConfig.Pomodoro = nil })
+	config.AppConfig.Pomodoro = &config.PomodoroSession{
+		Phase:        "work",
+		PhaseEndsAt:  time.Now().Add(10 * time.Minute),
+		WorkMinutes:  25,
+		BreakMinutes: 5,
+	}
+}
+
+func setBreakPhase(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { config.AppConfig.Pomodoro = nil })
+	config.AppConfig.Pomodoro = &config.PomodoroSession{
+		Phase:        "break",
+		PhaseEndsAt:  time.Now().Add(5 * time.Minute),
+		WorkMinutes:  25,
+		BreakMinutes: 5,
+	}
+}
+
+func TestPomodoroStart_ValidBody(t *testing.T) {
+	t.Cleanup(func() { config.AppConfig.Pomodoro = nil })
+
+	body, _ := json.Marshal(map[string]int{"work_minutes": 25, "break_minutes": 5})
+	req := authRequest("POST", "/api/pomodoro/start", body)
+	rr := httptest.NewRecorder()
+	PomodoroStartHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var result map[string]any
+	json.NewDecoder(rr.Body).Decode(&result)
+	if result["phase"] != "work" {
+		t.Errorf("expected phase=work, got %v", result["phase"])
+	}
+}
+
+func TestPomodoroStart_WorkMinutesTooLarge(t *testing.T) {
+	body, _ := json.Marshal(map[string]int{"work_minutes": 999, "break_minutes": 5})
+	req := authRequest("POST", "/api/pomodoro/start", body)
+	rr := httptest.NewRecorder()
+	PomodoroStartHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestPomodoroStart_BreakMinutesTooLarge(t *testing.T) {
+	body, _ := json.Marshal(map[string]int{"work_minutes": 25, "break_minutes": 999})
+	req := authRequest("POST", "/api/pomodoro/start", body)
+	rr := httptest.NewRecorder()
+	PomodoroStartHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestPomodoroStop_DuringBreak_Returns200(t *testing.T) {
+	setBreakPhase(t)
+
+	req := authRequest("DELETE", "/api/pomodoro", nil)
+	rr := httptest.NewRecorder()
+	PomodoroStopHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if config.AppConfig.Pomodoro != nil {
+		t.Error("expected Pomodoro to be nil after stop")
+	}
+}
+
+func TestPomodoroStop_DuringWork_Returns423(t *testing.T) {
+	setWorkPhase(t)
+
+	req := authRequest("DELETE", "/api/pomodoro", nil)
+	rr := httptest.NewRecorder()
+	PomodoroStopHandler(rr, req)
+
+	if rr.Code != http.StatusLocked {
+		t.Errorf("expected 423, got %d", rr.Code)
+	}
+}
+
+func TestPauseHandler_LockedDuringWork_Returns423(t *testing.T) {
+	setWorkPhase(t)
+
+	body, _ := json.Marshal(map[string]int{"minutes": 15})
+	req := authRequest("POST", "/api/pause", body)
+	rr := httptest.NewRecorder()
+	PauseHandler(rr, req)
+
+	if rr.Code != http.StatusLocked {
+		t.Errorf("expected 423, got %d", rr.Code)
+	}
+}
+
+func TestStatusHandler_IncludesPomodoroState(t *testing.T) {
+	setWorkPhase(t)
+
+	req, _ := http.NewRequest("GET", "/api/status", nil)
+	rr := httptest.NewRecorder()
+	StatusHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var result map[string]any
+	json.NewDecoder(rr.Body).Decode(&result)
+	pom, ok := result["pomodoro"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected pomodoro field in status response, got %v", result)
+	}
+	if pom["phase"] != "work" {
+		t.Errorf("expected phase=work, got %v", pom["phase"])
+	}
+	if pom["locked"] != true {
+		t.Errorf("expected locked=true, got %v", pom["locked"])
+	}
+}
+
+func TestUpdateConfigHandler_LockedDuringWork_Returns423(t *testing.T) {
+	setWorkPhase(t)
+
+	cfg := config.Config{
+		Settings: config.Settings{AuthToken: config.AppConfig.Settings.AuthToken},
+		Groups:   map[string][]string{"g": {"example.com"}},
+		Rules:    []config.Rule{{Group: "g", IsActive: true, Schedules: map[string][]config.TimeSlot{}}},
+	}
+	body, _ := json.Marshal(cfg)
+	req := authRequest("POST", "/api/config/update", body)
+	rr := httptest.NewRecorder()
+	UpdateConfigHandler(rr, req)
+
+	if rr.Code != http.StatusLocked {
+		t.Errorf("expected 423, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -482,6 +482,56 @@
             font-weight: 600;
             color: #856404;
         }
+
+        /* Pomodoro panel */
+        .pomodoro-panel {
+            background: #f0f2ff;
+            border: 1.5px solid #667eea;
+            border-radius: 10px;
+            padding: 16px 18px;
+        }
+        .pomodoro-panel.work-phase { background: #fff0f0; border-color: #dc3545; }
+        .pomodoro-panel.break-phase { background: #f0fff4; border-color: #28a745; }
+        .pomodoro-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 10px;
+        }
+        .pomodoro-title { font-size: 14px; font-weight: 700; color: #343a40; }
+        .pomodoro-countdown {
+            font-size: 28px;
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+            letter-spacing: -0.5px;
+            color: #343a40;
+            margin-bottom: 6px;
+        }
+        .pomodoro-start-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 10px;
+        }
+        .pomodoro-start-row label { font-size: 12px; font-weight: 600; color: #495057; }
+        .pomodoro-start-row input[type=number] {
+            width: 54px;
+            padding: 5px 7px;
+            border: 1.5px solid #dee2e6;
+            border-radius: 6px;
+            font-size: 13px;
+            text-align: center;
+        }
+        .lock-overlay-msg {
+            background: #fff3cd;
+            border: 1px solid #ffe082;
+            border-radius: 6px;
+            padding: 8px 12px;
+            font-size: 12px;
+            color: #856404;
+            font-weight: 600;
+        }
     </style>
 </head>
 <body>
@@ -503,6 +553,8 @@
 
     <!-- STATUS TAB -->
     <div id="statusTab" class="tab-content active">
+        <div class="section" id="pomodoroSection"></div>
+
         <div class="section">
             <div class="section-header">
                 <div class="section-title">Currently Blocked</div>
@@ -987,13 +1039,16 @@ async function loadStatus() {
 
         // Blocked list
         var blocked = Object.keys(data.blocked_domains || {}).filter(function(k) { return data.blocked_domains[k]; });
+        var sessionNote = (data.pomodoro && data.pomodoro.locked)
+            ? '<p style="font-size:12px;color:#dc3545;margin:8px 0 0;font-weight:600">🔴 Focus session active — all scheduled domains are forced on</p>'
+            : '';
         if (blocked.length === 0) {
-            contentEl.innerHTML = '<div class="status-empty">✓ No domains currently blocked</div>';
+            contentEl.innerHTML = '<div class="status-empty">✓ No domains currently blocked</div>' + sessionNote;
         } else {
             contentEl.innerHTML = '<ul class="blocked-list">' +
                 blocked.map(function(d) {
                     return '<li class="blocked-item"><span class="blocked-dot"></span>' + d + '</li>';
-                }).join('') + '</ul>';
+                }).join('') + '</ul>' + sessionNote;
         }
 
         // Last evaluated
@@ -1010,6 +1065,8 @@ async function loadStatus() {
 
         // Sync manage pause panel if already unlocked
         if (manageUnlocked) renderManagePause(data);
+
+        renderPomodoroPanel(data.pomodoro || null);
 
     } catch(e) {
         contentEl.innerHTML = '<div class="banner error">Error: ' + e.message + '</div>';
@@ -1369,11 +1426,13 @@ function renderManagePause(data) {
     var el = document.getElementById('managePauseContent');
     if (data.paused && data.paused_until) {
         var until = new Date(data.paused_until);
-        var fmt   = until.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+        var fmtTime = until.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
         el.innerHTML = '<div class="pause-active-row">' +
-            '<span>⏸ Paused until ' + fmt + '</span>' +
+            '<span>⏸ Paused until ' + fmtTime + '</span>' +
             '<button class="btn-success btn-sm" onclick="resumeBlocking()">▶ Resume now</button>' +
             '</div>';
+    } else if (data.pomodoro && data.pomodoro.locked) {
+        el.innerHTML = '<div class="lock-overlay-msg">🔒 Pause controls are locked during a Pomodoro work session.</div>';
     } else {
         el.innerHTML =
             '<p style="font-size:13px;color:#6c757d;margin-bottom:12px;">Pause all blocking for a set time.</p>' +
@@ -1414,6 +1473,105 @@ async function resumeBlocking() {
         loadManagePauseState();
     } catch(e) {
         showBanner('managePauseMsg', 'error', 'Error: ' + e.message);
+    }
+}
+
+// ── Pomodoro ──────────────────────────────────────────────────────────────────
+var pomodoroCountdownInterval = null;
+
+function renderPomodoroPanel(pomodoroData) {
+    var section = document.getElementById('pomodoroSection');
+    if (!section) return;
+
+    if (pomodoroCountdownInterval) {
+        clearInterval(pomodoroCountdownInterval);
+        pomodoroCountdownInterval = null;
+    }
+
+    // Treat an expired break as no session — scheduler will clear it on its next tick
+    if (pomodoroData && pomodoroData.phase === 'break' && new Date(pomodoroData.phase_ends_at) <= Date.now()) {
+        pomodoroData = null;
+    }
+
+    if (!pomodoroData) {
+        section.innerHTML =
+            '<div class="pomodoro-panel">' +
+            '<div class="pomodoro-header"><span class="pomodoro-title">Focus Session</span></div>' +
+            '<div class="pomodoro-start-row">' +
+            '<label>Work</label>' +
+            '<input type="number" id="pomWorkMin" value="25" min="1" max="120"> min' +
+            '<label style="margin-left:8px">Break</label>' +
+            '<input type="number" id="pomBreakMin" value="5" min="1" max="60"> min' +
+            '</div>' +
+            '<button class="btn-sm btn-success" onclick="startPomodoro()">▶ Start Focus Session</button>' +
+            '</div>';
+        return;
+    }
+
+    var phase    = pomodoroData.phase;
+    var endsAt   = new Date(pomodoroData.phase_ends_at);
+    var panelCls = phase === 'work' ? 'work-phase' : 'break-phase';
+    var label    = phase === 'work' ? '🔴 Work — blocking locked' : '🟢 Break — blocking unlocked';
+    var stopBtn  = phase === 'break'
+        ? '<button class="btn-sm btn-secondary" style="font-size:12px" onclick="stopPomodoro()">Stop session</button>'
+        : '<span style="font-size:11px;color:#dc3545;font-weight:700">🔒 Locked</span>';
+
+    section.innerHTML =
+        '<div class="pomodoro-panel ' + panelCls + '">' +
+        '<div class="pomodoro-header">' +
+        '<span class="pomodoro-title">' + label + '</span>' +
+        stopBtn +
+        '</div>' +
+        '<div class="pomodoro-countdown" id="pomCountdown">–:––</div>' +
+        '<div style="font-size:12px;color:#6c757d">' +
+        pomodoroData.work_minutes + ' min work / ' + pomodoroData.break_minutes + ' min break' +
+        '</div>' +
+        '</div>';
+
+    function tick() {
+        var remaining = Math.max(0, Math.ceil((endsAt - Date.now()) / 1000));
+        var m = Math.floor(remaining / 60);
+        var s = remaining % 60;
+        var el = document.getElementById('pomCountdown');
+        if (el) el.textContent = m + ':' + String(s).padStart(2, '0');
+        if (remaining === 0) {
+            clearInterval(pomodoroCountdownInterval);
+            pomodoroCountdownInterval = null;
+            setTimeout(loadStatus, 3000);
+        }
+    }
+    tick();
+    pomodoroCountdownInterval = setInterval(tick, 1000);
+}
+
+async function startPomodoro() {
+    var workMin  = parseInt(document.getElementById('pomWorkMin').value,  10);
+    var breakMin = parseInt(document.getElementById('pomBreakMin').value, 10);
+    try {
+        var res = await fetch('/api/pomodoro/start', {
+            method: 'POST',
+            headers: {'X-Auth-Token': authToken, 'Content-Type': 'application/json'},
+            body: JSON.stringify({work_minutes: workMin, break_minutes: breakMin})
+        });
+        var data = await res.json();
+        if (!res.ok) { alert(data.error || 'Failed to start session'); return; }
+        await loadStatus();
+    } catch(e) {
+        alert('Error: ' + e.message);
+    }
+}
+
+async function stopPomodoro() {
+    try {
+        var res = await fetch('/api/pomodoro', {
+            method: 'DELETE',
+            headers: {'X-Auth-Token': authToken}
+        });
+        var data = await res.json();
+        if (!res.ok) { alert(data.error || 'Cannot stop session'); return; }
+        await loadStatus();
+    } catch(e) {
+        alert('Error: ' + e.message);
     }
 }
 


### PR DESCRIPTION
## What

Merges issues #45 (locked sessions) and #57 (Pomodoro timer) into a single unified feature. **Starting a Pomodoro work session is the only way to activate lock-down mode** — there is no standalone "lock for N minutes" button.

## Why this design

Having two separate override mechanisms (a Pomodoro timer _and_ an independent lock mode) would create composition edge cases and duplicate UI surface. Instead, the Pomodoro timer _is_ the commitment device: committing to a work session implicitly locks controls for its duration.

## How it works

### Work phase
- User sets work/break durations (defaults: 25 min / 5 min) and clicks **▶ Start Focus Session**.
- `POST /api/pomodoro/start {"work_minutes": N, "break_minutes": M}` is called.
- `EvaluateRulesAtTime` bypasses all schedule windows and forces **all `IsActive` rules on** — stricter than normal scheduling.
- `POST /api/pause` and `POST /api/config/update` return **HTTP 423 Locked** for the duration.
- Dashboard shows a red countdown, a 🔒 lock indicator, and disables pause controls in the Manage tab.
- A note appears below the blocked-domains list: _"🔴 Focus session active — all scheduled domains are forced on"_.

### Break phase
- When the work timer expires, the scheduler tick transitions to `phase="break"`, sets the break countdown, and fires a macOS notification ("Break time! Take a 5-minute break").
- Normal schedule evaluation resumes — lock is released, pause controls re-enable.
- A **Stop session** button appears (only available during break).
- `DELETE /api/pomodoro` returns 423 during work phase; succeeds during break.

### Session end
- When the break timer expires, the scheduler tick clears the session entirely and fires a notification ("Break over. Start a new focus session when ready").
- The UI detects an expired break client-side (without waiting for the scheduler tick) and immediately reverts to the start-controls panel.

## Changes

### `internal/config/config.go`
- New `PomodoroSession` struct: `Phase`, `PhaseEndsAt`, `WorkMinutes`, `BreakMinutes`.
- `Pomodoro *PomodoroSession` field added to `Config` (`omitempty` — no migration needed for existing configs).
- New methods: `IsLockedByPomodoro(t)`, `StartPomodoro(workMin, breakMin)`, `AdvancePomodoroPhase()`, `ClearPomodoro()`.

### `internal/scheduler/scheduler.go`
- `EvaluateRulesAtTime`: after the pause check, new block forces all active rules during a work phase.
- `evaluateRules` tick: detects expired phases and drives work→break and break→clear transitions, including macOS notifications.
- New `sendPomodoroNotification` helper (uses the existing `scriptExecutor` interface so tests don't invoke `osascript`).

### `internal/web/server.go`
- `POST /api/pomodoro/start` — validates bounds (work: 1–120 min, break: 1–60 min), starts session.
- `DELETE /api/pomodoro` — stops session; 423 if work phase is active.
- 423 guards added to `PauseHandler` and `UpdateConfigHandler`.
- `GET /api/status` now includes a `pomodoro` object: `phase`, `phase_ends_at`, `work_minutes`, `break_minutes`, `locked`.

### `internal/web/static/index.html`
- **Status tab**: Pomodoro panel rendered above the blocked-domains list. Shows start controls when idle; live countdown + lock state when active.
- **Manage tab**: pause buttons replaced with a lock overlay message during work phase.
- Client-side break-expiry check: expired break data is treated as no session immediately, without waiting for the scheduler tick (up to 60s gap).

### `internal/config/config_test.go` (new)
- 8 tests covering `IsLockedByPomodoro`, `StartPomodoro`, `AdvancePomodoroPhase`, `ClearPomodoro`.

### `internal/scheduler/scheduler_test.go`
- 3 new tests: work-phase forces all active rules; break-phase uses normal schedule; expired work phase falls through to schedule.

### `internal/web/server_test.go`
- 8 new tests: start/stop handlers, 423 guards on pause and config-update, status field presence.

## Gotchas

- **Tamper resistance is API-only (v1).** The API is locked during a work phase, but a user with filesystem access can still edit `config.json` directly to clear the `pomodoro` field. Hardening the config directory to be root-owned is a follow-up (noted in #45).
- **Scheduler tick granularity.** Phase transitions happen on the next 1-minute tick after expiry — up to 59s late. The UI countdown is client-side and accurate to the second; the client-side break-expiry check ensures the panel reverts immediately without waiting for the tick.
- **No auto-restart.** Each work session must be started explicitly. This is intentional — forced auto-cycling felt coercive.
- **`fmt` added to `server.go` imports** — previously unused, now needed for `Sprintf` in validation error messages.

Closes #45, closes #57