### PR TITLE
feat: display running version on web dashboard (#96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Build Binary
-        run: go build -o ${{ matrix.output_name }} ./cmd/app
+        shell: bash
+        run: go build -ldflags "-X github.com/vsangava/sentinel/internal/version.Version=${{ github.ref_name }}" -o ${{ matrix.output_name }} ./cmd/app
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 VERSION ?= dev
 BINARY_NAME := sentinel
+LDFLAGS := -X github.com/vsangava/sentinel/internal/version.Version=$(VERSION)
 
 help:
 	@echo "📦 Sentinel Build Commands"
@@ -27,25 +28,25 @@ help:
 
 # Build for current OS
 build:
-	@echo "🔨 Building $(BINARY_NAME) for current OS..."
-	go build -o $(BINARY_NAME) ./cmd/app
+	@echo "🔨 Building $(BINARY_NAME) for current OS (version=$(VERSION))..."
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/app
 	@echo "✅ Built: $(BINARY_NAME)"
 
 # Build for all platforms
 build-all: clean
-	@echo "🔨 Building for all platforms..."
+	@echo "🔨 Building for all platforms (version=$(VERSION))..."
 	@echo ""
-	
+
 	@echo "  → macOS ARM64 (Apple Silicon)..."
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o $(BINARY_NAME)-macos-arm64 ./cmd/app
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-macos-arm64 ./cmd/app
 	@echo "     ✅ $(BINARY_NAME)-macos-arm64"
-	
+
 	@echo "  → macOS x86_64 (Intel)..."
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o $(BINARY_NAME)-macos-amd64 ./cmd/app
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-macos-amd64 ./cmd/app
 	@echo "     ✅ $(BINARY_NAME)-macos-amd64"
-	
+
 	@echo "  → Windows x86_64..."
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o $(BINARY_NAME)-windows-amd64.exe ./cmd/app
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME)-windows-amd64.exe ./cmd/app
 	@echo "     ✅ $(BINARY_NAME)-windows-amd64.exe"
 	@echo ""
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Most users should leave the default `hosts` mode and skip this step. See [Enforc
 
 ## The web dashboard
 
-Open **`http://localhost:8040`** while the service is running.
+Open **`http://localhost:8040`** while the service is running. The header displays the running version (e.g. `v0.1.19`) — handy for confirming whether a release update has actually rolled over to the live daemon.
 
 **Status tab** shows what's blocked right now, the current enforcement mode, and a timeline of upcoming block and unblock events for the next 24 hours. A good way to sanity-check that your schedule is doing what you expect.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,10 @@
+// Package version exposes the build-injected version string.
+//
+// The Version variable is overridden at build time via:
+//
+//	go build -ldflags "-X github.com/vsangava/sentinel/internal/version.Version=v1.2.3"
+//
+// In unreleased builds it stays at the default "dev".
+package version
+
+var Version = "dev"

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vsangava/sentinel/internal/proxy"
 	"github.com/vsangava/sentinel/internal/scheduler"
 	"github.com/vsangava/sentinel/internal/testcli"
+	"github.com/vsangava/sentinel/internal/version"
 )
 
 const maxPauseMinutes = 240 // 4 hours
@@ -32,8 +33,10 @@ const (
 //go:embed static/*
 var webFiles embed.FS
 
-// authMiddleware rejects requests to /api/* (except GET /api/config) without a valid X-Auth-Token.
-// GET /api/config is intentionally public so the web UI can bootstrap the token on first load.
+// authMiddleware rejects requests to /api/* without a valid X-Auth-Token. The
+// only routes wired up without it are GET /api/config (public so the web UI
+// can bootstrap the token on first load) and GET /api/version (public so the
+// dashboard can render the version pill before bootstrap completes).
 func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cfg := config.GetConfig()
@@ -45,6 +48,13 @@ func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
+}
+
+// VersionHandler returns the running binary's version string. Public (no auth) so
+// the dashboard can display it before the auth token is bootstrapped from /api/config.
+func VersionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"version": version.Version})
 }
 
 // ConfigHandler returns the current config as JSON, reloading from disk first so the
@@ -690,6 +700,7 @@ func StartWebServer() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", staticHandler)
+	mux.HandleFunc("/api/version", VersionHandler)
 	mux.HandleFunc("/api/config", ConfigHandler)
 	mux.HandleFunc("/api/status", authMiddleware(StatusHandler))
 	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))
