### PR TITLE
docs: AdGuard Home comparison in FAQ, README, and landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,15 @@ Config is re-read every scheduler tick — live edits take effect within 60 seco
 - DNS cache flush uses `dscacheutil -flushcache` + `killall -HUP mDNSResponder` on macOS.
 - Port 53 binding requires root; service installation requires admin privileges.
 
+## Documentation
+
+When a significant feature is added or changed, evaluate whether each of the following needs updating and propose changes — don't wait to be asked:
+
+- **`docs/index.html`** — the public landing page; update the features grid, FAQ accordion, or any comparison content that's no longer accurate
+- **`README.md`** — the primary user guide; update the "What it does" list, FAQ section, platform support table, or any affected configuration/usage sections
+- **`DESIGN.md`** — the architecture reference; update data flow, package responsibility table, or any structural decisions that changed
+- **`TROUBLESHOOTING.md`** — update or add entries for any new error conditions, config options, or operational behaviours the feature introduces
+
 ## Session Log
 
 After merging a PR or completing a significant unit of work, append a new entry to `session-log.md` in the repo root. Follow the existing format in that file:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,25 @@ Sentinel lets you set a schedule for the websites that are hardest to resist —
 
 It works across every browser and every app, not just the one you happen to have open. There's no extension to disable, no toggle to flick.
 
-## Why not a browser extension?
+## Frequently asked questions
+
+### Why not a browser extension?
 
 Browser extensions are easy to bypass — one click to disable, and kids know it. Sentinel works at the operating system level: it rewrites the system hosts file (or runs a local DNS resolver in advanced mode), so blocked sites don't load anywhere on the machine, in any browser or app. Getting around it requires admin credentials.
