### PR TITLE
docs(pomodoro): document focus sessions (README, DESIGN, landing)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -230,10 +230,11 @@ func CheckWarningDomainsAtTime(t time.Time, cfg config.Config) []string
 `EvaluateRulesAtTime` returns the set of domains that should be blocked at `t`. Algorithm:
 
 1. If `cfg.IsPaused(t)` — return empty map (pause overrides everything).
-2. For each rule with `is_active=true`, resolve `cfg.ResolveGroup(rule.Group)` to a domain list (skip the rule if the group is missing or empty), then look up `Schedules[t.Weekday().String()]`.
-3. For each slot, parse `Start`/`End` as `15:04`, build a same-day comparison time, check `slotStart <= now < slotEnd`.
-4. On the first matching slot, add every domain in the resolved group to the result and stop checking remaining slots for that rule.
-5. After schedule evaluation, if `quotaUsage` is non-nil, add every domain from any rule whose group has `used >= DailyQuotaMinutes` — quota-exhausted groups are blocked for the rest of the day regardless of the schedule window.
+2. If `cfg.IsLockedByPomodoro(t)` — return the union of every active rule's resolved domains (focus session forces blocking on, ignoring schedules and quota). See section 8 for details.
+3. For each rule with `is_active=true`, resolve `cfg.ResolveGroup(rule.Group)` to a domain list (skip the rule if the group is missing or empty), then look up `Schedules[t.Weekday().String()]`.
+4. For each slot, parse `Start`/`End` as `15:04`, build a same-day comparison time, check `slotStart <= now < slotEnd`.
+5. On the first matching slot, add every domain in the resolved group to the result and stop checking remaining slots for that rule.
+6. After schedule evaluation, if `quotaUsage` is non-nil, add every domain from any rule whose group has `used >= DailyQuotaMinutes` — quota-exhausted groups are blocked for the rest of the day regardless of the schedule window.
 
 `quotaUsage` maps group name → minutes used today (computed from DNS usage buckets). Callers pass `nil` when no quota enforcement is needed (e.g. test utilities, `--test-web` mode).
 
