### PR TITLE
feat: opt-in foreground tab time tracking on macOS (#92)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -314,12 +314,67 @@ Each scheduler tick also:
 **Usage measurement:** `proxy/usagelog.go` records each non-blocked DNS query for a group domain as a `UsageEvent{TS, Domain, Group}` in `{configDir}/usage.jsonl`. Usage is aggregated in 5-minute buckets (`TS.Unix() / 300`) and usage minutes = `distinct buckets × 5`. The 5-minute window deduplicates Chrome's aggressive DNS re-resolution (TTL capped at 60s internally) while keeping granularity fine enough for quotas of 15+ minutes.
 
 **Known limitations:**
-- Tracking requires `dns` or `strict` mode. In `hosts` mode the proxy never sees queries.
+- Tracking requires `dns` or `strict` mode. In `hosts` mode the proxy never sees queries — see *Foreground tab tracking* below for the complementary signal that does work in `hosts` mode.
 - **Browsers with a specific DoH provider manually configured bypass usage tracking.** Chrome's automatic mode will use the system resolver (`127.0.0.1`) and is unaffected — it only upgrades to DoH when the system DNS is a known provider (8.8.8.8, 1.1.1.1), and Sentinel replaces that with `127.0.0.1`. However, if a user has explicitly set a specific DoH provider in browser settings (Chrome: "With Google" / "With Cloudflare"; Firefox: "DNS over HTTPS" set to a provider), queries are sent directly over HTTPS on port 443, completely skipping `127.0.0.1:53`. Those queries never reach the proxy, so no usage event is recorded and quota never fills up. `strict` mode does not fix this — pf blocks connections but does not intercept HTTPS traffic to DoH providers. The fix is to leave browser DNS on automatic (the default), or disable the manually configured DoH provider. See [TROUBLESHOOTING.md §4 Browser DNS-over-HTTPS bypass](./TROUBLESHOOTING.md#browser-dns-over-https-doh-bypass) for diagnostic commands.
-- Background tabs for SPAs (Reddit, YouTube) generate DNS traffic and consume quota even when the user is not actively browsing. This mirrors the behaviour of iOS Screen Time for network-active apps and cannot be solved without a browser extension.
+- Background tabs for SPAs (Reddit, YouTube) generate DNS traffic and consume quota even when the user is not actively browsing. The optional foreground-tab tracker described below sidesteps this for *measurement* (not for quota — the DNS-bucket signal still drives `DailyQuotaMinutes`).
 - The 5-minute bucket slightly over-counts sessions shorter than 5 minutes (a 2-minute visit counts as 5 minutes) and slightly under-counts if another tool (AdGuard Home, systemd-resolved) intercepts queries before they reach Sentinel.
 
 **Retention:** `usage.jsonl` is pruned once per calendar day to 60 days. The block event log (`events.jsonl`) is pruned to 30 days on the same tick.
+
+### Foreground tab tracking (macOS, opt-in)
+
+A second usage signal sits alongside DNS-bucket tracking for users who want the
+"how long did I actually look at this site" view rather than "how often did the
+machine resolve it." It's macOS-only and opt-in via `settings.enable_foreground_tracking`.
+
+**How it works.** Each scheduler tick (1/min), if the flag is on, the scheduler
+runs a single AppleScript probe that returns `frontmost_app<TAB>active_url<TAB>idle_seconds`.
+Idle comes from IOKit's `HIDIdleTime` (no entitlement needed). The active URL
+is read from `active tab of front window` for Chrome/Arc/Brave, and `current
+tab of front window` for Safari. The tick is recorded as a `UsageEvent{Kind: "foreground"}`
+in the same `usage.jsonl` only when **all** of these are true:
+
+1. `idle_seconds < 60` — user is in front of the machine (not just leaving a tab open).
+2. `frontmost_app` is one of Chrome / Safari / Arc / Brave Browser.
+3. The URL parses as `http`/`https` with a non-empty host (filters out `chrome://newtab/`, `about:blank`, etc.).
+4. The host (with `www.` stripped, lowercased, subdomain-aware) matches a domain in some configured group **other than `_doh`**.
+
+The privacy floor — point 4 — is deliberate: the tracker only ever logs domains
+the user has already configured for blocking. Visiting your bank or therapist
+records nothing. `_doh` is excluded because those endpoints aren't user-visible
+sites and the user explicitly asked us to scope the metric.
+
+**Aggregation.** Foreground events are aggregated in **1-minute** buckets
+(`TS.Unix() / 60`), one minute per distinct bucket. This is naturally
+minute-granular because the scheduler ticks each minute and emits at most one
+event per tick. DNS-kind events are still aggregated in 5-minute buckets
+(`ComputeGroupUsageMinutes` filters by `IsDNSKind()`), so the two signals stay
+independent.
+
+**Backwards compatibility.** Pre-feature `usage.jsonl` entries have no `kind`
+field. `UsageEvent.IsDNSKind()` treats empty `Kind` as `dns`, so existing logs
+keep aggregating into `used_minutes` without any migration step.
+
+**Cross-mode coverage.** Foreground tracking has no coupling to `enforcement_mode`
+— it lives in the scheduler tick, not in the enforcer. Specifically:
+
+| Mode | DNS-bucket `used_minutes` | Foreground `foreground_minutes` |
+|------|---------------------------|----------------------------------|
+| `hosts` | unavailable (no DNS proxy) | works |
+| `dns` | works | works |
+| `strict` | works | works |
+
+So foreground tracking is the *only* per-domain time signal in `hosts` mode.
+
+**Quota enforcement is unchanged.** `DailyQuotaMinutes` continues to drive off
+the DNS-bucket signal. Routing foreground time into quota is a bigger product
+decision that's deliberately out of scope for the metrics addition.
+
+**Limitations.**
+- macOS-only. Windows is tracked separately as a follow-up.
+- Browser-only. Time spent in Slack, Discord, Xcode, etc. is not counted (tracked separately as a follow-up).
+- 60-second granularity. Sessions shorter than a minute may not register.
+- Inherits the `osascript` fragility tax of the per-tick close path — same `su -` user-context elevation under launchd-as-root.
 
 ### AppleScript abstraction
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ No. The scheduler's 1-minute ticker is a regular Go timer — it doesn't issue p
 - **Set a schedule, not a willpower battle** — group the sites you want to limit (e.g. `games`, `social`) and define exactly when they're off-limits. Blocks apply the moment the clock hits your window, and lift the moment it ends.
 - **Per-group granularity, multiple windows per day** — each domain group has its own independent schedule. Stack multiple block/allow windows in the same day (e.g. block social media 9–12 and 2–6, block gaming from 8pm onward — all as separate rules).
 - **Daily quotas (allowance mode)** — optionally cap how long a group is accessible each day. Add `"daily_quota_minutes": 30` to any rule and the group is blocked for the rest of the day once 30 minutes of active DNS usage is consumed — even if the scheduled window is still open. Requires `dns` or `strict` mode.
+- **Foreground time tracking (opt-in)** — flip `"enable_foreground_tracking": true` and the dashboard shows how long each configured site was the *active* browser tab, idle-aware and ignoring background tabs. macOS-only, browser-only, and works under any enforcement mode — including `hosts`, where DNS-derived usage isn't available. Privacy-scoped to domains you've already configured for blocking. (macOS)
 - **Tabs close automatically** — every minute during an active block, Chrome, Safari, Arc, and Brave have any open tabs for blocked sites closed. This catches not just the moment the block begins but also tabs opened *during* the window (e.g., via Safari iCloud Private Relay or browser DoH that bypass DNS-layer blocking). No willpower required. (macOS)
 - **A heads-up before the block** — a native notification appears 3 minutes early so you can finish what you're doing before the sites go dark. (macOS)
 - **Live config — no restart needed** — edit the schedule file and save; changes take effect within 60 seconds.
@@ -98,6 +99,7 @@ No. The scheduler's 1-minute ticker is a regular Go timer — it doesn't issue p
 | Firewall-layer blocking (strict mode) | ✅ | ❌ |
 | Browser tab closing | ✅ Chrome, Safari | ❌ |
 | 3-minute pre-block notifications | ✅ | ❌ |
+| Foreground tab time tracking | ✅ Chrome, Safari, Arc, Brave | ❌ |
 | Auto-start on boot | ✅ | ✅ |
 | One-command clean uninstall | ✅ | ✅ |
 
@@ -270,6 +272,7 @@ The `_doh` group is **active by default in strict mode**. It contains common DNS
 - **`settings.primary_dns` / `backup_dns`** — upstream resolvers used in `dns`/`strict` mode. Ignored in `hosts` mode.
 - **`settings.dns_failure_mode`** — `"open"` (default) or `"closed"`. Controls what happens if Sentinel stops unexpectedly while in `dns`/`strict` mode. `"open"`: the OS DNS is set to `127.0.0.1 <backup_dns_host>`, so if Sentinel crashes the machine falls through to `backup_dns` and stays online (blocking lapses until launchd restarts the service). `"closed"`: only `127.0.0.1` is set — DNS fails entirely while Sentinel is down, making a crash unbypassable. Requires `backup_dns` to be a non-loopback IP on port 53; if it isn't, `"open"` silently behaves like `"closed"` and logs a warning. Ignored in `hosts` mode.
 - **`settings.auth_token`** — auto-generated on first launch. The web UI sends this in `X-Auth-Token` for every mutating API call.
+- **`settings.enable_foreground_tracking`** *(optional, default `false`, macOS-only)* — opt-in flag for foreground-tab time tracking. When on, the scheduler runs an AppleScript probe every minute to record how long the active browser tab spends on a configured (non-`_doh`) domain. Idle-aware (≥60s of no input → don't count). Records nothing for tabs whose host isn't already in one of your groups, so you cannot accidentally start logging unrelated browsing. Aggregated separately from `used_minutes` and surfaced as `foreground_minutes` on `/api/usage`. Works under any enforcement mode, including `hosts` (where DNS-derived usage isn't available). Does **not** affect `daily_quota_minutes` — quotas still drive off the DNS-bucket signal.
 - **`groups`** — named lists of domains that rules are bound to. In `hosts` mode, common prefixes (`www.`, `m.`, `mobile.`, `app.`) are blocked automatically. In `dns` mode, subdomain matching is suffix-based (`a.b.example.com` is blocked if `example.com` is in the group).
 - **`rules[].group`** — must match a key in `groups`.
 - **`rules[].is_active`** — set to `false` to suspend a rule without deleting it.

--- a/docs/index.html
+++ b/docs/index.html
@@ -284,6 +284,15 @@
           <p class="text-slate-400 text-sm leading-relaxed">Cap how long a group is accessible each day. Add <code class="text-sky-400 text-xs">daily_quota_minutes: 30</code> to any rule — once the allowance is consumed, the group blocks for the rest of the day. Requires DNS or strict mode.</p>
         </div>
 
+        <!-- Feature: Foreground tab time tracking -->
+        <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
+          <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
+            <svg class="w-5 h-5 text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-2a4 4 0 014-4h6m0 0l-3-3m3 3l-3 3M5 21h12a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+          </div>
+          <h3 class="text-white font-semibold mb-2">Foreground time tracking</h3>
+          <p class="text-slate-400 text-sm leading-relaxed">Opt-in metric for "how long was this site actually the active tab" — idle-aware, ignores background tabs, only logs sites you've already configured. Works under any enforcement mode, including <code class="text-sky-400 text-xs">hosts</code>. macOS, Chrome / Safari / Arc / Brave.</p>
+        </div>
+
         <!-- Feature: Focus sessions / Pomodoro -->
         <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
           <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,13 @@ type Settings struct {
 	AuthToken       string `json:"auth_token"`
 	EnforcementMode string `json:"enforcement_mode,omitempty"`
 	DNSFailureMode  string `json:"dns_failure_mode,omitempty"`
+	// EnableForegroundTracking turns on the per-tick AppleScript probe that
+	// records how long each blocked-list domain is actually the foreground
+	// browser tab. macOS-only; safe under any enforcement_mode (hosts/dns/strict)
+	// because the probe runs in the scheduler, independent of the enforcer. Off
+	// by default — flip to true to start populating foreground_minutes in
+	// /api/usage.
+	EnableForegroundTracking bool `json:"enable_foreground_tracking,omitempty"`
 }
 
 // GetEnforcementMode returns the validated enforcement mode, defaulting to "hosts"

--- a/internal/proxy/foreground_test.go
+++ b/internal/proxy/foreground_test.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+)
+
+// usageEventsForKindFiltering builds a fixture with both DNS and foreground
+// events on the same day, same group, same domain — used to verify the two
+// aggregations stay independent.
+func usageEventsForKindFiltering(day time.Time) []UsageEvent {
+	at := func(h, m int) time.Time {
+		return time.Date(day.Year(), day.Month(), day.Day(), h, m, 0, 0, day.Location())
+	}
+	return []UsageEvent{
+		// Three DNS events in two distinct 5-min buckets → 10 minutes used.
+		{TS: at(9, 1), Domain: "youtube.com", Group: "social"},                      // legacy empty Kind
+		{TS: at(9, 4), Domain: "youtube.com", Group: "social", Kind: KindDNS},       // explicit dns
+		{TS: at(9, 8), Domain: "youtube.com", Group: "social", Kind: KindDNS},       // distinct bucket
+		// Four foreground events in three distinct minute buckets → 3 minutes.
+		{TS: at(10, 0), Domain: "youtube.com", Group: "social", Kind: KindForeground},
+		{TS: at(10, 0), Domain: "youtube.com", Group: "social", Kind: KindForeground}, // dup minute → collapse
+		{TS: at(10, 1), Domain: "youtube.com", Group: "social", Kind: KindForeground},
+		{TS: at(10, 2), Domain: "youtube.com", Group: "social", Kind: KindForeground},
+		// Foreground for a different group on the same day.
+		{TS: at(11, 30), Domain: "reddit.com", Group: "discussion", Kind: KindForeground},
+	}
+}
+
+func TestComputeGroupUsageMinutes_IgnoresForegroundEvents(t *testing.T) {
+	day := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	events := usageEventsForKindFiltering(day)
+
+	got := ComputeGroupUsageMinutes(events, "social", day.Add(15*time.Hour))
+	if got != 10 {
+		t.Errorf("ComputeGroupUsageMinutes(social) = %d, want 10 (DNS-only buckets, foreground excluded)", got)
+	}
+}
+
+func TestComputeGroupUsageMinutes_LegacyEmptyKindStillCounts(t *testing.T) {
+	// Pre-feature usage.jsonl entries have no Kind field. They must continue to
+	// count toward used_minutes — this is the backwards-compat contract.
+	day := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	at := func(h, m int) time.Time {
+		return time.Date(day.Year(), day.Month(), day.Day(), h, m, 0, 0, day.Location())
+	}
+	events := []UsageEvent{
+		{TS: at(8, 0), Domain: "youtube.com", Group: "social"}, // empty Kind
+		{TS: at(8, 6), Domain: "youtube.com", Group: "social"}, // distinct 5-min bucket
+	}
+	if got := ComputeGroupUsageMinutes(events, "social", day.Add(12*time.Hour)); got != 10 {
+		t.Errorf("legacy events: got %d minutes, want 10", got)
+	}
+}
+
+func TestComputeGroupForegroundMinutes_DistinctMinuteBuckets(t *testing.T) {
+	day := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	events := usageEventsForKindFiltering(day)
+
+	got := ComputeGroupForegroundMinutes(events, "social", day.Add(15*time.Hour))
+	if got != 3 {
+		t.Errorf("ComputeGroupForegroundMinutes(social) = %d, want 3 (distinct minute buckets)", got)
+	}
+
+	// Other group only has one foreground event.
+	if got := ComputeGroupForegroundMinutes(events, "discussion", day.Add(15*time.Hour)); got != 1 {
+		t.Errorf("ComputeGroupForegroundMinutes(discussion) = %d, want 1", got)
+	}
+}
+
+func TestComputeGroupForegroundMinutes_IgnoresDNSEvents(t *testing.T) {
+	day := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	at := func(h, m int) time.Time {
+		return time.Date(day.Year(), day.Month(), day.Day(), h, m, 0, 0, day.Location())
+	}
+	events := []UsageEvent{
+		{TS: at(8, 0), Domain: "youtube.com", Group: "social", Kind: KindDNS},
+		{TS: at(8, 1), Domain: "youtube.com", Group: "social"}, // legacy empty
+	}
+	if got := ComputeGroupForegroundMinutes(events, "social", day.Add(12*time.Hour)); got != 0 {
+		t.Errorf("foreground aggregator must ignore DNS-kind events; got %d", got)
+	}
+}
+
+func TestComputeGroupForegroundMinutes_DayBoundary(t *testing.T) {
+	// Events outside the calendar day of `t` must not count.
+	day := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	yesterday := day.Add(-1 * time.Hour) // previous day, late evening
+	tomorrow := day.Add(25 * time.Hour)
+	events := []UsageEvent{
+		{TS: yesterday, Domain: "youtube.com", Group: "social", Kind: KindForeground},
+		{TS: tomorrow, Domain: "youtube.com", Group: "social", Kind: KindForeground},
+		{TS: day.Add(10 * time.Hour), Domain: "youtube.com", Group: "social", Kind: KindForeground},
+	}
+	if got := ComputeGroupForegroundMinutes(events, "social", day.Add(15*time.Hour)); got != 1 {
+		t.Errorf("expected 1 minute (only same-day event), got %d", got)
+	}
+}
+
+func TestUsageEvent_IsDNSKind(t *testing.T) {
+	cases := []struct {
+		kind string
+		want bool
+	}{
+		{"", true},
+		{KindDNS, true},
+		{KindForeground, false},
+		{"unknown", false},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			if got := (UsageEvent{Kind: c.kind}).IsDNSKind(); got != c.want {
+				t.Errorf("IsDNSKind(%q) = %v, want %v", c.kind, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/proxy/usagelog.go
+++ b/internal/proxy/usagelog.go
@@ -10,11 +10,36 @@ import (
 	"github.com/vsangava/sentinel/internal/config"
 )
 
-// UsageEvent records a single DNS lookup for a domain in a known group.
+// UsageEvent records a single observation that a domain in a known group was
+// touched by the user. Two flavours coexist in the same JSONL log:
+//
+//   - Kind == "" (legacy) or "dns": one entry per DNS lookup. Aggregated into
+//     5-minute buckets — feeds the existing used_minutes / quota signal.
+//   - Kind == "foreground": one entry per scheduler tick where the active
+//     browser tab matched a configured group. Aggregated into 1-minute buckets
+//     — feeds foreground_minutes. macOS-only.
+//
+// The empty-string default for Kind is intentional — it keeps every entry that
+// existed before foreground tracking was introduced parsing as DNS without a
+// migration step.
 type UsageEvent struct {
 	TS     time.Time `json:"ts"`
 	Domain string    `json:"domain"`
 	Group  string    `json:"group"`
+	Kind   string    `json:"kind,omitempty"`
+}
+
+// Usage event Kind constants. Empty Kind on an existing event is equivalent to
+// KindDNS for backwards compatibility.
+const (
+	KindDNS        = "dns"
+	KindForeground = "foreground"
+)
+
+// IsDNSKind reports whether a UsageEvent should count toward DNS-bucket usage.
+// Treats the legacy empty Kind as DNS so pre-feature events keep aggregating.
+func (e UsageEvent) IsDNSKind() bool {
+	return e.Kind == "" || e.Kind == KindDNS
 }
 
 func usageFilePath() string {
@@ -108,13 +133,18 @@ func bucketKey(t time.Time) int64 {
 
 // ComputeGroupUsageMinutes returns the number of minutes a group was actively
 // used on the calendar day containing t, derived from the provided events.
-// Usage is measured in distinct 5-minute buckets × 5 minutes.
+// Usage is measured in distinct 5-minute buckets × 5 minutes. Only DNS-kind
+// events count — foreground events live alongside in the same log but are
+// aggregated separately via ComputeGroupForegroundMinutes.
 func ComputeGroupUsageMinutes(events []UsageEvent, group string, t time.Time) int {
 	dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 	dayEnd := dayStart.Add(24 * time.Hour)
 
 	buckets := make(map[int64]struct{})
 	for _, e := range events {
+		if !e.IsDNSKind() {
+			continue
+		}
 		if e.Group != group {
 			continue
 		}
@@ -134,4 +164,35 @@ func ComputeAllGroupUsageMinutes(events []UsageEvent, groups []string, t time.Ti
 		result[g] = ComputeGroupUsageMinutes(events, g, t)
 	}
 	return result
+}
+
+// minuteBucketKey returns the 1-minute bucket for a timestamp. Foreground
+// observations are minute-granular by construction (one per scheduler tick),
+// so 5-minute bucketing would only obscure the signal.
+func minuteBucketKey(t time.Time) int64 {
+	return t.Unix() / 60
+}
+
+// ComputeGroupForegroundMinutes returns minutes spent with the foreground
+// browser tab on a domain in `group`, for the calendar day containing t.
+// Counts distinct 1-minute buckets — duplicate observations within the same
+// minute (shouldn't happen, but harmless) collapse to a single tick.
+func ComputeGroupForegroundMinutes(events []UsageEvent, group string, t time.Time) int {
+	dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	dayEnd := dayStart.Add(24 * time.Hour)
+
+	buckets := make(map[int64]struct{})
+	for _, e := range events {
+		if e.Kind != KindForeground {
+			continue
+		}
+		if e.Group != group {
+			continue
+		}
+		if e.TS.Before(dayStart) || !e.TS.Before(dayEnd) {
+			continue
+		}
+		buckets[minuteBucketKey(e.TS)] = struct{}{}
+	}
+	return len(buckets)
 }

--- a/internal/scheduler/foreground.go
+++ b/internal/scheduler/foreground.go
@@ -1,0 +1,258 @@
+package scheduler
+
+import (
+	"fmt"
+	neturl "net/url"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/enforcer"
+	"github.com/vsangava/sentinel/internal/proxy"
+)
+
+// foregroundIdleCutoffSeconds is the threshold above which the user is treated
+// as idle (away from keyboard). Set to 60 because the scheduler ticks every
+// minute, so any idle period >= 60s means the user has been away across at
+// least one full sample interval — attributing that minute to the last
+// foreground tab would inflate the metric. Anything under is "in front of the
+// machine doing something."
+const foregroundIdleCutoffSeconds = 60
+
+// supportedForegroundBrowsers mirrors the set the per-tick close path supports.
+// AppleScript URL access uses a slightly different idiom for Safari ("current
+// tab") vs the others ("active tab"), handled inside the probe script.
+var supportedForegroundBrowsers = []string{
+	"Google Chrome",
+	"Safari",
+	"Arc",
+	"Brave Browser",
+}
+
+// ForegroundProbeResult is the parsed output of one probe invocation.
+//
+//   - App is the macOS frontmost application name (e.g. "Google Chrome").
+//   - URL is the active tab URL when App is a supported browser; "" otherwise.
+//   - IdleSeconds is how long the user has been idle (no keyboard/mouse input).
+type ForegroundProbeResult struct {
+	App         string
+	URL         string
+	IdleSeconds int
+}
+
+// ForegroundProbeGenerator interface so tests can swap in a deterministic
+// script body without forking osascript.
+type ForegroundProbeGenerator interface {
+	GenerateForegroundProbeScript() string
+}
+
+// MacOSForegroundProbeGenerator emits AppleScript that prints
+// `frontmost_app<TAB>active_url<TAB>idle_seconds` on stdout.
+type MacOSForegroundProbeGenerator struct{}
+
+func (g *MacOSForegroundProbeGenerator) GenerateForegroundProbeScript() string {
+	// Per-browser URL fetches are wrapped individually so a single
+	// "Application isn't running" (-600) fails the inner block, not the whole
+	// probe — same defensive shape used by GenerateCloseTabsScript.
+	//
+	// Idle time comes from IOKit (HIDIdleTime in nanoseconds). It needs no
+	// special permission and is the standard idiom; AppleScript has no
+	// first-class idle-time accessor.
+	return `
+		set frontApp to ""
+		set activeURL to ""
+		set idleSeconds to 0
+
+		try
+			tell application "System Events"
+				set frontApp to name of first application process whose frontmost is true
+			end tell
+		end try
+
+		try
+			set idleNanos to do shell script "/usr/sbin/ioreg -c IOHIDSystem | /usr/bin/awk '/HIDIdleTime/ {print int($NF/1000000000); exit}'"
+			set idleSeconds to idleNanos as integer
+		end try
+
+		if frontApp is "Google Chrome" then
+			try
+				tell application "Google Chrome" to set activeURL to URL of active tab of front window
+			end try
+		else if frontApp is "Safari" then
+			try
+				tell application "Safari" to set activeURL to URL of current tab of front window
+			end try
+		else if frontApp is "Arc" then
+			try
+				tell application "Arc" to set activeURL to URL of active tab of front window
+			end try
+		else if frontApp is "Brave Browser" then
+			try
+				tell application "Brave Browser" to set activeURL to URL of active tab of front window
+			end try
+		end if
+
+		return frontApp & tab & activeURL & tab & (idleSeconds as text)
+	`
+}
+
+var foregroundProbeGenerator ForegroundProbeGenerator = &MacOSForegroundProbeGenerator{}
+
+// SetForegroundProbeGenerator replaces the probe-script generator. Tests use
+// this to substitute a stub.
+func SetForegroundProbeGenerator(g ForegroundProbeGenerator) {
+	foregroundProbeGenerator = g
+}
+
+// runForegroundProbe is the production probe runner — executes the generated
+// AppleScript and returns its stdout. Replaceable in tests.
+var runForegroundProbe = func() (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", nil
+	}
+	return runOsaScriptCapture(foregroundProbeGenerator.GenerateForegroundProbeScript())
+}
+
+// parseForegroundProbeOutput parses the tab-separated probe output.
+// Trailing whitespace from AppleScript is tolerated; an empty/missing URL
+// field is normal (frontmost app isn't a supported browser).
+func parseForegroundProbeOutput(out string) (ForegroundProbeResult, error) {
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return ForegroundProbeResult{}, fmt.Errorf("probe produced no output")
+	}
+	parts := strings.SplitN(line, "\t", 3)
+	if len(parts) != 3 {
+		return ForegroundProbeResult{}, fmt.Errorf("probe output malformed (expected 3 tab-separated fields, got %d): %q", len(parts), line)
+	}
+	idle, err := strconv.Atoi(strings.TrimSpace(parts[2]))
+	if err != nil {
+		return ForegroundProbeResult{}, fmt.Errorf("probe output: idle seconds not an integer: %w", err)
+	}
+	return ForegroundProbeResult{
+		App:         strings.TrimSpace(parts[0]),
+		URL:         strings.TrimSpace(parts[1]),
+		IdleSeconds: idle,
+	}, nil
+}
+
+// trackedDomainSet returns every domain across every group in cfg, except the
+// _doh group. Foreground tracking is opt-in to "domains the user explicitly
+// configured for blocking" — _doh is infrastructure, not user-tracked sites,
+// and its endpoints aren't visited via browsers anyway.
+func trackedDomainSet(cfg config.Config) map[string]bool {
+	out := make(map[string]bool)
+	for group, domains := range cfg.Groups {
+		if group == enforcer.DohGroupName {
+			continue
+		}
+		for _, d := range domains {
+			out[d] = true
+		}
+	}
+	return out
+}
+
+// matchTrackedDomain returns the configured domain that host belongs to, or ""
+// if none. host should already have a leading "www." stripped. Subdomain-aware:
+// "music.youtube.com" matches a configured "youtube.com".
+func matchTrackedDomain(host string, tracked map[string]bool) string {
+	if host == "" {
+		return ""
+	}
+	if tracked[host] {
+		return host
+	}
+	for d := range tracked {
+		if strings.HasSuffix(host, "."+d) {
+			return d
+		}
+	}
+	return ""
+}
+
+// extractHost pulls the lowercase, www-stripped hostname from a browser-tab
+// URL. Returns "" on any parse failure, missing host, or non-http(s) scheme.
+// The scheme gate is deliberate: chrome://newtab/, brave://settings/, file://,
+// about:blank etc. are internal browser URLs, not web destinations — they must
+// not feed the tracked-domain matcher (otherwise "newtab" could be parsed out
+// and a configured "newtab.example" would falsely attribute time).
+func extractHost(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	return strings.TrimPrefix(host, "www.")
+}
+
+// isSupportedBrowser reports whether name is one of the browsers the probe
+// can read tab URLs from.
+func isSupportedBrowser(name string) bool {
+	for _, b := range supportedForegroundBrowsers {
+		if b == name {
+			return true
+		}
+	}
+	return false
+}
+
+// recordForegroundTick is the per-tick gate: probe → parse → filter → emit one
+// usage event when every condition passes. Returns ok=false (no event to
+// append) on any miss, with no error logged — these are normal cases (no
+// browser frontmost, idle, off-list domain).
+//
+// groupLookup is the shared domain→group map already built each tick by the
+// scheduler; reusing it avoids walking cfg.Groups again here.
+func recordForegroundTick(t time.Time, cfg config.Config, runProbe func() (string, error), groupLookup map[string]string) (proxy.UsageEvent, bool, error) {
+	out, err := runProbe()
+	if err != nil {
+		return proxy.UsageEvent{}, false, err
+	}
+	if strings.TrimSpace(out) == "" {
+		// Non-darwin / no GUI session: probe is a no-op, no event to record.
+		return proxy.UsageEvent{}, false, nil
+	}
+
+	res, err := parseForegroundProbeOutput(out)
+	if err != nil {
+		return proxy.UsageEvent{}, false, err
+	}
+	if res.IdleSeconds >= foregroundIdleCutoffSeconds {
+		return proxy.UsageEvent{}, false, nil
+	}
+	if !isSupportedBrowser(res.App) {
+		return proxy.UsageEvent{}, false, nil
+	}
+	host := extractHost(res.URL)
+	if host == "" {
+		return proxy.UsageEvent{}, false, nil
+	}
+
+	tracked := trackedDomainSet(cfg)
+	matched := matchTrackedDomain(host, tracked)
+	if matched == "" {
+		return proxy.UsageEvent{}, false, nil
+	}
+	group := groupLookup[matched]
+	if group == "" {
+		// Defensive: matched came from cfg.Groups, so a missing lookup entry
+		// should be impossible. Skip rather than emit a group-less event.
+		return proxy.UsageEvent{}, false, nil
+	}
+	return proxy.UsageEvent{
+		TS:     t,
+		Domain: matched,
+		Group:  group,
+		Kind:   proxy.KindForeground,
+	}, true, nil
+}

--- a/internal/scheduler/foreground_test.go
+++ b/internal/scheduler/foreground_test.go
@@ -1,0 +1,295 @@
+package scheduler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/proxy"
+)
+
+// withForegroundProbeStub swaps runForegroundProbe with a stub that returns the
+// given output (and optional error). Restores the original on test cleanup so
+// parallel tests don't leak state into each other.
+func withForegroundProbeStub(t *testing.T, out string, runErr error) {
+	t.Helper()
+	orig := runForegroundProbe
+	runForegroundProbe = func() (string, error) { return out, runErr }
+	t.Cleanup(func() { runForegroundProbe = orig })
+}
+
+// trackedCfg builds a minimal config covering the tracked-domain branches.
+func trackedCfg() config.Config {
+	return config.Config{
+		Groups: map[string][]string{
+			"social": {"youtube.com", "reddit.com"},
+			"_doh":   {"dns.google", "cloudflare-dns.com"},
+		},
+	}
+}
+
+func TestParseForegroundProbeOutput_HappyPath(t *testing.T) {
+	res, err := parseForegroundProbeOutput("Google Chrome\thttps://www.youtube.com/watch?v=abc\t3\n")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res.App != "Google Chrome" {
+		t.Errorf("App = %q, want Google Chrome", res.App)
+	}
+	if res.URL != "https://www.youtube.com/watch?v=abc" {
+		t.Errorf("URL = %q", res.URL)
+	}
+	if res.IdleSeconds != 3 {
+		t.Errorf("IdleSeconds = %d, want 3", res.IdleSeconds)
+	}
+}
+
+func TestParseForegroundProbeOutput_EmptyURL(t *testing.T) {
+	// Frontmost is a non-browser app — URL field is empty by design.
+	res, err := parseForegroundProbeOutput("Slack\t\t12")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res.App != "Slack" || res.URL != "" || res.IdleSeconds != 12 {
+		t.Errorf("got %+v", res)
+	}
+}
+
+func TestParseForegroundProbeOutput_Malformed(t *testing.T) {
+	cases := []string{
+		"",
+		"only one field",
+		"two\tfields",
+		"app\turl\tnotanint",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parseForegroundProbeOutput(in); err == nil {
+				t.Errorf("expected error for %q, got nil", in)
+			}
+		})
+	}
+}
+
+func TestTrackedDomainSet_ExcludesDoH(t *testing.T) {
+	cfg := trackedCfg()
+	got := trackedDomainSet(cfg)
+	if !got["youtube.com"] || !got["reddit.com"] {
+		t.Errorf("missing tracked domain: %v", got)
+	}
+	if got["dns.google"] || got["cloudflare-dns.com"] {
+		t.Errorf("trackedDomainSet leaked _doh entry: %v", got)
+	}
+}
+
+func TestMatchTrackedDomain(t *testing.T) {
+	tracked := map[string]bool{"youtube.com": true, "reddit.com": true}
+	cases := []struct {
+		host, want string
+	}{
+		{"youtube.com", "youtube.com"},
+		{"music.youtube.com", "youtube.com"},
+		{"old.reddit.com", "reddit.com"},
+		{"notyoutube.com", ""},
+		{"", ""},
+		{"example.com", ""},
+		// "youtubex.com" must not match "youtube.com" — partial-string false positive guard.
+		{"youtubex.com", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.host, func(t *testing.T) {
+			got := matchTrackedDomain(c.host, tracked)
+			if got != c.want {
+				t.Errorf("matchTrackedDomain(%q) = %q, want %q", c.host, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractHost(t *testing.T) {
+	cases := []struct {
+		raw, want string
+	}{
+		{"https://www.youtube.com/watch?v=abc", "youtube.com"},
+		{"https://music.YOUTUBE.com/", "music.youtube.com"},
+		{"http://reddit.com", "reddit.com"},
+		{"about:blank", ""},
+		{"chrome://newtab/", ""},
+		{"", ""},
+		{"::not a url::", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			if got := extractHost(c.raw); got != c.want {
+				t.Errorf("extractHost(%q) = %q, want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestGenerateForegroundProbeScript_IncludesAllBrowsers(t *testing.T) {
+	g := &MacOSForegroundProbeGenerator{}
+	script := g.GenerateForegroundProbeScript()
+	for _, browser := range []string{"Google Chrome", "Safari", "Arc", "Brave Browser"} {
+		if !strings.Contains(script, browser) {
+			t.Errorf("probe script missing browser %q", browser)
+		}
+	}
+	// Different idiom for Safari than the others — important.
+	if !strings.Contains(script, "current tab of front window") {
+		t.Error("probe script missing Safari 'current tab of front window' idiom")
+	}
+	if !strings.Contains(script, "active tab of front window") {
+		t.Error("probe script missing Chromium 'active tab of front window' idiom")
+	}
+	// HIDIdleTime is the only standard idle source available without entitlements.
+	if !strings.Contains(script, "HIDIdleTime") {
+		t.Error("probe script missing HIDIdleTime idle-source idiom")
+	}
+	// Must emit tab-separated output for parseForegroundProbeOutput.
+	if !strings.Contains(script, "frontApp & tab & activeURL & tab") {
+		t.Error("probe script missing tab-separated stdout return")
+	}
+}
+
+func TestRecordForegroundTick_HappyPath(t *testing.T) {
+	withForegroundProbeStub(t, "Google Chrome\thttps://music.youtube.com/playlist\t0", nil)
+
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	gl := BuildGroupLookup(cfg)
+
+	event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, gl)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected event to be emitted")
+	}
+	if event.Domain != "youtube.com" {
+		t.Errorf("Domain = %q, want youtube.com (subdomain attribution)", event.Domain)
+	}
+	if event.Group != "social" {
+		t.Errorf("Group = %q, want social", event.Group)
+	}
+	if event.Kind != proxy.KindForeground {
+		t.Errorf("Kind = %q, want foreground", event.Kind)
+	}
+	if !event.TS.Equal(now) {
+		t.Errorf("TS = %v, want %v", event.TS, now)
+	}
+}
+
+func TestRecordForegroundTick_IdleAboveCutoff(t *testing.T) {
+	withForegroundProbeStub(t, "Google Chrome\thttps://youtube.com\t120", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("idle >= cutoff should suppress the event")
+	}
+}
+
+func TestRecordForegroundTick_NonBrowserApp(t *testing.T) {
+	withForegroundProbeStub(t, "Slack\t\t0", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("non-browser frontmost app should suppress the event")
+	}
+}
+
+func TestRecordForegroundTick_DomainNotInGroups(t *testing.T) {
+	withForegroundProbeStub(t, "Safari\thttps://example.com/article\t0", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("untracked domain should suppress the event (privacy floor)")
+	}
+}
+
+func TestRecordForegroundTick_DohDomainExcluded(t *testing.T) {
+	// Even if a user pulls up a DoH provider's marketing page, _doh entries
+	// must not be tracked as foreground time.
+	withForegroundProbeStub(t, "Google Chrome\thttps://dns.google/\t0", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("_doh domain visited in browser must not produce a foreground event")
+	}
+}
+
+func TestRecordForegroundTick_EmptyProbeOutputIsNoOp(t *testing.T) {
+	// Non-darwin (or no GUI session) → empty stdout. Must NOT be treated as an
+	// error and must NOT emit an event.
+	withForegroundProbeStub(t, "", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Errorf("expected no error on empty probe output, got %v", err)
+	}
+	if ok {
+		t.Error("empty probe output must not produce an event")
+	}
+}
+
+func TestRecordForegroundTick_ProbeError(t *testing.T) {
+	stubErr := errors.New("osascript exited 1")
+	withForegroundProbeStub(t, "", stubErr)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err == nil {
+		t.Error("expected probe error to propagate")
+	}
+	if ok {
+		t.Error("probe error must not produce an event")
+	}
+}
+
+func TestRecordForegroundTick_StripsWWW(t *testing.T) {
+	// www.youtube.com must collapse to youtube.com (matches the configured group entry).
+	withForegroundProbeStub(t, "Google Chrome\thttps://www.youtube.com/\t0", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil || !ok {
+		t.Fatalf("expected event, got ok=%v err=%v", ok, err)
+	}
+	if event.Domain != "youtube.com" {
+		t.Errorf("Domain = %q, want youtube.com after www strip", event.Domain)
+	}
+}
+
+func TestRecordForegroundTick_BlankURLForBrowser(t *testing.T) {
+	// User has Chrome frontmost on a chrome://newtab/ tab — URL field is the
+	// blank/internal page, no host. No event should fire.
+	withForegroundProbeStub(t, "Google Chrome\tchrome://newtab/\t0", nil)
+	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
+	cfg := trackedCfg()
+	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Error("internal browser URL with no host must not produce an event")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -552,6 +552,21 @@ func evaluateRules() {
 	// with browsers, and probing for them wastes osascript work.
 	runPerTickCloseTabs(newBlocked, cfg, browserTabProbe)
 
+	// Per-tick foreground-tab tracker. Off by default; opt-in via
+	// settings.enable_foreground_tracking. Independent of enforcement_mode —
+	// works under hosts/dns/strict alike, and is the only per-domain time signal
+	// available in hosts mode (no DNS proxy → no DNS-bucket usage events).
+	if cfg.Settings.EnableForegroundTracking {
+		event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, gl)
+		if err != nil {
+			log.Printf("scheduler: foreground probe: %v", err)
+		} else if ok {
+			if err := proxy.AppendUsageEvent(event); err != nil {
+				log.Printf("scheduler: append foreground usage: %v", err)
+			}
+		}
+	}
+
 	// Log block/unblock events grouped by config group.
 	if len(newlyBlocked) > 0 || len(newlyUnblocked) > 0 {
 		blockedSet := make(map[string]bool, len(newlyBlocked))

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -577,11 +577,16 @@ func UsageHandler(w http.ResponseWriter, r *http.Request) {
 
 	cfg := config.GetConfig()
 
-	// Per-group totals.
+	// Per-group totals. used_minutes comes from DNS-kind events bucketed in
+	// 5-minute windows (preserves existing semantics + quota signal).
+	// foreground_minutes comes from foreground-kind events bucketed in 1-minute
+	// windows — naturally minute-granular because the scheduler ticks each
+	// minute and emits at most one foreground event per tick.
 	type groupRow struct {
-		Group        string `json:"group"`
-		UsedMinutes  int    `json:"used_minutes"`
-		QuotaMinutes int    `json:"quota_minutes,omitempty"`
+		Group              string `json:"group"`
+		UsedMinutes        int    `json:"used_minutes"`
+		ForegroundMinutes  int    `json:"foreground_minutes,omitempty"`
+		QuotaMinutes       int    `json:"quota_minutes,omitempty"`
 	}
 	groupMap := make(map[string]*groupRow)
 	for _, rule := range cfg.Rules {
@@ -590,51 +595,83 @@ func UsageHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Per-domain totals using 5-min bucket deduplication.
 	type domainRow struct {
-		Domain      string `json:"domain"`
-		Group       string `json:"group"`
-		UsedMinutes int    `json:"used_minutes"`
+		Domain             string `json:"domain"`
+		Group              string `json:"group"`
+		UsedMinutes        int    `json:"used_minutes"`
+		ForegroundMinutes  int    `json:"foreground_minutes,omitempty"`
 	}
-	domainBuckets := make(map[string]map[int64]struct{}) // domain → set of bucket keys
-	groupBuckets := make(map[string]map[int64]struct{})  // group → set of bucket keys
+	// DNS-kind aggregations: 5-minute buckets per domain/group.
+	dnsDomainBuckets := make(map[string]map[int64]struct{})
+	dnsGroupBuckets := make(map[string]map[int64]struct{})
+	// Foreground-kind aggregations: 1-minute buckets per domain/group.
+	fgDomainBuckets := make(map[string]map[int64]struct{})
+	fgGroupBuckets := make(map[string]map[int64]struct{})
 
 	for _, e := range events {
+		if e.Kind == proxy.KindForeground {
+			bk := e.TS.Unix() / 60
+			if fgDomainBuckets[e.Domain] == nil {
+				fgDomainBuckets[e.Domain] = make(map[int64]struct{})
+			}
+			fgDomainBuckets[e.Domain][bk] = struct{}{}
+			if fgGroupBuckets[e.Group] == nil {
+				fgGroupBuckets[e.Group] = make(map[int64]struct{})
+			}
+			fgGroupBuckets[e.Group][bk] = struct{}{}
+			continue
+		}
+		// DNS or legacy (empty Kind).
 		bk := e.TS.Unix() / 300
-		if domainBuckets[e.Domain] == nil {
-			domainBuckets[e.Domain] = make(map[int64]struct{})
+		if dnsDomainBuckets[e.Domain] == nil {
+			dnsDomainBuckets[e.Domain] = make(map[int64]struct{})
 		}
-		domainBuckets[e.Domain][bk] = struct{}{}
-		if groupBuckets[e.Group] == nil {
-			groupBuckets[e.Group] = make(map[int64]struct{})
+		dnsDomainBuckets[e.Domain][bk] = struct{}{}
+		if dnsGroupBuckets[e.Group] == nil {
+			dnsGroupBuckets[e.Group] = make(map[int64]struct{})
 		}
-		groupBuckets[e.Group][bk] = struct{}{}
+		dnsGroupBuckets[e.Group][bk] = struct{}{}
 	}
 
-	// Populate group rows.
-	for group, buckets := range groupBuckets {
+	// Populate group rows from DNS buckets.
+	for group, buckets := range dnsGroupBuckets {
 		if row, ok := groupMap[group]; ok {
 			row.UsedMinutes = len(buckets) * 5
 		} else {
 			groupMap[group] = &groupRow{Group: group, UsedMinutes: len(buckets) * 5}
 		}
 	}
+	for group, buckets := range fgGroupBuckets {
+		if row, ok := groupMap[group]; ok {
+			row.ForegroundMinutes = len(buckets)
+		} else {
+			groupMap[group] = &groupRow{Group: group, ForegroundMinutes: len(buckets)}
+		}
+	}
 	groups := make([]groupRow, 0, len(groupMap))
 	for _, row := range groupMap {
-		if row.UsedMinutes > 0 || row.QuotaMinutes > 0 {
+		if row.UsedMinutes > 0 || row.ForegroundMinutes > 0 || row.QuotaMinutes > 0 {
 			groups = append(groups, *row)
 		}
 	}
 
-	// Build per-domain rows.
-	domainRows := make([]domainRow, 0, len(domainBuckets))
-	// Build domain→group from config for labelling.
+	// Build per-domain rows. Union of DNS + foreground domain keys so domains
+	// that show up only as foreground events (e.g. hosts mode) still appear.
 	gl := scheduler.BuildGroupLookup(cfg)
-	for domain, buckets := range domainBuckets {
+	domainKeys := make(map[string]struct{})
+	for d := range dnsDomainBuckets {
+		domainKeys[d] = struct{}{}
+	}
+	for d := range fgDomainBuckets {
+		domainKeys[d] = struct{}{}
+	}
+	domainRows := make([]domainRow, 0, len(domainKeys))
+	for domain := range domainKeys {
 		domainRows = append(domainRows, domainRow{
-			Domain:      domain,
-			Group:       gl[domain],
-			UsedMinutes: len(buckets) * 5,
+			Domain:             domain,
+			Group:              gl[domain],
+			UsedMinutes:        len(dnsDomainBuckets[domain]) * 5,
+			ForegroundMinutes:  len(fgDomainBuckets[domain]),
 		})
 	}
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -814,14 +814,19 @@
     <div id="usageTab" class="tab-content">
         <div class="section">
             <div class="section-header">
-                <div class="section-title">DNS Usage</div>
+                <div class="section-title">Usage</div>
                 <button class="btn-sm btn-success" onclick="loadUsage()">↻ Refresh</button>
             </div>
             <p style="font-size:12px;color:#6c757d;margin-bottom:14px;">
-                Measures time groups were actively used, based on DNS query patterns.
-                Requires <strong>dns</strong> or <strong>strict</strong> enforcement mode.
-                Background tabs for SPAs (Reddit, YouTube) may count toward usage.
-                Browsers in their default configuration are unaffected. If you have manually set a specific DoH provider in browser settings (Chrome: "With Google"/"With Cloudflare"; Firefox: "DNS over HTTPS" set to a provider), those queries bypass the proxy and will not be counted.
+                <strong>Used</strong> measures time groups were actively used, based on DNS query patterns —
+                requires <strong>dns</strong> or <strong>strict</strong> enforcement mode, and may count
+                background SPA tabs (Reddit, YouTube). If you've manually configured a DoH provider in your
+                browser, those queries bypass the proxy and are not counted.
+            </p>
+            <p style="font-size:12px;color:#6c757d;margin-bottom:14px;">
+                <strong>Foreground</strong> measures time the active browser tab was on a configured domain.
+                macOS-only; opt-in via <code>settings.enable_foreground_tracking</code>; works under any
+                enforcement mode (including <strong>hosts</strong>); ignores background tabs and idle periods.
             </p>
             <div class="usage-range-row" id="usageRangeRow">
                 <span style="font-size:12px;font-weight:600;color:#6c757d;">Range:</span>
@@ -1710,14 +1715,20 @@ async function loadUsage() {
             return;
         }
 
-        var groups  = (data.groups  || []).sort(function(a,b){ return b.used_minutes - a.used_minutes; });
-        var domains = (data.domains || []).sort(function(a,b){ return b.used_minutes - a.used_minutes; });
+        // Sort: rows with the most signal first — prefer the larger of used vs.
+        // foreground so a hosts-mode user (foreground only) still sees a useful order.
+        function sortKey(row) {
+            return Math.max(row.used_minutes || 0, row.foreground_minutes || 0);
+        }
+        var groups  = (data.groups  || []).sort(function(a,b){ return sortKey(b) - sortKey(a); });
+        var domains = (data.domains || []).sort(function(a,b){ return sortKey(b) - sortKey(a); });
 
         var html = '';
 
         if (groups.length === 0 && domains.length === 0) {
             html = '<p style="color:#adb5bd;font-size:13px;">No usage data for this range. ' +
-                'Usage tracking requires dns or strict enforcement mode.</p>';
+                'DNS-based usage requires dns or strict enforcement mode; foreground tracking ' +
+                'requires <code>enable_foreground_tracking: true</code> on macOS.</p>';
         } else {
             if (groups.length > 0) {
                 html += '<div class="section-title" style="margin-bottom:8px;">Groups</div>';
@@ -1725,23 +1736,31 @@ async function loadUsage() {
                     var quotaCell = g.quota_minutes
                         ? '<td class="usage-mins">' + g.quota_minutes + '</td>'
                         : '<td style="color:#adb5bd">—</td>';
+                    var fgCell = (g.foreground_minutes && g.foreground_minutes > 0)
+                        ? '<td class="usage-mins">' + g.foreground_minutes + '</td>'
+                        : '<td style="color:#adb5bd">—</td>';
                     return '<tr><td style="font-weight:600">' + escapeHtml(g.group) + '</td>' +
-                        '<td class="usage-mins">' + g.used_minutes + '</td>' + quotaCell + '</tr>';
+                        '<td class="usage-mins">' + (g.used_minutes || 0) + '</td>' +
+                        fgCell + quotaCell + '</tr>';
                 }).join('');
                 html += '<table class="usage-table" style="margin-bottom:20px;">' +
-                    '<thead><tr><th>Group</th><th>Used (min)</th><th>Quota (min)</th></tr></thead>' +
+                    '<thead><tr><th>Group</th><th>Used (min)</th><th>Foreground (min)</th><th>Quota (min)</th></tr></thead>' +
                     '<tbody>' + gRows + '</tbody></table>';
             }
 
             if (domains.length > 0) {
                 html += '<div class="section-title" style="margin-bottom:8px;">Domains</div>';
                 var dRows = domains.map(function(d) {
+                    var fgCell = (d.foreground_minutes && d.foreground_minutes > 0)
+                        ? '<td class="usage-mins">' + d.foreground_minutes + '</td>'
+                        : '<td style="color:#adb5bd">—</td>';
                     return '<tr><td style="font-family:monospace">' + escapeHtml(d.domain) + '</td>' +
                         '<td style="color:#6c757d">' + escapeHtml(d.group || '—') + '</td>' +
-                        '<td class="usage-mins">' + d.used_minutes + '</td></tr>';
+                        '<td class="usage-mins">' + (d.used_minutes || 0) + '</td>' +
+                        fgCell + '</tr>';
                 }).join('');
                 html += '<table class="usage-table">' +
-                    '<thead><tr><th>Domain</th><th>Group</th><th>Used (min)</th></tr></thead>' +
+                    '<thead><tr><th>Domain</th><th>Group</th><th>Used (min)</th><th>Foreground (min)</th></tr></thead>' +
                     '<tbody>' + dRows + '</tbody></table>';
             }
         }

--- a/session-log.md
+++ b/session-log.md
@@ -642,3 +642,60 @@ Anchor-file model section was the most stale — said "single `<blocked_ips>` ta
 2. **Docs drift from code shows up in the architecture sections first.** CLAUDE.md and DESIGN.md both still described the pre-multi-mode code layout. Worth a periodic `grep -L 'enforcer'` style audit against what actually exists in `internal/`.
 
 **Wrap-up:** PR opened with five files updated (CLAUDE.md, README.md, docs/index.html, TROUBLESHOOTING.md, DESIGN.md). Pure docs change — no release cut.
+
+---
+
+## May 6 — Foreground-tab time tracking, opt-in (issue #92)
+**Session ID:** `feat-issue-92-foreground` · **PR:** TBD
+
+**Opening prompt:**
+> "continue what you had planned to do on issue 92. your entire plan is added as a comment and I also added a latest comment to the issue with my response that you need to consider."
+
+**What happened:**
+
+Plan was already in #92 as a comment from the prior session: extend the per-tick AppleScript surface so the active browser tab's domain is recorded as a *separate* metric — `foreground_minutes` — alongside the DNS-bucket `used_minutes`. User's response on the comment crystallized the constraints:
+
+1. Keep the two metrics *separate*; do not feed foreground time into `daily_quota_minutes`.
+2. Browsers only for now — file a follow-up for non-browser apps (Slack, Discord, Xcode).
+3. File a follow-up for Windows.
+4. Behind a config flag.
+5. Confirm and call out that foreground tracking works in `hosts` mode (where DNS-bucket tracking does not).
+6. Privacy floor: only track domains in any configured group, excluding `_doh`.
+
+That last point is the big one — without it the feature silently expands from "tracking what you opted into" to "tracking everything you browse." Codified in `trackedDomainSet()` (`scheduler/foreground.go`) which walks `cfg.Groups` and skips `enforcer.DohGroupName`.
+
+### Implementation shape
+
+- `config.Settings.EnableForegroundTracking bool` — opt-in, default false.
+- `proxy.UsageEvent` gained `Kind` (`"" | "dns" | "foreground"`). Empty = legacy = DNS, so pre-feature `usage.jsonl` entries keep aggregating without migration.
+- New `scheduler/foreground.go`: AppleScript probe returns `frontmost_app<TAB>active_url<TAB>idle_seconds`. Idle from `ioreg | awk` on `HIDIdleTime` (no entitlement). Per-browser URL access uses `active tab` for Chrome/Arc/Brave, `current tab` for Safari (Safari is the odd one out — important).
+- Gating in `recordForegroundTick`: empty probe output is a clean no-op (non-darwin path), idle ≥ 60s suppresses the event, frontmost-app must be one of four supported browsers, URL must parse as `http`/`https` with a non-empty host (filters `chrome://newtab/`, `about:blank`), host (lowercased + `www.` stripped, subdomain-aware) must match a configured non-`_doh` domain.
+- Aggregation: `proxy.ComputeGroupForegroundMinutes` uses **1-minute** buckets — naturally minute-granular because the scheduler ticks each minute and emits at most one event per tick. DNS aggregator now filters by `IsDNSKind()` so the two signals stay independent.
+- `/api/usage` adds `foreground_minutes` to both group rows and domain rows; the dashboard adds a Foreground (min) column. The "no data" hint distinguishes DNS (needs dns/strict) vs foreground (needs the flag).
+
+### Cross-mode confirmation (the user's point #5)
+
+The probe lives in the scheduler tick, not in the enforcer — exactly the same call site as the existing per-tick close-tabs path. It writes to `usage.jsonl` directly via `proxy.AppendUsageEvent`. There is no DNS proxy in the path. Concretely:
+
+| Mode | DNS-bucket `used_minutes` | Foreground `foreground_minutes` |
+|------|---------------------------|----------------------------------|
+| `hosts` | unavailable | works |
+| `dns` | works | works |
+| `strict` | works | works |
+
+So foreground tracking is the *only* per-domain time signal in `hosts` mode — a meaningful change for users who run hosts mode for simplicity but still want to see where their time goes. Called out in DESIGN.md and the README field reference.
+
+### Edge case: `extractHost` and `chrome://newtab/`
+
+First attempt to extract host used `url.Parse(rawURL).Hostname()`. That returns `"newtab"` for `chrome://newtab/` because chrome:// is a valid URL scheme and "newtab" parses as the authority. Tracked-domain matching would then return "" (defense at the next layer), but it felt fragile — a user with a configured "newtab.example" *could* in principle get a false positive if a future browser ever exposed a similar URL scheme. Tightened `extractHost` to return "" for any non-http(s) scheme. Test had to be updated to match.
+
+### Tests
+
+Two new test files. `proxy/foreground_test.go` covers schema invariants — DNS aggregator must ignore foreground events, foreground aggregator must ignore DNS events, legacy empty-Kind events keep aggregating into `used_minutes`, `IsDNSKind` truth table. `scheduler/foreground_test.go` covers parser edge cases (malformed inputs, idle-non-integer), the tracked-domain set excluding `_doh`, the matcher's subdomain attribution and false-positive guards (`youtubex.com` must NOT match `youtube.com`), `extractHost` (lowercasing, www-stripping, scheme-gating), and the gating decisions in `recordForegroundTick` via a stub probe runner — happy path, idle skip, non-browser app, untracked domain, `_doh` excluded, `www.` stripping, internal browser URLs, and probe-error propagation.
+
+### Follow-ups filed
+
+- **#93** — foreground time tracking for non-browser apps (Slack, Discord, Xcode). Notes the data-shape change (no per-URL granularity), enumerates options, scopes out app-time quotas as a deliberately separate product call.
+- **#94** — Windows-side exploration. Documents the Win32 / UI-Automation / extension trade-offs and aligns on reusing the same `Kind: "foreground"` event shape so the dashboard renders without code changes.
+
+**Wrap-up:** Branch `feat/foreground-tab-tracking` opened with config flag, probe, parsing/matching helpers, scheduler wiring, usage-log schema bump, /api/usage and dashboard updates, and 18 new tests. Two follow-up issues filed (#93, #94). Docs updated across DESIGN.md, README.md, and docs/index.html.


### PR DESCRIPTION
Closes #92.

## Summary

Adds an opt-in usage metric that records how long the user's *active browser tab* spends on a configured domain — distinct from the existing DNS-bucket `used_minutes`, which counts every DNS query and inflates from background tabs. macOS-only, browsers only, behind `settings.enable_foreground_tracking` (default `false`).

## What was done

- **Schema.** `proxy.UsageEvent` gained a `Kind` field (`""` | `"dns"` | `"foreground"`). Empty Kind on a legacy event is treated as `dns` so existing `usage.jsonl` files keep aggregating into `used_minutes` without migration.
- **Probe.** New `internal/scheduler/foreground.go` runs a single AppleScript per tick that returns `frontmost_app<TAB>active_url<TAB>idle_seconds`. Idle from IOKit's `HIDIdleTime` (no entitlement needed). Reads `active tab of front window` for Chrome/Arc/Brave, `current tab of front window` for Safari.
- **Gating.** `recordForegroundTick` emits an event only when **all** of: `idle_seconds < 60`, `frontmost_app` is one of the four supported browsers, URL parses as `http`/`https` with non-empty host, and the host (lowercased, `www.`-stripped, subdomain-aware) matches a domain in some configured group **other than `_doh`**.
- **Aggregation.** `proxy.ComputeGroupForegroundMinutes` uses 1-minute buckets — naturally minute-granular because the scheduler ticks per minute and emits at most one event per tick. DNS aggregator now filters by `IsDNSKind()` so the two signals stay independent.
- **API + UI.** `/api/usage` adds `foreground_minutes` to group rows and domain rows. The Usage tab gains a Foreground (min) column with a hint that distinguishes the two metrics.
- **Docs.** DESIGN.md, README.md, docs/index.html, session-log.md.
- **Follow-ups filed.** #93 (non-browser apps like Slack/Discord/Xcode), #94 (Windows-side exploration). Both reference this PR.

## Why these choices

The user's response on issue #92 nailed down six constraints:

| # | Constraint | How it's reflected |
|---|---|---|
| 1 | Keep foreground vs DNS metrics *separate* | Two `Kind` values, two aggregators, two columns; quotas still drive off DNS. |
| 2 | Browsers only for now | Probe checks `frontmost_app` against an allow-list of four browsers. |
| 3 | File a follow-up for non-browser apps | Issue #93. |
| 4 | File a follow-up for Windows | Issue #94. |
| 5 | Behind a flag | `settings.enable_foreground_tracking` (default `false`). |
| 6 | Confirm + call out that this works in `hosts` mode | The probe lives in the scheduler tick, not the enforcer. Documented in DESIGN.md and the README. |
| 7 | Privacy floor: only domains in any block list, excluding `_doh` | `trackedDomainSet()` walks `cfg.Groups` and skips `enforcer.DohGroupName`. |

The big call-out from #6: in `hosts` mode the DNS proxy doesn't run, so `used_minutes` is always zero. Foreground tracking is the *only* per-domain time signal available there. This is documented and surfaced in the dashboard's "no data" copy.

## Gotchas for reviewers

- **The Safari idiom is different.** Safari uses `current tab of front window`; Chrome/Arc/Brave use `active tab of front window`. The probe script handles both — there's a regression-guard test (`TestGenerateForegroundProbeScript_IncludesAllBrowsers`) that asserts both idioms appear.
- **`extractHost` requires `http`/`https` scheme.** A naive `url.Parse(\"chrome://newtab/\").Hostname()` returns `\"newtab\"` (chrome:// is a valid scheme; \"newtab\" parses as authority). The scheme gate is defense-in-depth so internal browser URLs can never feed downstream matching, even hypothetically.
- **Backwards compatibility is contract, not coincidence.** `UsageEvent.IsDNSKind()` is what makes legacy entries (no `Kind` field) keep counting toward `used_minutes`. Changing that semantics would silently break existing `usage.jsonl` data on first start after upgrade.
- **The privacy floor is the most important review point.** If the `enforcer.DohGroupName` skip is ever removed by accident, `dns.google` and `cloudflare-dns.com` visits would start being recorded — and more critically, if the \"only in cfg.Groups\" filter is ever loosened, every site the user visits ends up in `usage.jsonl`. There's a dedicated test (`TestRecordForegroundTick_DomainNotInGroups`) guarding this.
- **`osascript` fragility tax.** This inherits the same launchd-as-root → `su - <user> -c osascript` plumbing as the per-tick close path. If that plumbing breaks again (PR #81's history), this feature breaks alongside.
- **Quota enforcement is deliberately untouched.** `daily_quota_minutes` continues to drive off DNS-bucket minutes. Routing foreground time into quota is a bigger product call and was scoped out of this metrics addition.
- **Bundle.** Four logically-separate commits on the branch (proxy schema → scheduler probe → web/dashboard → docs) — each builds and tests cleanly in isolation.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass (18 new tests across `internal/proxy` and `internal/scheduler`)
- [ ] Manual: with `enable_foreground_tracking: true` on macOS, run the daemon and confirm `/api/usage` populates `foreground_minutes` on a configured domain and stays at 0 on an unconfigured domain
- [ ] Manual: confirm idle (Cmd+Tab away or lock screen for >60s) suppresses events
- [ ] Manual: confirm `_doh` group sites do not produce events even when visited in a browser
- [ ] Manual: confirm hosts-mode users see `foreground_minutes` populate while `used_minutes` stays empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)