### PR TITLE
fix(scheduler): make per-tick tab closer actually work (issue #81 round 2)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -112,89 +112,109 @@ func (g *MacOSAppleScriptGenerator) GenerateCloseTabsScript(domains []string) st
 		set domainsToBlock to %s
 		set closedCount to 0
 
-		if application "Google Chrome" is running then
-			tell application "Google Chrome"
-				set tabsToClose to {}
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToBlock
-							if tabURL contains d then
-								set end of tabsToClose to t
-								exit repeat
-							end if
+		try
+			if application "Google Chrome" is running then
+				tell application "Google Chrome"
+					set tabsToClose to {}
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToBlock
+								if tabURL contains d then
+									set end of tabsToClose to t
+									exit repeat
+								end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-				set closedCount to closedCount + (count of tabsToClose)
-				repeat with t in tabsToClose
-					close t
-				end repeat
-			end tell
-		end if
+					set toCloseCount to count of tabsToClose
+					repeat with i from toCloseCount to 1 by -1
+						try
+							close item i of tabsToClose
+							set closedCount to closedCount + 1
+						end try
+					end repeat
+				end tell
+			end if
+		end try
 
-		if application "Safari" is running then
-			tell application "Safari"
-				set tabsToClose to {}
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToBlock
-							if tabURL contains d then
-								set end of tabsToClose to t
-								exit repeat
-							end if
+		try
+			if application "Safari" is running then
+				tell application "Safari"
+					set tabsToClose to {}
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToBlock
+								if tabURL contains d then
+									set end of tabsToClose to t
+									exit repeat
+								end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-				set closedCount to closedCount + (count of tabsToClose)
-				repeat with t in tabsToClose
-					close t
-				end repeat
-			end tell
-		end if
+					set toCloseCount to count of tabsToClose
+					repeat with i from toCloseCount to 1 by -1
+						try
+							close item i of tabsToClose
+							set closedCount to closedCount + 1
+						end try
+					end repeat
+				end tell
+			end if
+		end try
 
-		if application "Arc" is running then
-			tell application "Arc"
-				set tabsToClose to {}
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToBlock
-							if tabURL contains d then
-								set end of tabsToClose to t
-								exit repeat
-							end if
+		try
+			if application "Arc" is running then
+				tell application "Arc"
+					set tabsToClose to {}
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToBlock
+								if tabURL contains d then
+									set end of tabsToClose to t
+									exit repeat
+								end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-				set closedCount to closedCount + (count of tabsToClose)
-				repeat with t in tabsToClose
-					close t
-				end repeat
-			end tell
-		end if
+					set toCloseCount to count of tabsToClose
+					repeat with i from toCloseCount to 1 by -1
+						try
+							close item i of tabsToClose
+							set closedCount to closedCount + 1
+						end try
+					end repeat
+				end tell
+			end if
+		end try
 
-		if application "Brave Browser" is running then
-			tell application "Brave Browser"
-				set tabsToClose to {}
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToBlock
-							if tabURL contains d then
-								set end of tabsToClose to t
-								exit repeat
-							end if
+		try
+			if application "Brave Browser" is running then
+				tell application "Brave Browser"
+					set tabsToClose to {}
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToBlock
+								if tabURL contains d then
+									set end of tabsToClose to t
+									exit repeat
+								end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-				set closedCount to closedCount + (count of tabsToClose)
-				repeat with t in tabsToClose
-					close t
-				end repeat
-			end tell
-		end if
+					set toCloseCount to count of tabsToClose
+					repeat with i from toCloseCount to 1 by -1
+						try
+							close item i of tabsToClose
+							set closedCount to closedCount + 1
+						end try
+					end repeat
+				end tell
+			end if
+		end try
 
 		if closedCount > 0 then
 			display notification %s with title "Sentinel" subtitle "Tab Closed"
@@ -630,6 +650,44 @@ func runAsMacUser(scriptContent string) error {
 	return nil
 }
 
+// runOsaScriptCapture runs an AppleScript via osascript and returns stdout. It
+// uses the same root → console-user shell-out as runAsMacUser: when the daemon
+// is launchd-managed and running as root, the script is dispatched via
+// `su - <console user> -c osascript ...` so it inherits a GUI session and can
+// talk to Chrome / Safari / Arc / Brave. Without this, root-context osascript
+// calls return exit 1 with no GUI session attached and probing for open tabs
+// silently fails (regression behind issue #81's per-tick close path).
+//
+// Uses a separate tmpfile from runAsMacUser so concurrent close + probe paths
+// in the same tick can't clobber each other's script content.
+func runOsaScriptCapture(scriptContent string) (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", nil
+	}
+
+	scriptPath := "/tmp/df_probe.scpt"
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
+		return "", fmt.Errorf("write script: %w", err)
+	}
+
+	user := getMacUser()
+	var cmd *exec.Cmd
+	if user == "" || os.Getuid() != 0 {
+		cmd = exec.Command("osascript", scriptPath)
+	} else {
+		cmd = exec.Command("su", "-", user, "-c", "osascript "+scriptPath)
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("osascript exit %d: %s", exitErr.ExitCode(), strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("osascript: %w", err)
+	}
+	return string(out), nil
+}
+
 func getOpenBrowserDomains(domains []string) []string {
 	if runtime.GOOS != "darwin" || len(domains) == 0 {
 		return nil
@@ -645,73 +703,81 @@ func getOpenBrowserDomains(domains []string) []string {
 		set domainsToCheck to %s
 		set matchedDomains to {}
 
-		if application "Google Chrome" is running then
-			tell application "Google Chrome"
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToCheck
-							if tabURL contains d then
-								if matchedDomains does not contain d then
-									set end of matchedDomains to d
+		try
+			if application "Google Chrome" is running then
+				tell application "Google Chrome"
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToCheck
+								if tabURL contains d then
+									if matchedDomains does not contain d then
+										set end of matchedDomains to d
+									end if
 								end if
-							end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-			end tell
-		end if
+				end tell
+			end if
+		end try
 
-		if application "Safari" is running then
-			tell application "Safari"
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToCheck
-							if tabURL contains d then
-								if matchedDomains does not contain d then
-									set end of matchedDomains to d
+		try
+			if application "Safari" is running then
+				tell application "Safari"
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToCheck
+								if tabURL contains d then
+									if matchedDomains does not contain d then
+										set end of matchedDomains to d
+									end if
 								end if
-							end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-			end tell
-		end if
+				end tell
+			end if
+		end try
 
-		if application "Arc" is running then
-			tell application "Arc"
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToCheck
-							if tabURL contains d then
-								if matchedDomains does not contain d then
-									set end of matchedDomains to d
+		try
+			if application "Arc" is running then
+				tell application "Arc"
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToCheck
+								if tabURL contains d then
+									if matchedDomains does not contain d then
+										set end of matchedDomains to d
+									end if
 								end if
-							end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-			end tell
-		end if
+				end tell
+			end if
+		end try
 
-		if application "Brave Browser" is running then
-			tell application "Brave Browser"
-				repeat with w in windows
-					repeat with t in tabs of w
-						set tabURL to URL of t
-						repeat with d in domainsToCheck
-							if tabURL contains d then
-								if matchedDomains does not contain d then
-									set end of matchedDomains to d
+		try
+			if application "Brave Browser" is running then
+				tell application "Brave Browser"
+					repeat with w in windows
+						repeat with t in tabs of w
+							set tabURL to URL of t
+							repeat with d in domainsToCheck
+								if tabURL contains d then
+									if matchedDomains does not contain d then
+										set end of matchedDomains to d
+									end if
 								end if
-							end if
+							end repeat
 						end repeat
 					end repeat
-				end repeat
-			end tell
-		end if
+				end tell
+			end if
+		end try
 
 		if matchedDomains is {} then
 			return ""
@@ -727,13 +793,13 @@ func getOpenBrowserDomains(domains []string) []string {
 		end if
 	`, domainListStr)
 
-	out, err := exec.Command("osascript", "-e", script).Output()
+	out, err := runOsaScriptCapture(script)
 	if err != nil {
 		log.Printf("Error checking open browser domains: %v", err)
 		return nil
 	}
 
-	result := strings.TrimSpace(string(out))
+	result := strings.TrimSpace(out)
 	if result == "" {
 		return nil
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -674,6 +675,72 @@ func TestGenerateCloseTabsScript_IncludesArcAndBrave(t *testing.T) {
 		if !strings.Contains(script, app) {
 			t.Errorf("GenerateCloseTabsScript: expected block for %q but not found in script", app)
 		}
+	}
+}
+
+func TestGenerateCloseTabsScript_WrapsEachBrowserInTryBlock(t *testing.T) {
+	// Regression for the -600 "Application isn't running" error when Safari (or
+	// any other browser) is closed but `application "X" is running` returns a
+	// stale true via Launch Services. Without the try wrapper, a single dead
+	// browser would crash the whole probe and prevent us from closing tabs in
+	// the browsers that ARE running.
+	g := &MacOSAppleScriptGenerator{}
+	script := g.GenerateCloseTabsScript([]string{"facebook.com"})
+
+	tries := strings.Count(script, "try")
+	endTries := strings.Count(script, "end try")
+	if tries < 4 || endTries < 4 {
+		t.Errorf("expected >=4 try/end try blocks (one per browser), got try=%d end_try=%d", tries, endTries)
+	}
+}
+
+func TestGenerateCloseTabsScript_ClosesCollectedTabsInReverse(t *testing.T) {
+	// Regression for: forward-order close walked specifiers like `tab 1, tab 2,
+	// tab 3 of window 1`. Closing tab 1 shifts the indices, so closing "tab 2"
+	// next actually closed the original tab 3, and closing "tab 3" failed
+	// because the index no longer existed. Net effect: only some matching tabs
+	// closed per tick, and the wrong ones at that.
+	//
+	// Fix: collect specifiers via the dictionary-independent generic form
+	// (`repeat with t in tabs of w` — works even when an app like Arc/Brave
+	// isn't installed locally and AppleScript can't load its scripting
+	// dictionary), then close in REVERSE of the collected list. Highest tab
+	// index closes first, so the indices of remaining specifiers don't shift.
+	g := &MacOSAppleScriptGenerator{}
+	script := g.GenerateCloseTabsScript([]string{"facebook.com"})
+
+	if !strings.Contains(script, "repeat with i from toCloseCount to 1 by -1") {
+		t.Error("expected close script to walk collected tabs in reverse (`repeat with i from toCloseCount to 1 by -1`)")
+	}
+	if !strings.Contains(script, "close item i of tabsToClose") {
+		t.Error("expected close script to close via positional list access, not stored specifier iteration")
+	}
+	// The old forward-iteration close that caused the index-shift bug must be gone.
+	if strings.Contains(script, "repeat with t in tabsToClose") {
+		t.Error("close script still uses forward `repeat with t in tabsToClose` (the buggy pattern); should iterate in reverse via index")
+	}
+	// Stays dictionary-independent — no explicit indexed `tab N of window M`
+	// access (would fail to compile if Arc/Brave isn't installed locally).
+	if strings.Contains(script, "tab tIdx of window wIdx") {
+		t.Error("close script uses explicit indexed tab access; this requires the app's AppleScript dictionary and breaks compilation when the browser isn't installed")
+	}
+}
+
+func TestRunOsaScriptCapture_NonDarwinIsNoOp(t *testing.T) {
+	// On non-darwin (CI is Linux) the helper must return ("", nil) without
+	// trying to write or fork osascript. Regression guard for the bug where
+	// getOpenBrowserDomains called exec.Command("osascript", ...) directly,
+	// which on Linux would fail and on macOS root would silently break the
+	// per-tick close path.
+	if runtime.GOOS == "darwin" {
+		t.Skip("non-darwin behavior; skipping on macOS")
+	}
+	out, err := runOsaScriptCapture(`tell application "Google Chrome" to count windows`)
+	if err != nil {
+		t.Errorf("expected nil error on non-darwin, got %v", err)
+	}
+	if out != "" {
+		t.Errorf("expected empty output on non-darwin, got %q", out)
 	}
 }
 


### PR DESCRIPTION
v0.1.15 shipped the per-tick tab-closer scaffolding but it was silently broken end-to-end in production. This PR fixes it for real, with three layered fixes that emerged from live debugging.

## Summary

- Probe (`getOpenBrowserDomains`) now shells out via the console user when the daemon runs as root, instead of calling `osascript` directly with no GUI session.
- Each browser block in both the probe and close scripts is wrapped in `try ... end try` so a single dead browser doesn't abort the rest.
- Close phase iterates the collected `tabsToClose` list **in reverse**, so closing the highest-index tab first doesn't invalidate the specifiers for lower-index tabs we haven't visited yet.

## Why three fixes (the iteration log)

This was not a clean single-shot fix — each fix unmasked the next layer of the bug.

### Round 1: tabs not closing at all under strict mode

Daemon logs every tick:
```
2026/05/03 12:10:44 Error checking open browser domains: exit status 1
```

`getOpenBrowserDomains` (`scheduler.go:701` pre-fix) was calling `exec.Command("osascript", "-e", script).Output()` directly. The daemon runs as root under launchd. Root has no GUI session attached to Chrome/Safari/Arc/Brave, so AppleScript exits 1 with no usable output. The new per-tick close path is gated on this probe → probe always returns empty → close never fires.

`runAsMacUser` (already in the codebase, used by the close-tabs script itself) handles this correctly via `su - <console user> -c osascript ...` when running as root. But it returns only error/no-error, no stdout. The probe needs stdout to parse the matched-domain list.

**Fix:** new `runOsaScriptCapture(script string) (string, error)` helper that mirrors `runAsMacUser`'s root → console-user shell-out and captures stdout. Uses a separate tmpfile (`/tmp/df_probe.scpt` vs. `/tmp/df_script.scpt`) so the probe and close calls don't clobber each other within a single tick.

This also fixes the long-broken 3-minute pre-block warning, which uses the same probe and was silently never firing under launchd.

### Round 2: Safari -600 errors on every probe

After round 1, the probe was reaching the browsers — but every tick logged:
```
osascript exit 1: /tmp/df_probe.scpt:990:1320: execution error: Safari got an error: Application isn't running. (-600)
```

`if application "Safari" is running` returns a stale true via Launch Services when Safari was launched at some point in the user's session but isn't actively running now (process gone, but Launch Services hasn't fully cleared it). The inner `tell application "Safari"` then errors with -600. With four browser blocks chained, one bad browser killed the whole probe. Empirically reproduced (without the wrap, exit 1; with it, exit 0).

**Fix:** wrap each browser block in both the probe and close script with `try ... end try`. Whatever -600 (or anything else) gets raised in one block is caught and the script proceeds to the next browser.

### Round 3a (broken attempt): only some tabs closing, wrong ones at that

After rounds 1 and 2, with two windows × three matching tabs each, only 1–2 tabs closed per tick — and inconsistently. Diagnosis: the close phase iterated `tabsToClose` forward. Each entry is a specifier like `tab 2 of window 1` resolved at close time:

- Close `tab 1 of window 1` → correct.
- Close `tab 2 of window 1` → after the previous close, what was tab 3 is now tab 2. Closes the wrong tab.
- Close `tab 3 of window 1` → no longer exists. Errors. Loop aborts.

Net effect: ~1 tab closed correctly, ~1 tab closed at the wrong position, the rest skipped. Exactly the user-visible symptom.

**First attempt:** rewrite the loop as full reverse iteration with explicit indexed access:
```applescript
set windowCount to count of windows
repeat with wIdx from windowCount to 1 by -1
    set tabCount to count of tabs of window wIdx
    repeat with tIdx from tabCount to 1 by -1
        set tabURL to URL of tab tIdx of window wIdx
        ...
        close tab tIdx of window wIdx
        ...
```

Compiled and tested fine. **Then broke compilation entirely** in production:
```
osascript: exit status 1: /tmp/df_script.scpt:1668:1672: script error: Expected end of line but found identifier. (-2741)
```

Empirically isolated: `tab tIdx of window wIdx` fails to compile when the app's AppleScript dictionary isn't loaded. Specifically, when Arc and Brave aren't installed on the user's machine (common — most folks have one Chromium browser, not three), the compiler can't parse `tab N of window M` as an indexed-tab reference. The whole script fails to compile, so Chrome and Safari blocks don't run either.

The previous forward-iter syntax (`repeat with t in tabs of w` / `URL of t`) compiles fine without the dictionary because it uses generic terminology that the parser handles independently. So we needed a fix that stays dictionary-independent.

### Round 3b (final): collected-list closed in reverse

**Fix:** keep the dictionary-independent forward collection, but walk the collected list in reverse at close time:
```applescript
set tabsToClose to {}
repeat with w in windows
    repeat with t in tabs of w
        ... if match: set end of tabsToClose to t
    end repeat
end repeat
set toCloseCount to count of tabsToClose
repeat with i from toCloseCount to 1 by -1
    try
        close item i of tabsToClose
        set closedCount to closedCount + 1
    end try
end repeat
```

`tabs of w` returns specifiers in index-ascending order, so the collected `tabsToClose` is also index-ascending per window. Walking it in reverse means we close the highest-index tab first, and the specifiers for lower-index tabs remain valid because their indices haven't shifted. Per-close `try` handles the case where closing the last matching tab in a window also closes the window (subsequent references would error — caught and skipped, we move on).

## Files changed

- `internal/scheduler/scheduler.go`
  - New `runOsaScriptCapture` helper.
  - `getOpenBrowserDomains` routes through it (with `try` wraps per browser).
  - `GenerateCloseTabsScript` rewritten for all four browsers: outer `try` around each browser block, generic-syntax forward collection, reverse close loop with per-close `try`.
- `internal/scheduler/scheduler_test.go`
  - `TestRunOsaScriptCapture_NonDarwinIsNoOp` — verifies the helper returns `("", nil)` on non-darwin so Linux CI doesn't try to fork osascript.
  - `TestGenerateCloseTabsScript_WrapsEachBrowserInTryBlock` — asserts ≥4 `try`/`end try` pairs.
  - `TestGenerateCloseTabsScript_ClosesCollectedTabsInReverse` — asserts the reverse close-loop syntax, AND explicitly forbids both the buggy forward iteration (`repeat with t in tabsToClose`) AND the dictionary-dependent `tab tIdx of window wIdx` pattern. This catches both regression directions: someone reverting to forward, or someone optimising to "cleaner" indexed access that breaks on machines without all four browsers installed.

## Gotchas to watch out for in review

1. **Dictionary independence is load-bearing.** Anyone tempted to "clean up" the AppleScript by switching to `tab N of window M` syntax will break the script for users who don't have all four browsers installed. The test guards against this.
2. **The probe and close use different tmpfiles.** `/tmp/df_probe.scpt` for the probe, `/tmp/df_script.scpt` for the close. If you ever consolidate them, make sure the probe and close don't run concurrently within a tick.
3. **The 3-minute warning was always broken under launchd.** It used the same probe and was silently failing all along. This PR fixes it as a side effect — users may suddenly start seeing pre-block warning notifications they've never seen before. Not a regression, but worth flagging.
4. **`try ... end try` swallows everything.** If a real bug emerges in the close logic later, it'll silently fail rather than surface in logs. The cost-benefit favours silence here (this script runs every tick), but be aware when debugging future close-related issues — temporarily replace the bare `try ... end try` with `try ... on error errMsg if errMsg contains "..." then ... end try` to surface specific failures.

## Test plan

- [x] `go test ./...` — full suite green; 16 scheduler tests pass.
- [x] `make build-all` succeeds for darwin/arm64, darwin/amd64, windows/amd64.
- [x] Empirical: generated close script compiles cleanly with `osacompile` on a machine without Arc or Brave installed (this would fail on the previous indexed-tab attempt).
- [x] User confirmed live behaviour: tabs in two windows × three tabs each all close correctly within 60 s of opening, on both Chrome and Safari, even when Safari isn't running.
- [ ] Reviewer to confirm pre-block warning notification fires (was silently broken before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)