### PR TITLE
fix: make setup/clean idempotent so re-installs always work (#85)

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -173,11 +173,19 @@ func runSetup() {
 		log.Fatalf("setup: could not create service handle: %v", err)
 	}
 
+	// setup is idempotent: re-running it on an existing installation should
+	// produce a working installation, not abort. The previous behaviour
+	// (refuse if /usr/local/bin/sentinel exists) made `clean && setup`
+	// dependent on `clean` having already removed the binary — which older
+	// builds did not do — and left users stuck without a manual `rm`.
+	// Order: stop + uninstall any existing service registration (so kardianos
+	// install doesn't trip on a duplicate plist), then overwrite the binary,
+	// then install + start fresh.
+	_ = service.Control(s, "stop")      // best-effort; not running is fine
+	_ = service.Control(s, "uninstall") // best-effort; not registered is fine
+
 	if runtime.GOOS == "darwin" {
 		dest := "/usr/local/bin/sentinel"
-		if _, err := os.Stat(dest); err == nil {
-			log.Fatalf("Sentinel is already installed at %s. Run 'sudo sentinel clean' to remove it first.", dest)
-		}
 		src, err := os.Executable()
 		if err != nil {
 			log.Fatalf("setup: could not resolve binary path: %v", err)
@@ -189,6 +197,10 @@ func runSetup() {
 		if err := os.MkdirAll("/usr/local/bin", 0755); err != nil {
 			log.Fatalf("setup: could not create /usr/local/bin: %v", err)
 		}
+		// Remove first so we don't write through any open file descriptors held
+		// by a previous service process; the kernel keeps the old inode alive
+		// for already-running readers, while new launchd loads see fresh bytes.
+		_ = os.Remove(dest)
 		if err := os.WriteFile(dest, data, 0755); err != nil {
 			log.Fatalf("setup: could not write binary to %s: %v", dest, err)
 		}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -265,10 +265,14 @@ func runClean(yes bool) {
 	// Step 7 — Remove config directory.
 	addStep(cleanup.RemoveConfigDir(yes))
 
-	// Step 8 — Remove temp files.
+	// Step 8 — Remove the binary that setup installed at /usr/local/bin/sentinel
+	// (macOS only). Without this, a follow-up `setup` aborts with "already installed".
+	addStep(cleanup.RemoveInstalledBinary())
+
+	// Step 9 — Remove temp files.
 	addStep(cleanup.RemoveTempFiles())
 
-	// Step 9 — Verify port 53 is free.
+	// Step 10 — Verify port 53 is free.
 	addStep(cleanup.CheckPort53())
 
 	// Print summary.

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -218,6 +218,36 @@ func RemoveConfigDir(yes bool) Step {
 	return Step{Label: "Remove config directory", Status: StatusDone}
 }
 
+// installedBinaryPath is the path that `setup` copies the binary to on macOS.
+// Exposed as a package-private var so tests can substitute a tempdir path.
+var installedBinaryPath = "/usr/local/bin/sentinel"
+
+// RemoveInstalledBinary removes the installed sentinel binary at /usr/local/bin/sentinel
+// (macOS only). This is the binary that `setup` copies in. Without this, a user who
+// runs `clean` and then `setup` again gets "Sentinel is already installed" because the
+// stale binary is still on disk even though the service is gone.
+//
+// On Unix, unlink succeeds even if the binary is currently executing — including the
+// case where the running process *is* /usr/local/bin/sentinel — because the kernel
+// keeps the inode alive until the last open reference is dropped.
+func RemoveInstalledBinary() Step {
+	if runtime.GOOS != "darwin" {
+		return Step{Label: "Remove installed binary", Status: StatusSkipped, Detail: "not applicable on " + runtime.GOOS}
+	}
+	return removeBinary(installedBinaryPath)
+}
+
+func removeBinary(path string) Step {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return Step{Label: "Remove installed binary", Status: StatusSkipped, Detail: "not installed at " + path}
+	}
+	fmt.Printf(" $ rm -f %s\n", path)
+	if err := os.Remove(path); err != nil {
+		return Step{Label: "Remove installed binary", Status: StatusWarn, Detail: err.Error()}
+	}
+	return Step{Label: "Remove installed binary", Status: StatusDone, Detail: path}
+}
+
 // RemoveTempFiles removes known temporary files created by the daemon.
 func RemoveTempFiles() Step {
 	candidates := []string{"/tmp/df_script.scpt"}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -1,0 +1,37 @@
+package cleanup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveBinary_NotInstalled verifies that the no-op branch returns a
+// "skipped" step instead of an error when the binary is not on disk.
+func TestRemoveBinary_NotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "sentinel")
+
+	step := removeBinary(missing)
+	if step.Status != StatusSkipped {
+		t.Errorf("expected Skipped for missing binary, got %s (detail=%q)", step.Status, step.Detail)
+	}
+}
+
+// TestRemoveBinary_Installed verifies that an existing file is unlinked and
+// the step is reported as done.
+func TestRemoveBinary_Installed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sentinel")
+	if err := os.WriteFile(path, []byte("dummy"), 0755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	step := removeBinary(path)
+	if step.Status != StatusDone {
+		t.Errorf("expected Done, got %s (detail=%q)", step.Status, step.Detail)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected file to be removed, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #85.

`sudo sentinel setup` was aborting with "Sentinel is already installed at /usr/local/bin/sentinel. Run 'sudo sentinel clean' to remove it first." even when the user *had* run `clean`. The advice was self-contradictory: `clean` removed the launchd plist, the config dir, hosts/pf entries, etc., but **left the installed binary at `/usr/local/bin/sentinel` in place** — and `setup`'s existence guard then refused to proceed. Users were stuck unable to upgrade or recover without a manual `sudo rm`.

This PR fixes both ends of the loop.

### What

1. **`clean` now removes `/usr/local/bin/sentinel`** as step 8 of the cleanup pipeline (after service uninstall, before temp-file removal). New helper `cleanup.RemoveInstalledBinary()` — the path is captured in a package-private var so unit tests can substitute a tempdir without touching the real filesystem.
2. **`setup` is now idempotent**. Removed the "already installed" guard. Setup now best-effort stops + uninstalls any existing service registration, unlinks the old binary, writes the new one, and re-registers + starts the service. Re-running `setup` on top of an existing install just produces a working install — no `clean` required, no manual `rm` required.

### Why this shape

- **`clean` removing the binary** is what users already expected from "forensic uninstall." The previous omission was a bug, not a deliberate boundary.
- **`setup` being idempotent** breaks the chicken-and-egg: even if a user has an old build of `clean` (which doesn't remove the binary), the new `setup` no longer cares about prior state. This is what unblocks current users without requiring a manual bootstrap on the next release after this one.
- **Order of operations in `setup`** — stop → uninstall → unlink → write → install → start — is the only safe ordering. Stopping kills the launchd-managed daemon; uninstalling removes the plist so `KeepAlive` can't fire; unlinking before writing avoids any chance of writing through an open fd held by a previous process.
- **Order of operations in `clean`** — stop → ... → uninstall → ... → unlink binary — keeps launchd out of the picture before we touch the binary, so there's no respawn risk even in the (rare) case the cleaning process *is* `/usr/local/bin/sentinel`.

### Self-deletion correctness

`os.Remove` on a running executable is supported on macOS (standard Unix `unlink(2)` semantics: directory entry goes immediately, kernel keeps the inode alive until the last open reference closes). This was verified end-to-end with a real LaunchAgent — `KeepAlive=true` daemon installed, then bootout → plist removal → unlink the running binary → confirmed no respawn 2s later.

### Gotchas / things to watch

- **One-time bootstrap**: users on builds prior to this release have a `/usr/local/bin/sentinel` that doesn't know how to remove itself. After this PR ships, they have two paths:
  - Run `sudo ./sentinel setup` with the new binary — works straight away thanks to the idempotency fix; OR
  - The old workflow (`sudo sentinel clean && sudo rm /usr/local/bin/sentinel && sudo ./sentinel setup`) still works.

  After the new binary is installed, `clean` removes it cleanly and no manual `rm` is ever needed again.
- **No behaviour change on Windows or Linux**: `RemoveInstalledBinary` short-circuits to `Skipped` on non-darwin (the original `setup` only copied to `/usr/local/bin` on darwin too).
- **Tests added**: `internal/cleanup/cleanup_test.go` exercises both branches of `removeBinary` (missing → skipped, present → unlinked).

## Test plan

- [x] `go test ./...` passes
- [x] Self-deletion of a running executable verified manually on macOS (Darwin 25.4)
- [x] LaunchAgent end-to-end verified: install → daemon running under launchd with `KeepAlive=true` → bootout + plist removal + unlink binary → no respawn
- [ ] After merge: pull main, `make build`, `sudo ./sentinel setup` over the existing install — expect success without any prompts about "already installed"
- [ ] `sudo sentinel clean --yes && sudo ./sentinel setup` — expect a fully working install with no manual `rm` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)