### PR TITLE
fix: isolate test config to a tempdir, stop reformatting repo file (#79)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,25 +104,40 @@ var (
 	AppConfig      Config
 	mu             sync.RWMutex
 	UseLocalConfig bool
+	// ConfigDirOverride, if non-empty, takes precedence over UseLocalConfig and
+	// the OS-specific defaults. Used by tests to point config I/O at a tempdir
+	// so parallel test packages don't race on the repo-rooted ./config.json
+	// (and don't reformat it as a side effect).
+	ConfigDirOverride string
 )
 
 func GetConfigFilePath() (string, error) {
-	var dir string
-	if UseLocalConfig {
-		dir = "."
-	} else if runtime.GOOS == "darwin" {
-		dir = "/Library/Application Support/Sentinel"
-	} else if runtime.GOOS == "windows" {
-		dir = filepath.Join(os.Getenv("PROGRAMDATA"), "Sentinel")
-	} else {
-		dir = "/etc/sentinel"
-	}
+	dir := configDir()
 	if dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return "", err
 		}
 	}
 	return filepath.Join(dir, "config.json"), nil
+}
+
+// configDir resolves the directory that should hold config.json.
+// Precedence: explicit override > local mode > OS default.
+func configDir() string {
+	if ConfigDirOverride != "" {
+		return ConfigDirOverride
+	}
+	if UseLocalConfig {
+		return "."
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/Sentinel"
+	case "windows":
+		return filepath.Join(os.Getenv("PROGRAMDATA"), "Sentinel")
+	default:
+		return "/etc/sentinel"
+	}
 }
 
 func generateToken() (string, error) {
@@ -291,15 +306,5 @@ func AutoSetPrimaryDNS(server string) {
 
 // ConfigDir returns the OS-specific config directory path without creating it.
 func ConfigDir() string {
-	if UseLocalConfig {
-		return "."
-	}
-	switch runtime.GOOS {
-	case "darwin":
-		return "/Library/Application Support/Sentinel"
-	case "windows":
-		return filepath.Join(os.Getenv("PROGRAMDATA"), "Sentinel")
-	default:
-		return "/etc/sentinel"
-	}
+	return configDir()
 }

--- a/internal/testcli/testcli_test.go
+++ b/internal/testcli/testcli_test.go
@@ -1,8 +1,8 @@
 package testcli
 
 import (
+	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,21 +11,20 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// go test sets CWD to the package directory; walk up to the module root
-	// so UseLocalConfig=true finds ./config.json in the right place.
-	dir, _ := os.Getwd()
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			os.Chdir(dir)
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
+	// Point config I/O at a tempdir so the test run doesn't read or write
+	// the repo-rooted ./config.json. Without this, LoadConfig + SaveConfig
+	// (e.g. via the Pomodoro/Pause handlers under test) would re-marshal
+	// the on-disk file — alphabetizing weekday keys, expanding inline
+	// arrays — and the testcli + web packages would race when go test ./...
+	// runs them in parallel.
+	dir, err := os.MkdirTemp("", "sentinel-testcli-*")
+	if err != nil {
+		log.Fatalf("could not create temp config dir: %v", err)
 	}
-	os.Exit(m.Run())
+	config.ConfigDirOverride = dir
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 func TestQueryBlocking_ValidTimeFormat(t *testing.T) {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3,10 +3,10 @@ package web
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,23 +14,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Use local config so tests don't attempt to create/read the system config
-	// directory (/Library/Application Support/Sentinel on macOS), which requires
-	// root and fails in CI runners.
-	config.UseLocalConfig = true
-	dir, _ := os.Getwd()
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			os.Chdir(dir) //nolint:errcheck
-			break
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
+	// Point config I/O at a tempdir. Several handlers under test (Pomodoro,
+	// Pause) call config.SaveConfig, which would otherwise rewrite the
+	// repo-rooted ./config.json with json.MarshalIndent — alphabetizing
+	// weekday keys and expanding inline arrays — and race with the testcli
+	// package when go test ./... runs them in parallel.
+	dir, err := os.MkdirTemp("", "sentinel-web-*")
+	if err != nil {
+		log.Fatalf("could not create temp config dir: %v", err)
 	}
-	os.Exit(m.Run())
+	config.ConfigDirOverride = dir
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 func TestConfigHandler_ReturnsJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #79.

`go test ./...` was reformatting the checked-in `config.json` on every run — alphabetizing the weekday map keys and expanding the previously inline `TimeSlot` arrays into multi-line objects — and the `testcli` and `web` packages were racing on it under parallel execution.

### What was happening

Both `testcli` and `web` test packages set `config.UseLocalConfig = true` and chdir up to the module root so `LoadConfig`/`SaveConfig` would hit `./config.json`. Two failure modes:

1. **Reformatting**: handlers under test (Pomodoro start/stop, Pause) call `config.SaveConfig`, which re-marshals the in-memory config with `json.MarshalIndent`. Go's `encoding/json` sorts map keys alphabetically, so weekdays `Monday → Sunday` become `Friday → Wednesday`. Inline `[{...}]` arrays in the source file get exploded into multi-line objects. Every test run silently dirtied the working tree.
2. **Race**: both packages wrote to the same `./config.json` path. Under `go test ./...` (parallel by default), they'd occasionally clobber each other.

### Fix

Adds `config.ConfigDirOverride` — a string that takes precedence over both `UseLocalConfig` and the OS-specific defaults when non-empty. Each `TestMain` in `testcli` and `web` now mints its own tempdir via `os.MkdirTemp` and points the override at it; `LoadConfig` falls back to writing the embedded `default_config.json` when the tempdir is empty, so tests still get a valid config to operate on.

### Why this shape

- **An override variable, not a function/setter**: matches the existing `UseLocalConfig` style; one line in `TestMain` and you're done.
- **Per-package tempdirs (not per-test `t.TempDir`)**: `TestMain` doesn't have a `*testing.T`, and the SaveConfig calls happen via shared globals (`config.AppConfig`) that aren't easy to unwind per-test. A per-package tempdir is sufficient to fix both the reformat and the cross-package race.
- **Centralized resolution**: pulled the dir-resolution logic into a private `configDir()` helper so `GetConfigFilePath` and the exported `ConfigDir` go through one path. Avoids drift if the precedence rules ever change.

### Gotchas / things to watch

- **`UseLocalConfig = true` lines in individual test functions are now no-ops** under the override. Left them in place to minimise diff churn — they're harmless.
- **Production behaviour unchanged**: `ConfigDirOverride` is empty by default, so `cmd/app/main.go` and the running daemon continue to use the OS-specific paths.
- **The chdir-walk-up-to-go.mod gymnastics** in both `TestMain`s are gone, since the override doesn't depend on CWD. One fewer thing that breaks if `go test` is invoked from somewhere unexpected.

## Test plan

- [x] `go test ./...` passes
- [x] `go test -count=3 -p 8 ./internal/testcli ./internal/web ./internal/config` (parallel, repeated) passes
- [x] After repeated test runs, `git diff config.json` is empty — the repo-rooted file is no longer touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)