### PR TITLE
fix(dns): set RecursionAvailable on all proxy responses

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -157,6 +157,14 @@ networksetup -setdnsservers Wi-Fi 127.0.0.1
 sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
 ```
 
+If `nslookup <domain>` says `Got recursion not available from 127.0.0.1, trying next server` and falls through to your backup DNS, the service is running an old binary that predates the RA-bit fix. Restart it with:
+
+```bash
+sudo ./sentinel stop && sudo ./sentinel start
+```
+
+See [§6 Restarting after a binary update](#restarting-after-a-binary-update) for why `launchctl stop/start` is not sufficient here.
+
 ### `strict` mode
 
 Strict mode = DNS mode + pf. Verify both layers:
@@ -284,6 +292,12 @@ sudo ./sentinel uninstall
 ls ~/Library/LaunchAgents/com.github.sentinel.plist  # should be gone
 launchctl list | grep sentinel                       # should be empty
 ```
+
+#### Restarting after a binary update
+
+Always use `sudo ./sentinel stop && sudo ./sentinel start` — not raw `launchctl stop/start`.
+
+`launchctl stop <label>` sends SIGTERM, but with `KeepAlive: true` in the plist launchd immediately relaunches the process. Running `launchctl start` on top of that races the KeepAlive restart and can silently no-op. The `./sentinel stop/start` path calls `launchctl unload`/`launchctl load` through the `kardianos/service` library, which fully unregisters and re-registers the job — guaranteeing the new binary is exec'd.
 
 ---
 

--- a/internal/proxy/dns.go
+++ b/internal/proxy/dns.go
@@ -40,6 +40,7 @@ func GetDNSResponse(r *dns.Msg, blockedDomainsList map[string]bool, primaryDNS, 
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Compress = false
+	m.RecursionAvailable = true
 
 	if len(r.Question) == 0 {
 		return m, nil


### PR DESCRIPTION
## What

Sets `m.RecursionAvailable = true` on every DNS response the proxy emits.

## Why

The proxy never set the RA (Recursion Available) bit, so **every** response — including blocked-domain `0.0.0.0` replies — had `RA=0`. DNS clients (macOS resolver, `nslookup`, browsers) treat `RA=0` as "this server does not perform recursion; try the next one." In `open` failure mode, `configureSystemDNS` deliberately registers the backup DNS (`1.1.1.1`) as a second OS-level server so the machine stays online if Sentinel crashes. That fallback was silently activating on every single query, routing around the block entirely.

Symptom: `nslookup discord.com` prints `Got recursion not available from 127.0.0.1, trying next server` and returns a real IP via `1.1.1.1`.

## Gotchas

- This is a one-line fix but the blast radius is large: **dns and strict mode blocking was completely ineffective** for any client that respects the RA bit (which is most of them). `hosts` mode is unaffected since it never uses the proxy.
- The bug was masked in unit tests because `GetDNSResponse` is tested in isolation — tests don't check the RA bit and don't exercise the OS fallback behaviour.
- Also documents the correct restart method after a binary update in TROUBLESHOOTING.md: `sudo ./sentinel stop && sudo ./sentinel start` (which uses `launchctl unload/load` via `kardianos/service`) rather than raw `launchctl stop/start`, which races the `KeepAlive` restart and can silently no-op.

## Test plan

- [x] `go test ./internal/proxy/...` passes
- [x] Verified live: `nslookup discord.com` returns `0.0.0.0` via `127.0.0.1` with no fallback after restart