### PR TITLE
docs(doh): document comprehensive DoH/DoT coverage across all surfaces (#82)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-A system-level DNS proxy daemon for macOS (and Windows) that enforces productivity schedules by intercepting DNS at the OS level. It runs as a privileged background service (`launchd` on macOS), blocking distracting domains by returning `0.0.0.0`, closing browser tabs via AppleScript, and sending pre-block warnings — all unkillable by regular users.
+A system-level productivity daemon for macOS (and Windows) that enforces per-time-of-day blocking rules. It runs as a privileged background service (`launchd` on macOS) and offers three interchangeable enforcement modes selected by `enforcement_mode` in config:
+
+- **`hosts`** (default, cross-platform) — rewrites the system hosts file. Survives browser-DoH bypass because `getaddrinfo` reads `/etc/hosts` before any resolver.
+- **`dns`** — local DNS proxy on `127.0.0.1:53` returning `0.0.0.0` for blocked domains and forwarding everything else upstream.
+- **`strict`** (macOS only, recommended) — DNS proxy plus a `pf` packet-filter anchor that drops outbound packets to the resolved IPs at the kernel. Includes a `_doh` group of public DoH/DoT endpoints that's always-on, so even browsers with a manually-configured DoH provider can't route around the block.
+
+The daemon also closes Chrome/Safari/Arc/Brave tabs via AppleScript on every tick during an active block, fires a 3-minute pre-block notification, and runs a web dashboard on `:8040` for rule editing, status, pause, focus sessions, and quota inspection. All unkillable by regular users.
 
 ## Workflow
 
@@ -41,20 +47,25 @@ The binary has four flags for development testing — none require root or servi
 
 ### Data Flow
 
-1. Scheduler ticks every minute, calling `EvaluateRulesAtTime(now, cfg)` to compute `map[string]bool` of blocked domains.
-2. On state change: flushes macOS DNS cache, generates AppleScript to close matching browser tabs.
-3. DNS proxy on port 53 checks each query against the `activeBlocks` map — returns `0.0.0.0` if blocked, otherwise forwards to upstream (default: 8.8.8.8, fallback: 1.1.1.1).
-4. 3 minutes before a block starts, `CheckWarningDomainsAtTime()` triggers native macOS notifications.
+1. Scheduler ticks every minute, calling `EvaluateRulesAtTime(now, cfg, quotaUsage)` to compute the blocked-domain set. Pause and Pomodoro work-phase are checked first as overrides.
+2. The scheduler diffs against the previous tick and hands `newlyBlocked` / `newlyUnblocked` to the active enforcer (one of `HostsEnforcer` / `DNSEnforcer` / `StrictEnforcer`, picked from `enforcement_mode`).
+3. On state change: enforcer applies its mode-specific change (`/etc/hosts` rewrite, in-memory blocked map update, or pf anchor regen + DNS cache flush). AppleScript closes matching browser tabs every tick, not just on state transitions.
+4. In `strict` mode, the enforcer also calls `pf.Refresh()` every tick to re-resolve CDN IPs that may have rotated since the last activation, keeping the pf table current.
+5. The DNS proxy on port 53 (used by `dns` and `strict` modes) checks each query against the `activeBlocks` map and returns `0.0.0.0` if blocked, else forwards to `primary_dns` (default `8.8.8.8:53`) with `backup_dns` failover (default `1.1.1.1:53`). Non-blocked queries for configured groups are appended to a usage log used for daily-quota enforcement.
+6. 3 minutes before a block starts, `CheckWarningDomainsAtTime()` triggers native macOS notifications.
 
 ### Key Packages
 
 | Package | Responsibility |
 |---|---|
-| `cmd/app/main.go` | Entry point; dispatches service, test, and direct-run modes |
-| `internal/config` | JSON config loading from OS-specific paths; thread-safe via `RWMutex` |
-| `internal/scheduler` | 1-minute ticker, rule evaluation, pre-block warnings, AppleScript tab closing |
-| `internal/proxy` | DNS server; blocking vs. upstream forwarding; primary/backup DNS failover |
-| `internal/web` | HTTP dashboard on `:8040`; embedded static files via `go:embed`; `/api/config` and `/api/test-query` |
+| `cmd/app/main.go` | Entry point; dispatches service, test, and direct-run modes; idempotent `setup` and forensic `clean` paths |
+| `internal/config` | JSON config loading from OS-specific paths; thread-safe via `RWMutex`; pause/pomodoro state helpers |
+| `internal/enforcer` | `Enforcer` interface + factory; `HostsEnforcer` / `DNSEnforcer` / `StrictEnforcer` impls; calls `pf.RemoveAnchorIfPresent` on mode downgrade so leftover state self-heals |
+| `internal/pf` | macOS pf anchor management — two-section anchor (regular all-port blocks + DoH/DoT port-restricted blocks on TCP/443 + TCP/UDP/853), multi-resolver IP union, `pfctl` invocations |
+| `internal/scheduler` | 1-minute ticker, rule evaluation, pre-block warnings, per-tick AppleScript tab closing, daily quota tracking |
+| `internal/proxy` | DNS server; blocking vs. upstream forwarding; primary/backup DNS failover; usage event logging for quotas |
+| `internal/web` | HTTP dashboard on `:8040`; embedded static files via `go:embed`; `/api/config`, `/api/status`, `/api/pause`, `/api/pomodoro/*`, `/api/usage`, `/api/test-query` |
+| `internal/cleanup` | Per-step idempotent `clean` pipeline — service uninstall, hosts revert, pf anchor removal, DNS reset, config dir delete, installed-binary unlink |
 | `internal/testcli` | Shared logic for `--test-query` (CLI) and web UI query handler |
 
 ### Testability Pattern
@@ -77,8 +88,9 @@ Config is re-read every scheduler tick — live edits take effect within 60 seco
 
 ### OS-Specific Notes
 
-- Tab closing and pre-block notifications are macOS-only (AppleScript targeting Chrome and Safari).
+- Tab closing and pre-block notifications are macOS-only (AppleScript targets Chrome, Safari, Arc, and Brave). The probe shells out via `su - <console-user> -c osascript ...` because the daemon runs as root.
 - DNS cache flush uses `dscacheutil -flushcache` + `killall -HUP mDNSResponder` on macOS.
+- `strict` mode is macOS only — `pf` integration is gated behind `//go:build darwin` and the enforcer factory falls back to `dns` mode on other OSes.
 - Port 53 binding requires root; service installation requires admin privileges.
 
 ## Documentation

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -396,16 +396,28 @@ This function is what the test suite hits — no port binding, no global state, 
 
 ### Anchor file model
 
-The daemon owns one pf anchor named `sentinel`, stored at `/etc/pf.anchors/sentinel`. The anchor file content is regenerated on every Activate:
+The daemon owns one pf anchor named `sentinel`, stored at `/etc/pf.anchors/sentinel`. The anchor file content is regenerated on every Activate. It has **two sections** depending on whether the `_doh` group is part of the active block set:
 
 ```
-table <blocked_ips> persist {
-  142.251.215.110
-  142.251.215.111
-  ...
-}
-block drop out quick proto {tcp udp} from any to <blocked_ips>
+# Section 1 — regular blocked-domain IPs (all ports, both protocols)
+block drop out quick inet  proto tcp from any to { 142.251.215.110 142.251.215.111 ... }
+block drop out quick inet  proto udp from any to { 142.251.215.110 ... }
+block drop out quick inet6 proto tcp from any to { 2607:f8b0:4007:80a::200e ... }
+block drop out quick inet6 proto udp from any to { 2607:f8b0:4007:80a::200e ... }
+
+# Section 2 — DoH/DoT endpoints, port-restricted so plain UDP/53 still works
+block drop out quick inet  proto tcp from any to { 8.8.8.8 1.1.1.1 ... } port = 443
+block drop out quick inet  proto tcp from any to { 8.8.8.8 1.1.1.1 ... } port = 853
+block drop out quick inet  proto udp from any to { 8.8.8.8 1.1.1.1 ... } port = 853
+# (plus inet6 equivalents)
 ```
+
+macOS automatically promotes inline IP lists to internal `__automatic_<hash>_<n>` tables, which is what shows up under `pfctl -a sentinel -s Tables`. The two sections exist because:
+
+- Regular blocked IPs (Reddit, YouTube, …) get an **all-port** drop — there's no legitimate traffic the daemon needs to those CDNs.
+- DoH/DoT endpoints (`dns.google`, `cloudflare-dns.com`, …) get a **port-restricted** drop on TCP/443 and TCP+UDP/853 only. UDP/53 plain DNS to the same IPs is left open so the daemon's own `backup_dns` (typically `1.1.1.1:53`) keeps working — which is what makes the `_doh` group safe to enable by default in strict mode.
+
+The two-section split is what allows the `_doh` group to be **always-on** in strict mode without breaking the daemon's own upstream resolution. See `internal/pf/pf.go` (`Generate*` helpers) and the rendered example at `/etc/pf.anchors/sentinel` after `sudo ./sentinel start`.
 
 The anchor is wired into `/etc/pf.conf` between marker lines:
 
@@ -420,9 +432,11 @@ load anchor "sentinel" from "/etc/pf.anchors/sentinel"
 
 `RemoveAnchor()` flushes the table, strips the marker block from pf.conf, reloads pf, and deletes the anchor file.
 
-`ActivateBlock(domains, primaryDNS)` resolves each domain to A and AAAA addresses (via `miekg/dns`, falling back to `net.LookupHost`), regenerates the anchor file, runs `pfctl -a sentinel -f <anchor>` to load it, and then runs `pfctl -k <src> -k <ip>` per IP to kill any existing connections.
+`ActivateBlockMixed(domains, dohDomains, primaryDNS, backupDNS)` resolves each domain to A and AAAA addresses against both `primaryDNS` and `backupDNS` (the union widens coverage when CDN edges return geo-different answers per resolver), regenerates the anchor file with the two sections shown above, runs `pfctl -a sentinel -f <anchor>` to load it, and then runs `pfctl -k <src> -k <ip>` per IP **only for the regular block set** to kill any existing connections. State-kill is intentionally skipped for DoH IPs: killing all states to `1.1.1.1` would also drop the daemon's own `backup_dns` sessions on UDP/53. `ActivateBlock(domains, primaryDNS, backupDNS)` is a thin wrapper that passes `nil` for `dohDomains`.
 
-`DeactivateBlock()` flushes the table via `pfctl -a sentinel -t blocked_ips -T flush`, tolerating "No such table" since the table may not exist on first run.
+`DeactivateBlock()` writes a stub anchor (`# no IPs to block`) and reloads it, which empties any `__automatic_*` tables that pf had promoted from the previous activation. No explicit `pfctl -t … -T flush` is needed because the reload replaces the rule set wholesale.
+
+`Refresh()` is called by `StrictEnforcer` every scheduler tick to re-resolve the currently-blocked domains. CDNs rotate IPs constantly, so the rule set has to be rebuilt periodically rather than left static after the initial activation.
 
 ### Why preview functions are exported
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,22 @@ AdGuard Home is a solid network-wide DNS blocker, and Sentinel can run alongside
 | Multiple block windows per day per group | ✅ e.g. 9–12 and 2–6 | ❌ One slot per day ([#7253](https://github.com/AdguardTeam/AdGuardHome/issues/7253)) |
 | Independent schedule per domain group | ✅ Each rule is separate | ❌ One shared schedule for all ([#7146](https://github.com/AdguardTeam/AdGuardHome/issues/7146)) |
 | Custom domain groups | ✅ Any domains you choose | ❌ Predefined catalog only ([#1692](https://github.com/AdguardTeam/AdGuardHome/issues/1692)) |
+| Survives browser DNS-over-HTTPS (Secure DNS) | ✅ `hosts` & `strict` modes | ❌ DoH skips it |
+| Kernel-level IP blocking (pf firewall) | ✅ `strict` mode (macOS) | ❌ DNS-only |
 | Browser tab auto-close on block | ✅ macOS | ❌ |
 | Pre-block notifications | ✅ macOS | ❌ |
 
-AdGuard Home excels at network-wide content filtering — blocking ad trackers or adult content for every device on a home network. Sentinel is built for personal schedule enforcement on a single machine: granular enough to say "block Reddit 9–12 and 2–6, block gaming all evening, and leave streaming open on weekends." If you already run AdGuard Home, see [Running alongside AdGuard Home](TROUBLESHOOTING.md#running-sentinel-alongside-adguard-home-or-any-other-local-dns-service) to run both together.
+AdGuard Home excels at network-wide content filtering — blocking ad trackers or adult content for every device on a home network. Sentinel is built for personal schedule enforcement on a single machine: granular enough to say "block Reddit 9–12 and 2–6, block gaming all evening, and leave streaming open on weekends." It also stays effective against a browser configured for DNS-over-HTTPS, which AdGuard Home cannot — see [the DoH FAQ](#what-about-browsers-using-dns-over-https-doh-or-secure-dns) below for how each Sentinel mode handles that. If you already run AdGuard Home, see [Running alongside AdGuard Home](TROUBLESHOOTING.md#running-sentinel-alongside-adguard-home-or-any-other-local-dns-service) to run both together.
+
+### What about browsers using DNS-over-HTTPS (DoH or "Secure DNS")?
+
+Sentinel handles all three common DoH cases:
+
+1. **Default browser installs.** Chrome's automatic Secure DNS only upgrades to DoH when the system DNS is a *known* provider (8.8.8.8, 1.1.1.1, etc.). Sentinel sets system DNS to `127.0.0.1` (the local proxy), which is not on Chrome's list, so automatic mode stays on regular DNS and goes through the proxy normally. **No action needed.**
+2. **`hosts` mode.** `getaddrinfo` reads `/etc/hosts` before any resolver, so blocked entries take effect even when the browser is using DoH. **No action needed.**
+3. **`strict` mode (recommended for advanced users).** Even if a user has manually set "With Google" / "With Cloudflare" in `chrome://settings/security`, strict mode still blocks because (a) it resolves the real IPs of blocked domains and drops outbound packets at the kernel via `pf`, and (b) it bundles an always-on `_doh` group of common DoH/DoT endpoints (`dns.google`, `cloudflare-dns.com`, `mozilla.cloudflare-dns.com`, `dns.quad9.net`, …) and blocks them on TCP/443 (DoH) and TCP+UDP/853 (DoT) so the browser can't reach the DoH provider in the first place. UDP/53 plain DNS to those CDNs is left open so the daemon's own `backup_dns` keeps working. **No action needed.**
+
+The only mode DoH can bypass is `dns`-only mode combined with a browser that has a *manually-configured* DoH provider — switch that machine to `hosts` or `strict` and you're covered. See [TROUBLESHOOTING.md § Browser DNS-over-HTTPS bypass](TROUBLESHOOTING.md#browser-dns-over-https-doh-bypass) for verification commands and a deeper walkthrough.
 
 ### Does Sentinel keep my laptop awake?
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -170,6 +170,43 @@ See [§6 Restarting after a binary update](#restarting-after-a-binary-update) fo
 
 Strict mode adds a pf (packet filter) firewall layer on top of DNS blocking. DNS alone can be bypassed by apps that have cached a real IP; pf drops packets to those IPs at the kernel level regardless. Both layers must be working for strict mode to be effective.
 
+#### One-shot health check (copy-paste this block first)
+
+If something seems off and you want a single status snapshot before drilling into specific layers, run this — it touches every layer strict mode relies on:
+
+```bash
+# All-layers strict-mode health check. Read top to bottom — first failure narrows the problem.
+echo "=== service ===";          sudo ./sentinel status
+echo "=== mode    ===";          curl -s http://localhost:8040/api/config | jq -r '.settings.enforcement_mode'
+echo "=== sys DNS ===";          scutil --dns | grep "nameserver\[0\]" | head -3
+echo "=== dns layer ===";        dig @127.0.0.1 facebook.com +short
+echo "=== pf enabled ===";       sudo pfctl -s info | head -1
+echo "=== pf anchor ===";        sudo pfctl -s Anchors | grep sentinel
+echo "=== pf rule count ===";    sudo pfctl -a sentinel -s rules 2>/dev/null | wc -l
+echo "=== pf tables ===";        sudo pfctl -a sentinel -s Tables 2>/dev/null
+echo "=== pf v4 IPs (first table) ==="
+HASH=$(sudo pfctl -a sentinel -s rules 2>/dev/null | grep -oE '__automatic_[a-f0-9]+_0' | head -1)
+[ -n "$HASH" ] && sudo pfctl -a sentinel -t "$HASH" -T show | head -10
+echo "=== anchor file on disk ===";  sudo head -20 /etc/pf.anchors/sentinel 2>/dev/null
+echo "=== pf.conf injection  ===";  grep -A2 'sentinel' /etc/pf.conf
+echo "=== last 60s of logs ===";    log show --predicate 'process == "sentinel"' --last 60s 2>/dev/null | grep -E "pf:|enforcer|error" | tail -20
+```
+
+What the output should look like when strict mode is healthy:
+
+- `mode` = `strict`
+- `sys DNS` includes `127.0.0.1`
+- `dns layer` returns `0.0.0.0` for a domain you've blocked
+- `pf enabled` says `Status: Enabled`
+- `pf anchor` shows `sentinel`
+- `pf rule count` is non-zero (typically 4–8 rule lines per table set)
+- `pf v4 IPs` lists at least one IP for an active block
+- `anchor file on disk` is non-empty
+- `pf.conf injection` shows the `anchor "sentinel"` block
+- `last 60s of logs` has no `error` lines
+
+If any of these look wrong, jump to the matching layer-specific section below.
+
 #### Layer 1: Verify DNS is blocking (same as `dns` mode)
 
 ```bash
@@ -347,6 +384,17 @@ If step 1 returns `0.0.0.0` but step 2 returns a real IP, the block is being byp
 **Option B — Switch to `strict` mode (recommended)**
 
 Strict mode resolves the real IPs of blocked domains and installs them in a pf table. Even if DoH gives the browser a live IP, pf drops the connection at the kernel before any packets leave the machine.
+
+In addition, strict mode bundles an always-on `_doh` group that lists the public DoH/DoT endpoints (`dns.google`, `cloudflare-dns.com`, `mozilla.cloudflare-dns.com`, `dns.quad9.net`, etc.). Their IPs are kept in a separate pf table with **port-restricted** rules — TCP/443 (DoH) and TCP+UDP/853 (DoT) only — so the browser can't reach the DoH provider over its dedicated ports while leaving regular HTTPS traffic to those CDNs untouched. You can confirm the `_doh` rules are loaded with:
+
+```bash
+sudo pfctl -a sentinel -s rules | grep -E 'port = (443|853)'
+# Should show three rules per IP family:
+#   block drop out quick inet  proto tcp from any to <__automatic_xxxxxxxx_4> port = 443
+#   block drop out quick inet  proto tcp from any to <__automatic_xxxxxxxx_5> port = 853
+#   block drop out quick inet  proto udp from any to <__automatic_xxxxxxxx_6> port = 853
+#   (plus inet6 equivalents)
+```
 
 ```bash
 # Verify strict mode is blocking at the IP layer:

--- a/docs/index.html
+++ b/docs/index.html
@@ -429,10 +429,10 @@
               <span class="w-2.5 h-2.5 rounded-full bg-sky-400"></span>
             </div>
           </div>
-          <p class="text-slate-400 text-sm leading-relaxed mb-5">DNS proxy plus a <code class="text-slate-300">pf</code> (Packet Filter) anchor that drops outbound packets to blocked IPs at the kernel level. For when DNS isn't enough.</p>
+          <p class="text-slate-400 text-sm leading-relaxed mb-5">DNS proxy plus a <code class="text-slate-300">pf</code> (Packet Filter) anchor that drops outbound packets to blocked IPs at the kernel level. Includes an always-on <code class="text-slate-300">_doh</code> group covering public DoH/DoT endpoints, so even browsers configured for Secure DNS can't escape.</p>
           <ul class="space-y-2 mb-6 flex-1">
             <li class="flex items-center gap-2 text-sm text-slate-300"><span class="text-emerald-400">✓</span> Kernel-level IP blocking</li>
-            <li class="flex items-center gap-2 text-sm text-slate-300"><span class="text-emerald-400">✓</span> Beats hard-coded resolvers</li>
+            <li class="flex items-center gap-2 text-sm text-slate-300"><span class="text-emerald-400">✓</span> Beats browser DoH / hard-coded resolvers</li>
             <li class="flex items-center gap-2 text-sm text-slate-400"><span class="text-amber-400">!</span> macOS only</li>
             <li class="flex items-center gap-2 text-sm text-slate-400"><span class="text-slate-600">✗</span> Degrades to DNS if pf fails</li>
           </ul>
@@ -549,6 +549,10 @@
             a: `VPNs reroute your traffic but DNS resolution still goes through the system resolver (or Sentinel's local proxy in DNS/strict mode). In strict mode, pf drops IP-level packets too, so VPN tunnels that don't fully capture the system resolver are also covered.`
           },
           {
+            q: `What about browsers using DNS-over-HTTPS (DoH or "Secure DNS")?`,
+            a: `Sentinel handles all three common DoH cases. (1) Default browser installs — Chrome's automatic mode only upgrades to DoH when the system DNS is a known provider, but Sentinel sets system DNS to 127.0.0.1, so automatic mode stays on regular DNS. (2) hosts mode — getaddrinfo reads /etc/hosts before any resolver, so DoH never gets a chance to resolve a blocked domain. (3) strict mode (recommended for advanced users) — even if a user has manually picked "With Google" or "With Cloudflare" in the browser, strict mode resolves the real IPs and drops outbound packets at the kernel via pf. It also blocks the public DoH/DoT endpoints themselves on TCP/443 and TCP/UDP/853 via an always-on _doh group, so the browser can't reach the DoH provider at all. The only mode DoH can bypass is dns-only mode with a manually configured browser-level DoH provider — switch to hosts or strict and you're covered.`
+          },
+          {
             q: `Will it affect apps other than browsers?`,
             a: `Yes. Sentinel blocks at the network layer, so every app — Electron apps, Discord, games, native clients — is blocked if the domain is in your schedule. That's the advantage over browser extensions.`
           },
@@ -601,7 +605,7 @@
             </svg>
           </button>
           <div x-show="open" x-transition x-cloak class="px-6 pb-5 text-slate-400 text-sm leading-relaxed space-y-4">
-            <p>AdGuard Home is a solid network-wide DNS blocker, and Sentinel can run alongside it. But its scheduling model has hard limits that make fine-grained personal rules impractical:</p>
+            <p>AdGuard Home is a solid network-wide DNS blocker, and Sentinel can run alongside it. But its scheduling model has hard limits that make fine-grained personal rules impractical, and it can't survive a browser configured to use DNS-over-HTTPS (Secure DNS) — DoH skips the network resolver entirely. Sentinel's hosts and strict modes both stay effective in that scenario:</p>
             <div class="overflow-x-auto rounded-xl border border-slate-700">
               <table class="w-full text-xs">
                 <thead>
@@ -626,6 +630,16 @@
                     <td class="px-4 py-2.5 text-slate-300">Custom domain groups</td>
                     <td class="px-4 py-2.5 text-center text-emerald-400">✓ Any domains</td>
                     <td class="px-4 py-2.5 text-center text-slate-500">Predefined catalog only</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Survives browser DNS-over-HTTPS (Secure DNS)</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ hosts &amp; strict mode</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">✗ DoH skips it</td>
+                  </tr>
+                  <tr class="bg-[#111111]">
+                    <td class="px-4 py-2.5 text-slate-300">Kernel-level IP blocking (pf firewall)</td>
+                    <td class="px-4 py-2.5 text-center text-emerald-400">✓ strict mode (macOS)</td>
+                    <td class="px-4 py-2.5 text-center text-slate-500">✗ DNS-only</td>
                   </tr>
                   <tr class="bg-[#111111]">
                     <td class="px-4 py-2.5 text-slate-300">Browser tab auto-close on block</td>

--- a/session-log.md
+++ b/session-log.md
@@ -600,3 +600,45 @@ Asked the user to confirm what deliverable they wanted (docs vs. code change vs.
 **Lesson:** The temptation on an `explore:` issue is to skip the investigation and write a long doc. Better order: investigate first, scope the deliverable to the smallest thing that actually answers the question, only then write. The investigation-first step also caught that the codebase has grown beyond what `CLAUDE.md` describes (`enforcer`, `pf`, `cleanup` packages weren't in the architecture overview) — worth keeping in mind when working from project docs alone.
 
 **Wrap-up:** PR #89 merged into main, issue #72 closed. No release cut — pure docs change.
+
+---
+
+## May 5 — Comprehensive DoH coverage docs (issue #82)
+**Session ID:** `docs-issue-82-doh` · **PR:** TBD
+
+**Opening prompt:**
+> "continue what you were doing working on issue 82 as you finished 57. pick up from where you left off."
+
+**What happened:**
+
+Continuation session. Issue #57 (Pomodoro / focus sessions) shipped via PR #90 in the previous turn; this session was the docs sweep for issue #82, which asks: *"with recent changes that handle browser-DoH bypass, our product is now more effective than AdGuard Home — make sure that fact is reflected in the user-facing docs, the FAQ, the troubleshooting guide, and CLAUDE.md."*
+
+The underlying code work for DoH coverage was already merged in earlier PRs:
+- PR #78 — comprehensive CDN/asset coverage + opt-in `_doh` group.
+- PR #83 — port-restricted pf rules for the `_doh` group (TCP/443 + TCP+UDP/853) + strict-mode self-heal on mode downgrade.
+
+So this PR is purely docs catching up to what the code already does.
+
+### CLAUDE.md
+Architecture overview was stale (matched the codebase pre-`enforcer`/`pf`/`cleanup` packages — flagged in the previous session as worth fixing). Rewrote the "What this project does" intro to lead with the three enforcement modes and what each does. Updated the data-flow steps to mention the per-tick `pf.Refresh()` (CDN IP rotation), the per-tick AppleScript browser closer, and the new `_doh`-aware behaviour. Added rows to the package table for `internal/enforcer`, `internal/pf`, and `internal/cleanup`. Noted that strict mode is macOS-only and the factory falls back to dns mode on other OSes.
+
+### docs/index.html (landing page FAQ)
+Added a new FAQ accordion item: *"What about browsers using DNS-over-HTTPS (DoH or 'Secure DNS')?"* — walks through the three cases (default install, hosts mode, strict mode) and explains why each is covered. Updated the strict-mode card description to call out the `_doh` group explicitly. Added two rows to the AdGuard comparison table: *"Survives browser DNS-over-HTTPS (Secure DNS)"* and *"Kernel-level IP blocking (pf firewall)"* — both ✓ for Sentinel, ✗ for AdGuard. Updated the AdGuard intro paragraph to note the DoH advantage.
+
+### README.md
+Mirrored the landing-page FAQ entry, and added the same two AdGuard comparison rows so the README table matches what's on the site. The README's "Configuration" section already had a deep `_doh` group write-up from earlier work, so no further edits there.
+
+### TROUBLESHOOTING.md
+Already had a comprehensive *"Browser DNS-over-HTTPS (DoH) bypass"* section (added in PR #83). Two additions this round:
+1. **One-shot health check.** A copy-paste bash block under §4 → strict mode that runs every layer's check (service status, mode, sys DNS, dig, `pfctl -s info`, anchor presence, rule count, table dump, anchor file on disk, pf.conf injection, last-60s logs) in sequence. Lists the expected healthy output beneath the block so the reader can compare. Builds on what I'd been pasting into Claude Code while debugging strict-mode issues across PRs #78/#83/#86.
+2. **`_doh` always-on detail in the DoH section.** Added a verification command (`sudo pfctl -a sentinel -s rules | grep -E 'port = (443|853)'`) and the expected rule-set layout so users on strict mode can confirm the `_doh` rules actually loaded.
+
+### DESIGN.md
+Anchor-file model section was the most stale — said "single `<blocked_ips>` table" with one rule, but the current code generates a two-section anchor. Replaced that with the actual two-section layout (regular IPs all-port + DoH IPs port-restricted on TCP/443 and TCP+UDP/853) and explained the rationale: regular blocked IPs get all-port drops because there's no legitimate traffic to those CDNs; DoH endpoints get port-restricted drops so UDP/53 plain DNS to the same IPs (1.1.1.1, etc.) stays open for `backup_dns`. Updated the `ActivateBlock` description to match the current `ActivateBlockMixed` signature (`domains`, `dohDomains`, `primaryDNS`, `backupDNS`) and noted the deliberately-asymmetric state-kill behaviour: only regular block IPs get `pfctl -k`'d, DoH IPs are left alone to preserve the daemon's own backup-DNS sessions.
+
+### Lessons
+
+1. **Docs PRs that follow a code PR are easy to defer and easy to skip.** PR #78 added the `_doh` group, PR #83 made it port-restricted and always-on, PR #86 reorganised tab-closer behaviour around DoH-bypassed tabs — but the user-facing FAQ never said the word "DoH" until this PR. Worth flagging in a future workflow: when shipping a feature whose value only makes sense when the user *understands* an obscure threat model (DoH bypass), the doc update is part of the feature, not optional.
+2. **Docs drift from code shows up in the architecture sections first.** CLAUDE.md and DESIGN.md both still described the pre-multi-mode code layout. Worth a periodic `grep -L 'enforcer'` style audit against what actually exists in `internal/`.
+
+**Wrap-up:** PR opened with five files updated (CLAUDE.md, README.md, docs/index.html, TROUBLESHOOTING.md, DESIGN.md). Pure docs change — no release cut.


### PR DESCRIPTION
Closes #82.

## Why this PR exists

Three earlier PRs landed the *code* for comprehensive DoH/DoT bypass coverage:

- **PR #78** added the opt-in `_doh` group of public DoH/DoT endpoints.
- **PR #83** made the `_doh` group port-restricted (TCP/443 for DoH, TCP+UDP/853 for DoT) and always-on in strict mode, plus added strict-mode self-heal on mode downgrade.
- **PR #86** made the per-tick tab closer aware of tabs opened via DoH bypass mid-block.

The user-facing docs never caught up — the landing FAQ never used the word "DoH", `CLAUDE.md` still described the pre-`enforcer`/`pf`/`cleanup` package layout, and `DESIGN.md`'s anchor-file model showed a single `<blocked_ips>` table that no longer matches reality. This PR is the docs sweep that closes that gap.

## Summary

- **`docs/index.html`** (landing) — New FAQ accordion item: *"What about browsers using DNS-over-HTTPS (DoH or 'Secure DNS')?"* — walks through (1) default browser installs, (2) `hosts` mode, (3) `strict` mode + `_doh` group. Strict-mode card now explicitly mentions the always-on `_doh` group and "Beats browser DoH / hard-coded resolvers". AdGuard comparison table gains two rows: *"Survives browser DNS-over-HTTPS (Secure DNS)"* and *"Kernel-level IP blocking (pf firewall)"*.
- **`README.md`** — Mirrors the landing FAQ entry. AdGuard table parity (same two new rows + intro paragraph that calls out the DoH advantage).
- **`TROUBLESHOOTING.md`** — Two additions:
  1. *One-shot strict-mode health check* under §4 → strict mode: a single paste-able bash block that runs every layer's check (service status, mode, sys DNS, dig at 127.0.0.1, `pfctl -s info`, anchor presence, rule count, table dump, anchor file on disk, pf.conf injection, last-60s logs) with the expected healthy-output checklist beneath it. This is the long set of commands I'd been reusing while debugging strict-mode issues across PRs #78 / #83 / #86.
  2. *`_doh` always-on detail* in the existing DoH-bypass section: verification command (`sudo pfctl -a sentinel -s rules | grep -E 'port = (443|853)'`) and expected rule layout so users on strict mode can confirm the `_doh` rules actually loaded.
- **`CLAUDE.md`** — Rewrote the *"What this project does"* intro to lead with the three enforcement modes. Updated the data-flow steps to mention per-tick `pf.Refresh()` (CDN IP rotation) and per-tick AppleScript browser closer (covers DoH-bypassed tabs). Package table adds rows for `internal/enforcer`, `internal/pf`, `internal/cleanup`. Strict-mode-is-macOS-only note added to OS-specific section.
- **`DESIGN.md`** — Anchor-file model now shows the actual two-section layout (Section 1: regular IPs all-port, both protocols; Section 2: DoH/DoT IPs port-restricted on TCP/443 + TCP+UDP/853) with the rationale: regular blocked IPs get all-port drops because nothing legitimate goes to those CDNs; DoH endpoints get port-restricted drops so UDP/53 plain DNS to the same IPs (1.1.1.1, etc.) stays open for `backup_dns`. `ActivateBlock` description matches the current `ActivateBlockMixed(domains, dohDomains, primaryDNS, backupDNS)` signature and notes the asymmetric state-kill behaviour (`pfctl -k` only on regular IPs, never on DoH IPs — would otherwise drop the daemon's own backup-DNS sessions).
- **`session-log.md`** — Appended an entry describing this docs sweep.

## Gotchas / things to look for in review

- **No code changes.** This PR is pure documentation. CI green is sufficient — no release needs to be cut.
- **Landing FAQ wording is intentionally exhaustive.** The DoH FAQ entry is longer than most because (a) the threat model is non-obvious to non-technical users, and (b) the answer genuinely depends on which mode you're in. Trimming it would lose the "you're already covered if you're using the defaults" reassurance that's the main value of the entry.
- **AdGuard comparison phrasing.** Saying AdGuard "can't survive" browser DoH is accurate — DoH bypasses any network-level DNS resolver, including AdGuard Home running on the same machine. The point isn't to disparage AdGuard (it's still recommended for network-wide content filtering — that point is preserved); it's to give users the information they need to decide between the two.
- **`DESIGN.md` anchor-file rewrite touches lines that have a code-truth anchor.** The new content matches `internal/pf/pf.go:GenerateAnchorContentMixed` and `ActivateBlockMixed` as of `74c689a` — if those signatures change later, this section is the canonical doc target to update alongside.
- **`TROUBLESHOOTING.md` health-check block uses `__automatic_<hash>_0` table name lookups via `grep -oE`.** macOS pfctl auto-promotes inline IP lists to internal tables with a content-hashed name, so the script discovers the table at runtime rather than hard-coding the hash. Should keep working across pf rule edits, but verify if you ever change how the anchor renders inline-vs-explicit-table.

## Test plan

- [ ] Visually inspect the rendered FAQ accordion locally (`open docs/index.html`) — confirm the new entry expands cleanly and contains no broken markup.
- [ ] Re-read the AdGuard comparison table on both `docs/index.html` and `README.md` and confirm the two new rows render as expected.
- [ ] Skim `CLAUDE.md` and `DESIGN.md` against `internal/enforcer/`, `internal/pf/`, `internal/cleanup/` to confirm the package descriptions still match the actual package boundaries.
- [ ] On a real strict-mode install: copy-paste the one-shot health-check block from `TROUBLESHOOTING.md` and confirm every line produces output that matches the "healthy" checklist underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)