@@ -442,6 +443,7 @@ type Config struct {
     Groups   map[string][]string `json:"groups"`
     Rules    []Rule              `json:"rules"`
     Pause    *PauseWindow        `json:"pause,omitempty"`
+    Pomodoro *PomodoroSession    `json:"pomodoro,omitempty"`
 }
 
 type Settings struct {
@@ -465,6 +467,13 @@ type TimeSlot struct {
 
 type PauseWindow struct {
     Until time.Time `json:"until"`
+}
+
+type PomodoroSession struct {
+    Phase        string    `json:"phase"`           // "work" | "break"
+    PhaseEndsAt  time.Time `json:"phase_ends_at"`
+    WorkMinutes  int       `json:"work_minutes"`    // 1..120, captured at session start
+    BreakMinutes int       `json:"break_minutes"`   // 1..60, captured at session start
 }
 ```
 
@@ -506,6 +515,19 @@ The scheduler calls `LoadConfig()` once per tick. `web.ConfigHandler` also calls
 
 `PauseWindow.Until` is an absolute `time.Time` (RFC3339 in JSON). `Config.IsPaused(t)` returns true when the field is non-nil and `t < Until`. `EvaluateRulesAtTime` and `CheckWarningDomainsAtTime` both short-circuit to empty when paused. The scheduler self-clears expired pauses at the top of each tick so `config.json` doesn't accumulate stale entries.
 
+### Pomodoro session
+
+Pomodoro is the inverse of pause: where pause forces blocking *off*, the work phase of a Pomodoro session forces blocking *on* for every active rule, regardless of schedule. `Config.IsLockedByPomodoro(t)` returns true when `Pomodoro != nil`, `Phase == "work"`, and `t < PhaseEndsAt`. When that returns true, `EvaluateRulesAtTime` short-circuits *before* the per-rule schedule check and returns the union of every active rule's resolved domains.
+
+The session is captured in config (rather than held in scheduler memory) so it survives daemon restarts and laptop sleep — the next tick after wake re-runs the same `IsLockedByPomodoro` check and either keeps the lock, transitions to break, or clears the session.
+
+Phase transitions happen in the scheduler tick when `t >= PhaseEndsAt`:
+
+1. **work → break** — `config.AdvancePomodoroPhase()` rewrites the field with `Phase="break"` and `PhaseEndsAt = now + BreakMinutes`. A macOS notification fires (`"Sentinel — Break time!"`).
+2. **break → cleared** — `config.ClearPomodoro()` sets the field to `nil`. Notification: `"Sentinel — Ready?"`. Sessions don't auto-restart; the user must explicitly start the next one from the dashboard.
+
+Two endpoints layer extra protection on top of this: the work phase causes `POST /api/pomodoro` (start) to refuse if a session is already running, `DELETE /api/pomodoro` to return `423 Locked`, and `POST /api/config/update` to also return `423`. This makes "edit your way out of focus mode" require dropping to `config.json` directly with admin access — friction, not security.
+
 ---
 
 ## 9. Web server & HTTP API
@@ -528,6 +550,8 @@ The scheduler calls `LoadConfig()` once per tick. `web.ConfigHandler` also calls
 | `/api/pf-preview` | GET, POST | token | Show resolved IPs and pf anchor content (strict mode only) |
 | `/api/pause` | POST | token | Body `{"minutes": N}` — `1 <= N <= 240` |
 | `/api/pause` | DELETE | token | Clear pause |
+| `/api/pomodoro/start` | POST | token | Body `{"work_minutes": 1..120, "break_minutes": 1..60}` |
+| `/api/pomodoro` | DELETE | token | Clear session — returns `423` during the work phase |
 | `/api/usage` | GET | token | Per-group and per-domain DNS usage minutes; `?range=today\|7d\|30d\|60d` |
 
 ### Auth model

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ No. The scheduler's 1-minute ticker is a regular Go timer — it doesn't issue p
 - [The web dashboard](#the-web-dashboard)
 - [Configuration](#configuration)
 - [Pause & resume](#pause--resume)
+- [Focus sessions (Pomodoro)](#focus-sessions-pomodoro)
 - [Enforcement modes](#enforcement-modes)
 - [Uninstall & cleanup](#uninstall--cleanup)
 - [Command-line reference](#command-line-reference)
@@ -285,6 +286,36 @@ curl -X DELETE http://localhost:8040/api/pause \
 ```
 
 The pause window is written to `config.json` as `pause.until` and cleared automatically when the time passes — no stale pauses left behind.
+
+---
+
+## Focus sessions (Pomodoro)
+
+A focus session is the inverse of pause: a fixed work interval where blocking is *forced on* regardless of your normal schedule, followed by a break interval where it's *released*. Open the dashboard's **Status** tab, set the work and break durations (defaults: 25 min / 5 min; allowed ranges 1–120 work, 1–60 break), and click **Start Focus Session**.
+
+**During the work phase** every active rule is treated as blocking right now, even rules whose schedule wouldn't fire at this time. The pause endpoint and the config-update endpoint both return `423 Locked` — you can't pause out, edit your way out, or stop the session early. When the work phase ends, a macOS notification fires and the daemon transitions automatically into the break phase.
+
+**During the break phase** all rules revert to their normal schedule (so most things are unblocked, unless your usual schedule blocks them anyway). A second notification fires when the break ends, and the session clears itself; sessions don't auto-restart.
+
+Via the API:
+
+```bash
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+
+# Start a 50-minute work / 10-minute break session
+curl -X POST http://localhost:8040/api/pomodoro/start \
+  -H "X-Auth-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"work_minutes": 50, "break_minutes": 10}'
+
+# Stop a session (only allowed during the break phase)
+curl -X DELETE http://localhost:8040/api/pomodoro \
+  -H "X-Auth-Token: $TOKEN"
+```
+
+Session state is persisted in `config.json` under the optional `pomodoro` field (`{phase, phase_ends_at, work_minutes, break_minutes}`). It survives daemon restart and laptop sleep — when the system wakes, the next scheduler tick (within ~60 s) re-evaluates the phase and transitions or clears as needed.
+
+> **Note:** the work-phase lock is an enforcement convenience, not a security boundary — anyone with admin access to your machine can still edit `config.json` directly to drop the session. The point is to add a couple of layers of friction during focused work.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,6 +284,15 @@
           <p class="text-slate-400 text-sm leading-relaxed">Cap how long a group is accessible each day. Add <code class="text-sky-400 text-xs">daily_quota_minutes: 30</code> to any rule — once the allowance is consumed, the group blocks for the rest of the day. Requires DNS or strict mode.</p>
         </div>
 
+        <!-- Feature: Focus sessions / Pomodoro -->
+        <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
+          <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
+            <svg class="w-5 h-5 text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+          </div>
+          <h3 class="text-white font-semibold mb-2">Focus sessions (Pomodoro)</h3>
+          <p class="text-slate-400 text-sm leading-relaxed">Start a 25/5 work-and-break session from the dashboard. During work, every active rule is forced on regardless of schedule and pause is locked out. Notifications fire at each phase boundary.</p>
+        </div>
+
         <!-- Feature: Clean uninstall -->
         <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
           <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
@@ -563,6 +572,10 @@
           {
             q: `Can I set a time allowance instead of a fixed block window?`,
             a: `Yes — add daily_quota_minutes to any rule. For example, "daily_quota_minutes": 30 gives you 30 minutes of access per day, whenever you want it. Once the allowance is consumed, the group blocks for the rest of the day and resets at midnight. Usage is measured from DNS activity, so background-active tabs (Reddit, YouTube) count toward the quota. Requires DNS or strict enforcement mode — hosts mode doesn't see DNS queries.`
+          },
+          {
+            q: `Is there a built-in Pomodoro / focus-session timer?`,
+            a: `Yes. Open the dashboard's Status tab, set a work and break duration (defaults 25 / 5 minutes; up to 120 / 60), and click Start Focus Session. During the work phase every active rule is forced on regardless of its schedule, and pause is locked out — you can't edit your way out until the work phase ends. Notifications fire at each phase boundary, the session survives sleep and daemon restart, and it clears itself when the break finishes. It's the inverse of pause: pause forces blocking off, focus sessions force blocking on.`
           },
           {
             q: `How do I uninstall?`,


### PR DESCRIPTION
## Summary

Closes #57.

The Pomodoro / focus-session feature was implemented but never documented in user-facing or architectural docs. The most recent comment on #57 called this out specifically: *"missing updates to README, DESIGN as well as landing page docs at docs/index.html. This is a significant feature and needs a card in the feature list on the landing page plus any other places."* This PR fills those gaps.

## What

- **README.md** — new "Focus sessions (Pomodoro)" section between Pause & resume and Enforcement modes. Frames it as the inverse of pause: pause forces blocking *off*; focus sessions force it *on*. Covers dashboard flow, duration ranges (1–120 work, 1–60 break, default 25/5), work-phase lockout semantics (pause + config-edit return `423`), the `pomodoro` config field's persistence, and the `POST /api/pomodoro/start` / `DELETE /api/pomodoro` endpoints with example curl. TOC entry added.
- **DESIGN.md** —
  - Schema in section 8 now includes `PomodoroSession` and the optional `Config.Pomodoro` field
  - New "Pomodoro session" subsection alongside the existing "Pause window" subsection covering `IsLockedByPomodoro`, the `AdvancePomodoroPhase` / `ClearPomodoro` transitions, and the friction-not-security framing
  - `EvaluateRulesAtTime` algorithm in section 5 now lists the IsLockedByPomodoro override as step 2 (right after the IsPaused short-circuit) so the override layering is explicit
  - API routes table now lists the two `/api/pomodoro*` endpoints
- **docs/index.html** —
  - New "Focus sessions (Pomodoro)" feature card in the features grid (added between "Daily quotas" and "Clean uninstall")
  - New FAQ accordion item answering *"Is there a built-in Pomodoro / focus-session timer?"*

## Why this shape

- **Mirror the Pause docs.** Pause and Pomodoro are the two override mechanisms layered on top of the schedule evaluator; documenting them in parallel sections (README + DESIGN) makes the relationship obvious to a reader scanning the doc.
- **Note the lockout is friction, not security.** Both README and DESIGN call this out explicitly so a user looking for an actual lock-down mechanism reaches for #45 (locked sessions) instead of being misled.
- **Schema-first in DESIGN.** The `PomodoroSession` struct comes from `internal/config/config.go:72-80`; quoting it directly avoids drift if a contributor wonders what fields actually exist.

## Gotchas

- Pure docs change — no code, no tests, no behaviour impact.
- The feature card SVG icon (lightning bolt) is reused from Heroicons; the existing cards already pull from the same set.
- Did not touch TROUBLESHOOTING.md — there are no known Pomodoro-specific failure modes that need a debug recipe yet. If/when one shows up, that's a separate change.

## Test plan

- [ ] Reviewer renders `README.md` on GitHub and confirms the new section sits between Pause & resume and Enforcement modes, and the TOC entry resolves
- [ ] Reviewer renders `DESIGN.md` on GitHub and confirms the schema, the new subsection in §8, the §5 algorithm step, and the routes-table additions all parse cleanly
- [ ] Reviewer opens `docs/index.html` in a browser and confirms the new feature card appears in the grid and the new FAQ accordion item expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)