### PR TITLE
fix(scheduler): probe AppleScript fails to compile when Arc/Brave aren't installed

### DIFF
--- a/internal/scheduler/foreground.go
+++ b/internal/scheduler/foreground.go
@@ -53,9 +53,18 @@ type ForegroundProbeGenerator interface {
 type MacOSForegroundProbeGenerator struct{}
 
 func (g *MacOSForegroundProbeGenerator) GenerateForegroundProbeScript() string {
-	// Per-browser URL fetches are wrapped individually so a single
-	// "Application isn't running" (-600) fails the inner block, not the whole
-	// probe — same defensive shape used by GenerateCloseTabsScript.
+	// Per-browser URL fetches are dispatched as nested `osascript -e` calls via
+	// `do shell script` rather than written as inline `tell application "X" to
+	// ...` blocks. Reason: AppleScript compiles the whole script up front, and
+	// `URL of active tab of front window` requires the target app's scripting
+	// dictionary at compile time. If the app isn't installed (e.g. Brave/Arc on
+	// most machines), compilation fails with -2741 "Expected end of line but
+	// found property" — and a `try` block can't catch a compile-time error, so
+	// the whole probe dies before the `if frontApp is "X"` runtime guard runs.
+	// Nesting via `do shell script "osascript -e ..."` isolates each app's
+	// terminology resolution into its own osascript process: only the branch
+	// that actually fires gets compiled, and a missing app errors only if it's
+	// somehow the frontmost (which can't happen if it isn't installed).
 	//
 	// Idle time comes from IOKit (HIDIdleTime in nanoseconds). It needs no
 	// special permission and is the standard idiom; AppleScript has no
@@ -78,19 +87,19 @@ func (g *MacOSForegroundProbeGenerator) GenerateForegroundProbeScript() string {
 
 		if frontApp is "Google Chrome" then
 			try
-				tell application "Google Chrome" to set activeURL to URL of active tab of front window
+				set activeURL to do shell script "osascript -e 'tell application \"Google Chrome\" to get URL of active tab of front window'"
 			end try
 		else if frontApp is "Safari" then
 			try
-				tell application "Safari" to set activeURL to URL of current tab of front window
+				set activeURL to do shell script "osascript -e 'tell application \"Safari\" to get URL of current tab of front window'"
 			end try
 		else if frontApp is "Arc" then
 			try
-				tell application "Arc" to set activeURL to URL of active tab of front window
+				set activeURL to do shell script "osascript -e 'tell application \"Arc\" to get URL of active tab of front window'"
 			end try
 		else if frontApp is "Brave Browser" then
 			try
-				tell application "Brave Browser" to set activeURL to URL of active tab of front window
+				set activeURL to do shell script "osascript -e 'tell application \"Brave Browser\" to get URL of active tab of front window'"
 			end try
 		end if
 


### PR DESCRIPTION
## Summary

PR #95 added a foreground-tab probe that emits a single AppleScript covering all four supported browsers — Chrome, Safari, Arc, Brave — using inline single-line `tell application \"X\" to set activeURL to URL of active tab of front window` blocks. On any machine that's missing one or more of those apps (which is most of them — Arc and Brave are uncommon), the script fails to compile with:

\`\`\`
scheduler: foreground probe: osascript exit 1: /tmp/df_probe.scpt:792:795: script error: Expected end of line but found property. (-2741)
\`\`\`

The error fires every tick. \`foreground_minutes\` stays at 0 regardless of \`enable_foreground_tracking: true\`. Reported with logs above.

## Root cause

AppleScript compiles the whole script up front and resolves application terminology against each named app's scripting dictionary at compile time. \`URL of active tab of front window\` is not generic AppleScript — \`active tab\` and \`front window\` are properties defined by Chrome/Arc/Brave's dictionary; \`current tab\` is Safari's. If the named app isn't installed, the compiler has no dictionary to resolve those properties against and emits **-2741: Expected end of line but found property**.

The surrounding \`try\` block can't catch this — \`try\` catches runtime errors, not parse failures. As a result, on a machine without Arc or Brave installed the probe dies before the \`if frontApp is \"X\"\` runtime guard ever runs.

The existing close-tabs script (\`scheduler.go:706\` \`getOpenBrowserDomains\`) doesn't trip this because it only references \`URL of t\` where \`t\` is a local AppleScript variable. \`URL\` of a local variable doesn't need any app-specific dictionary at compile time. The probe failed because it referenced \`active tab\` / \`current tab\` / \`front window\` directly.

## Fix

Dispatch each browser's URL fetch through nested \`osascript\` via \`do shell script\`:

\`\`\`applescript
if frontApp is \"Brave Browser\" then
    try
        set activeURL to do shell script \"osascript -e 'tell application \\\"Brave Browser\\\" to get URL of active tab of front window'\"
    end try
end if
\`\`\`

Each \`osascript -e\` invocation runs in its own process and only compiles its own one-liner. Terminology resolution happens lazily — only the branch matching the actual frontmost app ever runs, and a not-installed app can't be frontmost, so it can never be reached. The outer probe script no longer references any browser-specific dictionary terms, so it compiles cleanly on any macOS install regardless of which browsers are present.

## Why this approach over alternatives

- **\`using terms from application \"Google Chrome\"\` borrowing.** Works only if Chrome is installed — would still fail on a Safari-only or Arc-only machine. The shell-out has no such precondition.
- **Block-form \`tell application \"X\" ... end tell\`.** Doesn't help — block form has the same compile-time terminology requirement as single-line form when the inner content references app-specific properties (verified locally; same -2741 reproduces).
- **\`if application \"X\" is running then\` outer guard.** Doesn't gate compilation either — the dictionary still has to load to compile the inner block (verified).
- **Dynamic generator that conditionally emits only branches for installed browsers.** Possible but more code; the shell-out is one-liner per branch, no install-detection required.

## Gotchas / things to look at

- **One extra process per tick when a supported browser is frontmost.** Negligible — the per-tick close path already shells out to \`osascript\`, this is one more, and only when the user is actually using a tracked browser.
- **Idle path unchanged.** When the user is idle (≥60s) the probe parses then bails before an event is recorded — unchanged.
- **The other 3 browsers' branches were converted symmetrically** (not just Brave/Arc), so a Safari-only or Chrome-only machine also benefits and the script compiles uniformly.
- **No script content escaping issues.** The \`do shell script \"osascript -e '...'\"\` form uses double-quotes around the shell command and single-quotes around the AppleScript snippet, so the inner \`\\\"App Name\\\"\` only needs to be escaped for AppleScript's outer string — which is what \`\\\"\` does. Verified by writing the emitted script to disk and running osascript on it.

## Test plan

- [x] \`go test ./...\` passes
- [x] Reproduce the original failure: write the pre-fix probe to /tmp and run osascript on a machine with only Chrome and Safari installed → \`-2741\` as reported.
- [x] Apply fix: emit the new script via the \`MacOSForegroundProbeGenerator\` and run osascript → exits 0, returns \`Terminal\\t\\t31\\n\` (Terminal frontmost, no URL, idle 31s).
- [ ] Manual: install built binary, set \`enable_foreground_tracking: true\`, browse a tracked domain in Chrome, verify \`foreground_minutes\` increments in \`/api/usage\` after a couple of ticks.
- [ ] Manual: confirm scheduler log no longer prints the \`foreground probe: osascript exit 1\` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)