+
+### How does this compare to DNS blockers like AdGuard Home?
+
+AdGuard Home is a solid network-wide DNS blocker, and Sentinel can run alongside it (see [Running alongside AdGuard Home](TROUBLESHOOTING.md#running-sentinel-alongside-adguard-home-or-any-other-local-dns-service)). But its scheduling model has hard limits that make fine-grained personal productivity rules impractical — all three are tracked as open feature requests on their repo:
+
+| Capability | Sentinel | AdGuard Home |
+|---|---|---|
+| Multiple block windows per day per group | ✅ e.g. 9–12 and 2–6 | ❌ One slot per day ([#7253](https://github.com/AdguardTeam/AdGuardHome/issues/7253)) |
+| Independent schedule per domain group | ✅ Each rule is separate | ❌ One shared schedule for all ([#7146](https://github.com/AdguardTeam/AdGuardHome/issues/7146)) |
+| Custom domain groups | ✅ Any domains you choose | ❌ Predefined catalog only ([#1692](https://github.com/AdguardTeam/AdGuardHome/issues/1692)) |
+| Browser tab auto-close on block | ✅ macOS | ❌ |
+| Pre-block notifications | ✅ macOS | ❌ |
+
+AdGuard Home excels at network-wide content filtering — blocking ad trackers or adult content for every device on a home network. Sentinel is built for personal schedule enforcement on a single machine: granular enough to say "block Reddit 9–12 and 2–6, block gaming all evening, and leave streaming open on weekends." If you already run AdGuard Home, see [Running alongside AdGuard Home](TROUBLESHOOTING.md#running-sentinel-alongside-adguard-home-or-any-other-local-dns-service) to run both together.
 
 ---
 
@@ -24,6 +40,7 @@ Browser extensions are easy to bypass — one click to disable, and kids know it
 
 ## Table of contents
 
+- [FAQ](#frequently-asked-questions)
 - [What it does](#what-it-does)
 - [Platform support](#platform-support)
 - [Install](#install)
@@ -46,6 +63,7 @@ Browser extensions are easy to bypass — one click to disable, and kids know it
 ## What it does
 
 - **Set a schedule, not a willpower battle** — group the sites you want to limit (e.g. `games`, `social`) and define exactly when they're off-limits. Blocks apply the moment the clock hits your window, and lift the moment it ends.
+- **Per-group granularity, multiple windows per day** — each domain group has its own independent schedule. Stack multiple block/allow windows in the same day (e.g. block social media 9–12 and 2–6, block gaming from 8pm onward — all as separate rules).
 - **Tabs close automatically** — when a block begins, Chrome and Safari close any open tabs for blocked sites. No willpower required. (macOS)
 - **A heads-up before the block** — a native notification appears 3 minutes early so you can finish what you're doing before the sites go dark. (macOS)
 - **Live config — no restart needed** — edit the schedule file and save; changes take effect within 60 seconds.

--- a/docs/index.html
+++ b/docs/index.html
@@ -222,8 +222,8 @@
           <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
             <svg class="w-5 h-5 text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
           </div>
-          <h3 class="text-white font-semibold mb-2">Schedule-based</h3>
-          <p class="text-slate-400 text-sm leading-relaxed">Define time windows per day of the week. Blocks activate and lift to the minute — mornings, evenings, all day, whatever you need.</p>
+          <h3 class="text-white font-semibold mb-2">Schedule-based, per group</h3>
+          <p class="text-slate-400 text-sm leading-relaxed">Each domain group has its own independent schedule. Stack multiple block windows in the same day — mornings and evenings separately, or 9–12 and 2–6 on weekdays.</p>
         </div>
 
         <!-- Feature: Tab closing -->
@@ -570,6 +570,62 @@
             <div x-show="active === i" x-transition x-cloak class="px-6 pb-5 text-slate-400 text-sm leading-relaxed" x-text="item.a"></div>
           </div>
         </template>
+
+        <!-- AdGuard Home comparison — static item (needs table, x-text can't render HTML) -->
+        <div x-data="{ open: false }" class="bg-[#161616] border border-slate-800 rounded-2xl overflow-hidden">
+          <button
+            @click="open = !open"
+            class="w-full flex items-center justify-between px-6 py-5 text-left text-white font-semibold hover:text-sky-400 transition-colors"
+            :class="open ? 'text-sky-400' : ''"
+          >
+            <span>How does Sentinel compare to DNS blockers like AdGuard Home?</span>
+            <svg class="w-5 h-5 shrink-0 ml-4 transition-transform" :class="open ? 'rotate-45' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+          </button>
+          <div x-show="open" x-transition x-cloak class="px-6 pb-5 text-slate-400 text-sm leading-relaxed space-y-4">
+            <p>AdGuard Home is a solid network-wide DNS blocker, and Sentinel can run alongside it. But its scheduling model has hard limits that make fine-grained personal rules impractical:</p>
+            <div class="overflow-x-auto rounded-xl border border-slate-700">
+              <table class="w-full text-xs">
+                <thead>
+                  <tr class="bg-slate-800 text-slate-300">
+                    <th class="text-left px-4 py-2.5 font-semibold">Capability</th>
+                    <th class="px-4 py-2.5 text-center font-semibold">Sentinel</th>
+                    <th class="px-4 py-2.5 text-center font-semibold">AdGuard Home</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800">
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Multiple block windows per day per group</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ e.g. 9–12 and 2–6</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">One slot per day</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Independent schedule per domain group</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ Per rule</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">One shared schedule</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Custom domain groups</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ Any domains</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">Predefined catalog only</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Browser tab auto-close on block</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ macOS</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">✗</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Pre-block notifications</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ macOS</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">✗</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p>AdGuard Home excels at network-wide content filtering — blocking ad trackers or adult content for every device on a home network. Sentinel is built for personal schedule enforcement on a single machine: granular enough to say "block Reddit 9–12 and 2–6, block gaming all evening, and leave streaming open on weekends." The two tools serve different needs and can run alongside each other.</p>
+          </div>
+        </div>
 
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **README.md** — converts the standalone "Why not a browser extension?" section into a `## Frequently Asked Questions` section with two entries. The new AdGuard Home entry includes a markdown comparison table and links to their three open feature requests (#7253, #7146, #1692); adds a "per-group granularity, multiple windows per day" bullet to the "What it does" list; updates the TOC.
- **docs/index.html** — renames the "Schedule-based" feature card to "Schedule-based, per group" with updated copy; adds a new AdGuard Home accordion FAQ item with an HTML comparison table. Implemented as a standalone `x-data` element outside the Alpine.js loop because the existing loop uses `x-text` which strips HTML.
- **CLAUDE.md** — adds a `## Documentation` section instructing future sessions to evaluate `docs/index.html`, `README.md`, `DESIGN.md`, and `TROUBLESHOOTING.md` whenever a significant feature lands.

## Why

Research confirmed AdGuard Home has three hard scheduling limitations that Sentinel already handles correctly, all tracked as open issues on their repo:
1. One time slot per day per service (no stacking e.g. 9–12 and 2–6)
2. One shared schedule for all blocked services (can't give Reddit and YouTube independent rules)
3. Predefined service catalog only (~100 built-in services, no custom domain groups)

This is a meaningful differentiator worth surfacing to users evaluating options.

## Gotchas

- `config.json` was already modified before this branch was cut — it is intentionally excluded from this PR.
- The AdGuard Home FAQ item in `docs/index.html` is a static HTML element rather than an entry in the Alpine.js template loop. This is necessary because `x-text` (used by the loop) renders plain text only; the comparison table needs HTML. The existing loop items are untouched.

## Test plan

- [ ] Open `docs/index.html` in a browser and confirm the AdGuard Home FAQ accordion expands, the table renders correctly, and the existing FAQ items still work
- [ ] Confirm the "Schedule-based, per group" feature card reads naturally alongside adjacent cards
- [ ] Confirm README renders correctly on GitHub (table, links, TOC anchor)