### PR TITLE
fix(strict): end-to-end pf firewall blocking fixes

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -56,6 +56,7 @@ ipconfig /flushdns
 | Symptom | Likely cause | Where to look |
 |---|---|---|
 | Blocked sites still load | Wrong mode for your setup, or current time isn't in a block window | [§4 Mode-specific diagnostics](#4-mode-specific-diagnostics) |
+| Site blocked in DNS but loads in browser (strict mode) | CDN rotated to an IP not yet in pf rules, or pre-existing connection | [§4 strict mode — diagnosing "pf active but site still loads"](#diagnosing-pf-active-but-site-still-loads) |
 | All DNS broken (nothing resolves) | DNS-mode service stopped without restoring system DNS | [§1](#1-if-your-internet-is-broken--read-this-first) |
 | Service won't start: `permission denied` or `address already in use` on port 53 | Missing sudo, or another DNS service (AdGuard Home, dnsmasq…) holds port 53 | [§9 Port 53 errors](#port-53-errors-permission-denied--address-already-in-use) |
 | Service installed but `start` does nothing | Service framework is silent about startup failures — check logs | [§5 Reading logs](#5-reading-logs) |
@@ -167,31 +168,137 @@ See [§6 Restarting after a binary update](#restarting-after-a-binary-update) fo
 
 ### `strict` mode
 
-Strict mode = DNS mode + pf. Verify both layers:
+Strict mode adds a pf (packet filter) firewall layer on top of DNS blocking. DNS alone can be bypassed by apps that have cached a real IP; pf drops packets to those IPs at the kernel level regardless. Both layers must be working for strict mode to be effective.
+
+#### Layer 1: Verify DNS is blocking (same as `dns` mode)
 
 ```bash
-# pf enabled?
-sudo pfctl -s info | head -3
-# → Status: Enabled
+# Is the proxy returning 0.0.0.0 for blocked domains?
+dig @127.0.0.1 facebook.com +short
+# → 0.0.0.0 means DNS layer is working
 
-# Our anchor loaded?
-sudo pfctl -s Anchors
-# → sentinel should appear
-
-# What IPs are currently blocked at the firewall?
-sudo pfctl -a sentinel -t blocked_ips -T show
-
-# Preview what strict mode would produce for current blocks (no root needed)
-TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
-curl -s -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/pf-preview | jq
+# Is the OS actually using our proxy?
+networksetup -getdnsservers Wi-Fi
+# → should include 127.0.0.1
 ```
 
-If `Setup` failed (logs show `pf anchor setup failed`), the strict enforcer is degraded to DNS-only. That's intentional — better to keep blocking at the DNS layer than crash the daemon. Look in the daemon logs for the specific pfctl error.
+#### Layer 2: Verify pf is active and loaded
 
-If pf is loaded but the site still loads:
+```bash
+# Is pf enabled?
+sudo pfctl -s info | head -3
+# → "Status: Enabled" — if "Disabled", pf never started (see below)
 
-- The CDN may have rotated to a fresh IP not in your table. The next scheduler tick (within 60 s) re-resolves and reloads.
-- Existing TCP connections survive an anchor reload by default — the daemon does run `pfctl -k` to kill matching states, but a connection that was opened *before* the IP made it onto the table is unaffected. Close the browser and retry.
+# Is our anchor registered?
+sudo pfctl -s Anchors
+# → "sentinel" should appear in the list
+
+# What rules are active in our anchor?
+sudo pfctl -a sentinel -s rules
+# → Should show lines like:
+#   block drop out quick inet proto tcp from any to <__automatic_xxxxxxxx_0>
+#   block drop out quick inet proto udp from any to <__automatic_xxxxxxxx_1>
+#   block drop out quick inet6 proto tcp from any to <__automatic_xxxxxxxx_2>
+#   block drop out quick inet6 proto udp from any to <__automatic_xxxxxxxx_3>
+# macOS automatically promotes inline IP lists to internal tables (__automatic_*).
+# "No rules" means either no domains are currently blocked, or anchor loading failed.
+
+# What IPs are in the active tables?
+# (Replace the hash with what you see in "pfctl -a sentinel -s rules" above)
+sudo pfctl -a sentinel -t __automatic_<hash>_0 -T show
+# → Lists all blocked IPv4 addresses
+
+sudo pfctl -a sentinel -t __automatic_<hash>_2 -T show
+# → Lists all blocked IPv6 addresses
+```
+
+#### Checking if a specific IP is being blocked
+
+```bash
+# Resolve the current real IP for a domain (bypassing Sentinel's proxy):
+dig facebook.com @1.1.1.1 +short
+dig facebook.com @1.1.1.1 AAAA +short
+
+# Then check if that IP is in the active pf table:
+sudo pfctl -a sentinel -t __automatic_<hash>_0 -T show | grep <ip>
+# → If the IP appears: pf should be blocking it. Try:
+curl -v --max-time 5 https://facebook.com
+# → Should hang/timeout with connection dropped
+
+# → If the IP does NOT appear: pf doesn't know about this IP yet.
+# The Refresh() loop re-resolves every tick (≤60s). Wait one minute and recheck.
+# If it still doesn't appear, check the logs:
+log show --predicate 'process == "sentinel"' --last 5m | grep pf
+```
+
+#### Diagnosing "pf active but site still loads"
+
+**Step 1 — Is the IP in the table?**
+
+If the IP the browser is connecting to is not in the table, pf won't block it. CDN-backed sites (Facebook, Twitter, Instagram) rotate through dozens of IPs. The daemon re-resolves every minute via `Refresh()`, but there is a ≤60 s window where a fresh IP isn't blocked yet.
+
+```bash
+# See what IP an active connection is actually using:
+sudo pfctl -s states | grep 443 | grep <domain-ip-range>
+```
+
+**Step 2 — Check the anchor file on disk**
+
+```bash
+cat /etc/pf.anchors/sentinel
+# Should look like:
+#   block drop out quick inet proto {tcp udp} from any to { 1.2.3.4 5.6.7.8 }
+#   block drop out quick inet6 proto {tcp udp} from any to { 2001:db8::1 }
+# If it says "# no IPs to block", either no domains are scheduled or IP resolution failed.
+```
+
+**Step 3 — Check that pf.conf has our anchor**
+
+```bash
+grep -A3 "sentinel" /etc/pf.conf
+# Should show:
+#   # sentinel:begin
+#   anchor "sentinel"
+#   load anchor "sentinel" from "/etc/pf.anchors/sentinel"
+#   # sentinel:end
+# If absent, the anchor was never injected — check setup logs.
+```
+
+**Step 4 — Verify IP resolution is working**
+
+Strict mode resolves IPs using `backup_dns` as a fallback when `primary_dns` (usually `127.0.0.1:53`, Sentinel's own proxy) returns `0.0.0.0` for blocked domains. If `backup_dns` is unset or wrong, no IPs will be resolved.
+
+```bash
+# What does the config say?
+curl -s http://localhost:8040/api/config | jq '.settings | {primary_dns, backup_dns}'
+
+# Manually resolve using backup_dns to see what IPs you expect:
+dig facebook.com @1.1.1.1 +short      # replace 1.1.1.1 with your backup_dns host
+dig facebook.com @1.1.1.1 AAAA +short
+
+# Check log for IP resolution issues:
+log show --predicate 'process == "sentinel"' --last 5m | grep "pf:"
+# "pf: no IPs resolved" → backup_dns is failing or unreachable
+# "pf: load anchor: ... syntax error" → anchor file has malformed rules
+```
+
+**Step 5 — Re-activate manually to force a reload**
+
+If you need to force an immediate pf refresh without waiting for the next tick, restart the service:
+
+```bash
+sudo ./sentinel stop && sudo ./sentinel start
+# Then wait ~5s for the first tick, and verify:
+sudo pfctl -a sentinel -s rules
+```
+
+#### Known pf limitations
+
+- **CDN IP rotation**: Sites like Facebook serve from large IP pools and rotate constantly. There is always a ≤60 s window between a new IP appearing and Sentinel blocking it. Closing and reopening the browser tab forces a fresh connection through the updated rules.
+- **Pre-existing connections**: `pfctl -k` is run to kill existing states when a block activates, but connections opened before Sentinel started aren't guaranteed to be killed. Restart the browser if a site that should be blocked remains reachable.
+- **IPv6 must be covered**: Browsers will prefer IPv6 if available. If only IPv4 IPs are in the anchor, a site reachable via IPv6 will bypass the block. Sentinel resolves both A and AAAA records — verify both tables are populated.
+
+If `Setup` failed (logs show `pf anchor setup failed`), the strict enforcer degrades to DNS-only. That's intentional — better to keep blocking at the DNS layer than crash the daemon. Look in the daemon logs for the specific pfctl error, then run `sudo ./sentinel clean --yes && sudo ./sentinel install && sudo ./sentinel start` to reset.
 
 ### macOS AppleScript path
 

--- a/internal/enforcer/dns.go
+++ b/internal/enforcer/dns.go
@@ -26,6 +26,8 @@ func NewDNSEnforcer(cfg config.Config) *DNSEnforcer {
 	return &DNSEnforcer{cfg: cfg, blocked: make(map[string]bool)}
 }
 
+func (e *DNSEnforcer) Refresh() {}
+
 func (e *DNSEnforcer) Setup() error {
 	proxy.UpdateBlockedDomains(make(map[string]bool))
 	if runtime.GOOS == "darwin" {
@@ -112,7 +114,7 @@ func detectSystemDNS() string {
 			for _, srv := range strings.Split(strings.TrimSpace(string(dnsOut)), "\n") {
 				srv = strings.TrimSpace(srv)
 				if net.ParseIP(srv) != nil && !strings.HasPrefix(srv, "127.") {
-					return srv + ":53"
+					return hostPort(srv, "53")
 				}
 			}
 		}
@@ -128,12 +130,21 @@ func detectSystemDNS() string {
 			if len(parts) == 2 {
 				srv := strings.TrimSpace(parts[1])
 				if net.ParseIP(srv) != nil && !strings.HasPrefix(srv, "127.") {
-					return srv + ":53"
+					return hostPort(srv, "53")
 				}
 			}
 		}
 	}
 	return ""
+}
+
+// hostPort formats a host+port string, wrapping IPv6 addresses in brackets
+// so the result is valid for net.Dial ("host:port" or "[ipv6]:port").
+func hostPort(host, port string) string {
+	if strings.Contains(host, ":") {
+		return "[" + host + "]:" + port
+	}
+	return host + ":" + port
 }
 
 func (e *DNSEnforcer) Teardown() error {

--- a/internal/enforcer/enforcer.go
+++ b/internal/enforcer/enforcer.go
@@ -17,12 +17,15 @@ import (
 // Enforcer is implemented by every blocking backend.
 // Setup/Teardown are called once at service start/stop.
 // Activate/Deactivate are called with domain-level diffs each scheduler tick.
+// Refresh is called every tick when blocks are active; strict mode uses it to
+// re-resolve CDN IPs that rotate between Activate calls.
 type Enforcer interface {
 	Setup() error
 	Teardown() error
 	Activate(domains []string) error
 	Deactivate(domains []string) error
 	DeactivateAll() error
+	Refresh()
 }
 
 // New returns the Enforcer matching the config's enforcement_mode.

--- a/internal/enforcer/hosts.go
+++ b/internal/enforcer/hosts.go
@@ -60,6 +60,8 @@ func (e *HostsEnforcer) Setup() error {
 	return nil
 }
 
+func (e *HostsEnforcer) Refresh() {}
+
 func (e *HostsEnforcer) Teardown() error {
 	return e.DeactivateAll()
 }

--- a/internal/enforcer/strict.go
+++ b/internal/enforcer/strict.go
@@ -50,7 +50,7 @@ func (e *StrictEnforcer) Activate(domains []string) error {
 	}
 	e.dns.mu.Unlock()
 	pf.DeactivateBlock()
-	pf.ActivateBlock(allDomains, e.cfg.Settings.PrimaryDNS)
+	pf.ActivateBlock(allDomains, e.cfg.Settings.PrimaryDNS, e.cfg.Settings.BackupDNS)
 	return nil
 }
 
@@ -67,7 +67,7 @@ func (e *StrictEnforcer) Deactivate(domains []string) error {
 	}
 	e.dns.mu.Unlock()
 	if len(remaining) > 0 {
-		pf.ActivateBlock(remaining, e.cfg.Settings.PrimaryDNS)
+		pf.ActivateBlock(remaining, e.cfg.Settings.PrimaryDNS, e.cfg.Settings.BackupDNS)
 	}
 	return nil
 }
@@ -76,4 +76,22 @@ func (e *StrictEnforcer) DeactivateAll() error {
 	e.dns.DeactivateAll()
 	pf.DeactivateBlock()
 	return nil
+}
+
+// Refresh re-resolves all currently blocked domains and reloads the pf anchor.
+// Called every scheduler tick so CDN IP rotations are picked up without waiting
+// for a domain set change to trigger Activate.
+func (e *StrictEnforcer) Refresh() {
+	e.dns.mu.Lock()
+	domains := make([]string, 0, len(e.dns.blocked))
+	for d := range e.dns.blocked {
+		domains = append(domains, d)
+	}
+	e.dns.mu.Unlock()
+
+	if len(domains) == 0 {
+		return
+	}
+	pf.DeactivateBlock()
+	pf.ActivateBlock(domains, e.cfg.Settings.PrimaryDNS, e.cfg.Settings.BackupDNS)
 }

--- a/internal/pf/pf.go
+++ b/internal/pf/pf.go
@@ -7,9 +7,9 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -63,39 +63,47 @@ func ResolveDomainIPs(domain, dnsServer string) []string {
 		for _, ans := range r.Answer {
 			switch rr := ans.(type) {
 			case *dns.A:
-				add(rr.A.String())
+				// Skip 0.0.0.0 — Sentinel's own blocked-domain response.
+				if !rr.A.IsUnspecified() {
+					add(rr.A.String())
+				}
 			case *dns.AAAA:
-				add(rr.AAAA.String())
+				// Skip :: — Sentinel's own blocked-domain response.
+				if !rr.AAAA.IsUnspecified() {
+					add(rr.AAAA.String())
+				}
 			}
 		}
 	}
 
-	if len(ips) == 0 {
-		addrs, err := net.LookupHost(domain)
-		if err == nil {
-			for _, a := range addrs {
-				add(a)
-			}
-		}
-	}
 
 	return ips
 }
 
 // GenerateAnchorContent builds the pfctl anchor rules for the given IP list.
 // Pure function — no I/O, safe to call without root.
+// IPs are inlined directly into block rules (one rule per address family) rather than
+// using a table declaration, because macOS pfctl rejects table declarations in
+// anchor files loaded via "pfctl -a anchor -f file".
 func GenerateAnchorContent(ips []string) string {
 	if len(ips) == 0 {
 		return "# no IPs to block\n"
 	}
-
-	var sb strings.Builder
-	sb.WriteString("table <blocked_ips> persist {\n")
+	var v4, v6 []string
 	for _, ip := range ips {
-		sb.WriteString("  " + ip + "\n")
+		if strings.Contains(ip, ":") {
+			v6 = append(v6, ip)
+		} else {
+			v4 = append(v4, ip)
+		}
 	}
-	sb.WriteString("}\n")
-	sb.WriteString("block drop out quick proto {tcp udp} from any to <blocked_ips>\n")
+	var sb strings.Builder
+	if len(v4) > 0 {
+		sb.WriteString("block drop out quick inet proto {tcp udp} from any to { " + strings.Join(v4, " ") + " }\n")
+	}
+	if len(v6) > 0 {
+		sb.WriteString("block drop out quick inet6 proto {tcp udp} from any to { " + strings.Join(v6, " ") + " }\n")
+	}
 	return sb.String()
 }
 
@@ -185,7 +193,9 @@ func RemoveAnchor() {
 }
 
 // ActivateBlock resolves IPs for the given domains, writes the anchor file, and loads it into pf.
-func ActivateBlock(domains []string, primaryDNS string) {
+// backupDNS is tried per-domain when primaryDNS returns no usable IPs (e.g. when primaryDNS is
+// the local proxy and the domain is already DNS-blocked).
+func ActivateBlock(domains []string, primaryDNS, backupDNS string) {
 	if runtime.GOOS != "darwin" || len(domains) == 0 {
 		return
 	}
@@ -196,6 +206,9 @@ func ActivateBlock(domains []string, primaryDNS string) {
 
 	for _, d := range domains {
 		ips := ResolveDomainIPs(d, primaryDNS)
+		if len(ips) == 0 && backupDNS != "" && backupDNS != primaryDNS {
+			ips = ResolveDomainIPs(d, backupDNS)
+		}
 		resolved[d] = ips
 		for _, ip := range ips {
 			if !seen[ip] {
@@ -217,9 +230,14 @@ func ActivateBlock(domains []string, primaryDNS string) {
 	}
 
 	// Load the anchor into the running pf.
+	// macOS pfctl exits 1 for "Use of -f option" and ALTQ warnings even on success;
+	// only treat it as a real failure when the output contains an actual error.
 	if out, err := exec.Command("pfctl", "-a", anchorName, "-f", anchorFile).CombinedOutput(); err != nil {
-		log.Printf("pf: load anchor: %v: %s", err, strings.TrimSpace(string(out)))
-		return
+		msg := strings.TrimSpace(string(out))
+		if strings.Contains(msg, "syntax error") || strings.Contains(msg, "rules not loaded") {
+			log.Printf("pf: load anchor: %v: %s", err, msg)
+			return
+		}
 	}
 
 	// Kill existing outbound states to those IPs so cached connections are severed.
@@ -230,18 +248,21 @@ func ActivateBlock(domains []string, primaryDNS string) {
 	log.Printf("pf: activated block for %d domains (%d IPs)", len(domains), len(allIPs))
 }
 
-// DeactivateBlock flushes all IPs from the pf block table.
+// DeactivateBlock clears the sentinel anchor by loading an empty rule set.
 func DeactivateBlock() {
 	if runtime.GOOS != "darwin" {
 		return
 	}
 
-	out, err := exec.Command("pfctl", "-a", anchorName, "-t", "blocked_ips", "-T", "flush").CombinedOutput()
-	if err != nil {
-		// Table may not exist yet — that's fine on first run.
+	empty := []byte("# no IPs to block\n")
+	if err := os.WriteFile(anchorFile, empty, 0644); err != nil {
+		log.Printf("pf: clear anchor file: %v", err)
+		return
+	}
+	if out, err := exec.Command("pfctl", "-a", anchorName, "-f", anchorFile).CombinedOutput(); err != nil {
 		msg := strings.TrimSpace(string(out))
-		if !strings.Contains(msg, "No such table") && !strings.Contains(msg, "No ALTQ support") {
-			log.Printf("pf: flush table: %v: %s", err, msg)
+		if strings.Contains(msg, "syntax error") || strings.Contains(msg, "rules not loaded") {
+			log.Printf("pf: deactivate reload: %v: %s", err, msg)
 		}
 	}
 }
@@ -308,7 +329,7 @@ func stripPFConf() error {
 
 // atomicWrite writes data to path via a temp file + rename.
 func atomicWrite(path string, data []byte, perm os.FileMode) error {
-	dir := "/"
+	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, ".pf-tmp-*")
 	if err != nil {
 		return err

--- a/internal/pf/pf_test.go
+++ b/internal/pf/pf_test.go
@@ -17,16 +17,19 @@ func TestGenerateAnchorContent_withIPs(t *testing.T) {
 	ips := []string{"1.2.3.4", "5.6.7.8", "2001:db8::1"}
 	got := GenerateAnchorContent(ips)
 
-	if !strings.Contains(got, "table <blocked_ips>") {
-		t.Error("missing table declaration")
-	}
 	for _, ip := range ips {
 		if !strings.Contains(got, ip) {
 			t.Errorf("missing IP %s in anchor content", ip)
 		}
 	}
-	if !strings.Contains(got, "block drop out quick proto {tcp udp}") {
-		t.Error("missing block rule")
+	if !strings.Contains(got, "block drop out quick inet proto {tcp udp}") {
+		t.Error("missing inet block rule")
+	}
+	if !strings.Contains(got, "block drop out quick inet6 proto {tcp udp}") {
+		t.Error("missing inet6 block rule")
+	}
+	if strings.Contains(got, "table") {
+		t.Error("anchor content must not use table declarations (unsupported on macOS)")
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -43,15 +43,16 @@ type MacOSScriptExecutor struct{}
 
 func (e *MacOSScriptExecutor) ExecuteScript(script string) error {
 	if err := runAsMacUser(script); err != nil {
-		log.Printf("AppleScript execution failed: %v", err)
+		// "Application isn't running" (-600) is expected when Safari/Chrome isn't open — not worth logging.
+		if !strings.Contains(err.Error(), "isn't running") && !strings.Contains(err.Error(), "(-600)") {
+			log.Printf("AppleScript execution failed: %v", err)
+		}
 		return err
 	}
 	return nil
 }
 
-func (e *MacOSScriptExecutor) LogScript(script string) {
-	log.Printf("AppleScript generated:\n%s", script)
-}
+func (e *MacOSScriptExecutor) LogScript(script string) {}
 
 // TestScriptExecutor logs scripts instead of executing them
 type TestScriptExecutor struct {
@@ -443,6 +444,12 @@ func evaluateRules() {
 			if err := activeEnforcer.Deactivate(newlyUnblocked); err != nil {
 				log.Printf("scheduler: deactivate failed: %v", err)
 			}
+		}
+		// Refresh pf IPs every tick even when the domain set is unchanged.
+		// CDN-backed sites rotate IPs between Activate calls; Refresh re-resolves
+		// them so the firewall rules stay current. No-op for dns/hosts mode.
+		if len(newlyBlocked) == 0 && len(activeBlocks) > 0 {
+			activeEnforcer.Refresh()
 		}
 	}
 

--- a/session-log.md
+++ b/session-log.md
@@ -320,3 +320,54 @@ Development history for this project, captured from Claude Code sessions. Ordere
 ---
 
 *Generated from Claude Code session history on 2026-05-01.*
+
+---
+
+## May 2 — Session 20: Strict Mode pf Firewall — End-to-End Fixes
+**Session ID:** `45e8b2f6` · **PR:** #76 (fix/strict-mode-pf)
+
+**Opening prompt:**
+> "debugging help needed. DNS mode domains are not blocked... nslookup discord.com shows getting recursion not available from 127.0.0.1, trying next server..."
+
+**What happened:**
+
+This session started with a DNS-mode bug and expanded into a multi-turn deep dive on why strict mode pf blocking wasn't working end-to-end. What looked like a single problem turned out to be five independent bugs stacked on top of each other, each masking the next.
+
+**Bug 1 — DNS proxy not setting the RA bit (root cause of initial report)**
+
+`nslookup` was saying `Got recursion not available from 127.0.0.1, trying next server` and falling through to the backup DNS, so blocked sites were still resolving. The `GetDNSResponse` function in `internal/proxy/dns.go` was building reply messages without setting `m.RecursionAvailable = true`. Any stub resolver that checks the RA bit treats RA=0 as "server doesn't recurse" and queries the next configured server. Fix: one line. This was shipped in a separate PR (#75, v0.1.12) immediately.
+
+**Bug 2 — AppleScript log noise**
+
+While reviewing logs to diagnose strict mode, the user noticed `MacOSScriptExecutor.LogScript` was logging the full AppleScript text every scheduler tick (every 60 seconds), and `ExecuteScript` was logging "application isn't running" (-600) errors every minute because Safari wasn't open. Both are expected conditions that should be silent. Fixed: `LogScript` changed to no-op, `-600` errors suppressed in `ExecuteScript`.
+
+**Bug 3 — `atomicWrite` using read-only root as temp directory**
+
+Logs showed: `pf: update pf.conf: open /.pf-tmp-3309907590: read-only file system`. The `atomicWrite` helper in `internal/pf/pf.go` had `dir := "/"` hardcoded as the temp file location. macOS uses a sealed read-only root volume; temp files cannot be created there. Fix: changed to `dir := filepath.Dir(path)` so the temp file lives in the same directory as the target file (`/etc/`), which is writable.
+
+**Bug 4 — `0.0.0.0` / `::` poisoning the pf table**
+
+After fixing atomicWrite, pf activated but logs showed `pf: no IPs resolved for domains`. On closer inspection, the anchor file was being written with `0.0.0.0` and `::` — Sentinel's own blocked-domain responses. `ResolveDomainIPs` was querying `primaryDNS`, which is `127.0.0.1:53` (Sentinel's proxy). When a domain is actively blocked, the proxy returns `0.0.0.0`/`::`. The old code added those addresses to the pf table, then filtered them as a separate step; the `net.LookupHost` fallback also went through the system resolver (still pointing at `127.0.0.1`), producing the same poisoned response. Fix: filter unspecified addresses (`rr.A.IsUnspecified()`, `rr.AAAA.IsUnspecified()`) directly in `ResolveDomainIPs`, remove the `net.LookupHost` fallback entirely, and add a `backupDNS string` parameter to `ActivateBlock` so strict mode can re-resolve using `1.1.1.1` or the configured backup DNS when primary returns nothing.
+
+**Bug 5 — IPv6 `primary_dns` with malformed host:port**
+
+After adding the `backupDNS` fallback, logs showed `pf: no IPs resolved` again. Checking the config, `primary_dns` was `2001:558:feed::1:53` — an ISP-assigned IPv6 DNS server. Go's `net.Dial` requires IPv6 addresses to be bracketed: `[2001:558:feed::1]:53`. The unbracketed form parses ambiguously (the last `:53` could be part of the IPv6 address). `detectSystemDNS()` in `internal/enforcer/dns.go` was formatting all detected DNS addresses as `ip + ":53"`, which produces a malformed address for IPv6. Fix: added a `hostPort(host, port string) string` helper that wraps IPv6 in brackets, used for all DNS address formatting in that file.
+
+**Bug 6 — pf anchor syntax error (table declarations not allowed in anchor files)**
+
+After real IPs were finally being resolved, the anchor file was still failing to load: `/etc/pf.anchors/sentinel:1: syntax error`. The original `GenerateAnchorContent` used `table <blocked_ips> persist { ... }` syntax, which modern macOS pfctl accepts in `/etc/pf.conf` but rejects in anchor files loaded via `pfctl -a anchor -f file`. The workaround: inline the IPs directly in the block rules, split by address family (inet / inet6). macOS pfctl then automatically promotes the inline lists to internal `__automatic_*` tables. Fix: rewrote `GenerateAnchorContent` to produce `block drop out quick inet proto {tcp udp} from any to { ip1 ip2 }` and `block drop out quick inet6 proto {tcp udp} from any to { ip6_1 ip6_2 }`. Also rewrote `DeactivateBlock` — the old implementation flushed a named table that no longer exists; new version writes `# no IPs to block` to the anchor file and reloads the anchor.
+
+**Bug 7 — CDN IP rotation: IPs go stale between Activate calls**
+
+After all six bugs were fixed, `discord.com` was blocked correctly but `facebook.com` was not, even though `nslookup facebook.com` returned `0.0.0.0`. Investigation: `pfctl -a sentinel -t __automatic_*_0 -T show` showed the IPs from when the block was activated; `dig facebook.com @1.1.1.1` returned a different IP (`57.144.22.1`) not in the table. Facebook serves from a large CDN and rotates IPs constantly. The comment in `StrictEnforcer.Activate` said "re-resolve ALL currently blocked domains on every activation", but `Activate` is only called by the scheduler when the *set of blocked domains changes* — during a steady-state block window, `Activate` is never called again, so IPs go stale indefinitely. Fix: added a `Refresh()` method to the `Enforcer` interface. `StrictEnforcer.Refresh()` re-resolves all currently blocked domains and reloads the pf anchor. `DNSEnforcer.Refresh()` and `HostsEnforcer.Refresh()` are no-ops. The scheduler calls `activeEnforcer.Refresh()` every tick when blocks are active and no domains changed.
+
+**Verification methodology documented**
+
+Added a comprehensive strict mode diagnostics section to `TROUBLESHOOTING.md`, including:
+- The correct `pfctl` command sequence to verify each layer (pf enabled → anchor registered → rules loaded → IPs in `__automatic_*` tables)
+- How to correlate the current real IP of a CDN site with what's in the tables
+- Explanation of why `pfctl -a sentinel -t blocked_ips -T show` (the old command) no longer works
+- The chicken-and-egg issue with `primaryDNS` pointing at the proxy and why `backupDNS` is required
+- Known limitations: ≤60 s CDN gap, pre-existing connections, IPv6 must be covered
+
+**Wrap-up:** Six root-cause bugs in strict mode pf blocking fixed across `internal/pf/pf.go`, `internal/enforcer/` (all three backends), and `internal/scheduler/scheduler.go`. Strict mode now correctly resolves, loads, and periodically refreshes IP-level firewall rules. Testing confirmed discord.com blocked; facebook CDN rotation fix in place but requires further testing to confirm. Raised as PR #76.


### PR DESCRIPTION
## What

Seven root-cause bugs that collectively prevented strict mode from doing any IP-level firewall blocking. Each masked the next — fixing one revealed the next failure in the chain.

## Why each change was made

### 1. `atomicWrite`: temp dir was `/` (read-only on macOS)

`pf.go` had `dir := "/"` hardcoded as the temp file location for atomic writes. macOS uses a sealed, read-only root volume (since Big Sur). Symptom in logs: `pf: update pf.conf: open /.pf-tmp-3309907590: read-only file system`. Fixed to `filepath.Dir(path)` so temp files are created in `/etc/` (same directory as the target file, which is writable).

### 2. `ResolveDomainIPs`: included `0.0.0.0`/`::` from the proxy

When a domain is DNS-blocked, Sentinel's own proxy returns `0.0.0.0` (A) and `::` (AAAA). `primaryDNS` is `127.0.0.1:53` (the proxy itself), so resolving blocked domains against it yielded only unspecified addresses. Those were being added to the pf table, where they're harmless but mask the real problem: no real IPs were ever resolved. The old `net.LookupHost` fallback also went through the system resolver (still pointed at `127.0.0.1`), producing the same result. Fix: filter `rr.A.IsUnspecified()` / `rr.AAAA.IsUnspecified()`, remove the `net.LookupHost` fallback.

### 3. `ActivateBlock`: no fallback DNS for blocked domains

With unspecified addresses filtered, resolution now correctly returns nothing — which causes `ActivateBlock` to skip (`pf: no IPs resolved`). This is the chicken-and-egg: the domain is already DNS-blocked, so the proxy can't be used to look up its real IPs. Fix: added `backupDNS string` parameter to `ActivateBlock`. When `primaryDNS` yields no IPs, the function retries with `backupDNS` (e.g. `1.1.1.1:53`). `StrictEnforcer` passes `cfg.Settings.BackupDNS` for both its `Activate` and `Refresh` calls.

### 4. `detectSystemDNS`: IPv6 DNS formatted as `ip:port` instead of `[ip]:port`

If the detected upstream DNS was IPv6 (e.g. `2001:558:feed::1`), it was formatted as `2001:558:feed::1:53` — an ambiguous string that Go's `net.Dial` can't parse. All DNS exchanges silently returned errors. Fix: added `hostPort(host, port string)` helper that wraps IPv6 in brackets. Used in both code paths in `detectSystemDNS`.

### 5. `GenerateAnchorContent`: used table declarations, which macOS pfctl rejects in anchor files

The old implementation used `table <blocked_ips> persist { ... }` syntax. `pfctl` accepts this in `/etc/pf.conf` but rejects it in anchor files loaded via `pfctl -a anchor -f file`, producing: `/etc/pf.anchors/sentinel:1: syntax error`. Fix: inline IPs directly in block rules, split by address family:
```
block drop out quick inet proto {tcp udp} from any to { 1.2.3.4 5.6.7.8 }
block drop out quick inet6 proto {tcp udp} from any to { 2001:db8::1 }
```
macOS pfctl automatically promotes inline IP lists to internal `__automatic_*` tables. `DeactivateBlock` was also rewritten — the old version tried to flush a named table that no longer exists; the new version writes `# no IPs to block` to the anchor file and reloads it.

### 6. AppleScript log noise

`LogScript` was logging the full AppleScript body every scheduler tick (every 60 s). `ExecuteScript` was logging `-600` "Application isn't running" errors every minute when Safari wasn't open. Both are normal conditions that should be silent.

### 7. CDN IP rotation: `Refresh()` on every tick

`StrictEnforcer.Activate` re-resolves all blocked domains, but `Activate` is only called when the *set of blocked domains changes*. During a steady-state block window (same domains blocked for an hour), `Activate` is never called and IPs go stale. CDN-backed sites like Facebook serve from large IP pools and rotate constantly. The symptom: `nslookup facebook.com` returns `0.0.0.0` (DNS layer working), but the browser loads the page because it's connecting to a fresh IP not yet in the pf table.

Fix: added `Refresh()` to the `Enforcer` interface. `StrictEnforcer.Refresh()` re-resolves all currently blocked domains and reloads the pf anchor on every scheduler tick when blocks are active and no domain set change occurred. `DNSEnforcer.Refresh()` and `HostsEnforcer.Refresh()` are no-ops.

## Gotchas

- **`pfctl -a sentinel -t blocked_ips -T show` no longer works.** Since IPs are now inlined in block rules (not a named table), macOS creates `__automatic_<hash>_N` tables instead. To inspect current blocked IPs: `sudo pfctl -a sentinel -s rules` (shows table names), then `sudo pfctl -a sentinel -t __automatic_<hash>_0 -T show`.
- **`backupDNS` is required for strict mode.** If `backup_dns` is unset or incorrect, no IPs will ever be resolved and pf will remain empty.
- **Up to 60 s CDN gap remains.** There is always a window between a CDN rotating to a new IP and the next `Refresh()` tick loading it. This is unavoidable without continuous DNS polling.
- The `feat/issue-53-daily-quota` branch needs to be rebased or merged with this branch to pick up these fixes before that feature PR is raised.

## Testing

```bash
# Verify each layer after restart:
sudo pfctl -s info | head -3           # Status: Enabled
sudo pfctl -s Anchors                  # sentinel listed
sudo pfctl -a sentinel -s rules        # block rules with __automatic_* tables
sudo pfctl -a sentinel -t __automatic_<hash>_0 -T show  # real IPs present

# End-to-end test:
curl -v --max-time 5 https://discord.com    # should time out / connection dropped
dig discord.com @127.0.0.1 +short          # should return 0.0.0.0
```

All tests pass: `go test ./...`