@@ -742,6 +753,7 @@ func StartTestWebServer() {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", staticHandler)
+	mux.HandleFunc("/api/version", VersionHandler)
 	mux.HandleFunc("/api/config", ConfigHandler)
 	mux.HandleFunc("/api/status", authMiddleware(StatusHandler))
 	mux.HandleFunc("/api/test-query", authMiddleware(TestQueryHandler))

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/vsangava/sentinel/internal/config"
+	"github.com/vsangava/sentinel/internal/version"
 )
 
 func TestMain(m *testing.M) {
@@ -27,6 +28,30 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)
+}
+
+func TestVersionHandler_ReturnsCurrentVersion(t *testing.T) {
+	orig := version.Version
+	version.Version = "v9.9.9-test"
+	defer func() { version.Version = orig }()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	rr := httptest.NewRecorder()
+	VersionHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("response not valid JSON: %v", err)
+	}
+	if body["version"] != "v9.9.9-test" {
+		t.Errorf("expected version v9.9.9-test, got %q", body["version"])
+	}
 }
 
 func TestConfigHandler_ReturnsJSON(t *testing.T) {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -36,6 +36,18 @@
         .app-header img { height: 40px; width: auto; flex-shrink: 0; }
         .app-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.3px; }
         .app-header p  { font-size: 12px; opacity: 0.75; margin-top: 3px; }
+        .app-header .version-pill {
+            margin-left: auto;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 4px 10px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.18);
+            color: rgba(255, 255, 255, 0.92);
+            letter-spacing: 0.3px;
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+        }
 
         /* Tabs */
         .tabs {
@@ -590,6 +602,7 @@
             <h1>Sentinel</h1>
             <p>Schedule-based focus enforcement</p>
         </div>
+        <span id="versionPill" class="version-pill" title="Running version" hidden></span>
     </div>
 
     <div class="tabs">
@@ -881,8 +894,25 @@ var EXAMPLE_CONFIG = {
 window.onload = function() {
     setupPinBoxes();
     setDefaultTestTime();
+    loadVersion();
     loadConfig().then(function() { loadStatus(); });
 };
+
+async function loadVersion() {
+    var pill = document.getElementById('versionPill');
+    if (!pill) return;
+    try {
+        var res = await fetch('/api/version');
+        if (!res.ok) return;
+        var data = await res.json();
+        if (data && data.version) {
+            pill.textContent = data.version;
+            pill.hidden = false;
+        }
+    } catch (e) {
+        // Silently ignore — version is informational only.
+    }
+}
 
 async function loadConfig() {
     try {


### PR DESCRIPTION
Closes #96.

## Summary
- Adds an `internal/version` package whose `Version` string is overridden at build time via `-ldflags`.
- Exposes a public `GET /api/version` endpoint returning `{"version": "..."}`.
- Renders a small version pill in the dashboard header (e.g. `v0.1.19`) so the running build is visible at a glance.

## Why
After a release, there's currently no way to confirm from the UI whether the installed daemon has actually rolled over to the new binary. The pill makes that obvious without dropping to a terminal.

## Wiring
- `Makefile` injects `VERSION` (default `dev`) for both `build` and `build-all` targets via `-ldflags "-X github.com/vsangava/sentinel/internal/version.Version=$(VERSION)"`.
- `.github/workflows/release.yml` injects `${{ github.ref_name }}` (the pushed tag) under `shell: bash` so quoting works uniformly across the Linux/macOS/Windows runners.
- `/api/version` is intentionally public — same rationale as `/api/config`, so the dashboard can render the pill before the auth token has bootstrapped.

## Gotchas
- Builds that bypass the Makefile (e.g. plain `go build`) will report `dev`. That's the intended fallback for unreleased dev binaries.
- The pill silently no-ops if `/api/version` is unreachable, so older daemons running against a newer dashboard simply won't show it (no visible breakage).
- The release workflow now uses `shell: bash` for the build step. The Windows runner has Git Bash available, so the `-ldflags "..."` quoting is portable.

## Test plan
- [x] `go test ./...` passes (new `TestVersionHandler_ReturnsCurrentVersion` covers the handler).
- [x] `make build VERSION=v0.1.19-test` produces a binary whose embedded string is `v0.1.19-test` (verified via `strings`).
- [ ] After merge + tag push: confirm the GitHub-built binary reports the tag name in the dashboard pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)