### PR TITLE
feat(web): collapse DoH endpoints in dashboard blocked list (#97)

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -174,6 +174,41 @@
         }
         .status-meta { font-size: 11px; color: #adb5bd; margin-top: 8px; }
 
+        /* DoH disclosure */
+        .doh-details { margin-top: 12px; }
+        .doh-details > summary {
+            cursor: pointer;
+            list-style: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 10px;
+            border-radius: 6px;
+            font-size: 12px;
+            color: #6c757d;
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            user-select: none;
+        }
+        .doh-details > summary:hover { background: #f1f3f5; color: #495057; }
+        .doh-details > summary::-webkit-details-marker { display: none; }
+        .doh-details > summary::before {
+            content: '';
+            width: 0;
+            height: 0;
+            border-top: 4px solid transparent;
+            border-bottom: 4px solid transparent;
+            border-left: 7px solid #6c757d;
+            transition: transform 0.15s ease;
+            flex-shrink: 0;
+        }
+        .doh-details[open] > summary::before { transform: rotate(90deg); }
+        .doh-details > summary .doh-summary-hint {
+            color: #adb5bd;
+            font-weight: 400;
+        }
+        .doh-details .blocked-list { margin-top: 8px; }
+
         /* Upcoming */
         .upcoming-list { display: flex; flex-direction: column; }
         .upcoming-item {
@@ -1151,19 +1186,48 @@ async function loadStatus() {
             pauseEl.innerHTML = '';
         }
 
-        // Blocked list
+        // Blocked list — partition into user-tracked sites and the _doh
+        // infrastructure group. The DoH list is hidden by default since it's
+        // typically a long, always-on list of resolver endpoints (Google,
+        // Cloudflare, Quad9, …) that crowds out the rule-driven blocks the
+        // user actually scheduled.
         var blocked = Object.keys(data.blocked_domains || {}).filter(function(k) { return data.blocked_domains[k]; });
+        var dohSet = {};
+        var dohList = (liveConfig && liveConfig.groups && liveConfig.groups._doh) || [];
+        for (var di = 0; di < dohList.length; di++) dohSet[dohList[di]] = true;
+        var userBlocked = blocked.filter(function(d) { return !dohSet[d]; });
+        var dohBlocked  = blocked.filter(function(d) { return  dohSet[d]; });
+
         var sessionNote = (data.pomodoro && data.pomodoro.locked)
             ? '<p style="font-size:12px;color:#dc3545;margin:8px 0 0;font-weight:600">🔴 Focus session active — all scheduled domains are forced on</p>'
             : '';
-        if (blocked.length === 0) {
-            contentEl.innerHTML = '<div class="status-empty">✓ No domains currently blocked</div>' + sessionNote;
-        } else {
-            contentEl.innerHTML = '<ul class="blocked-list">' +
-                blocked.map(function(d) {
+
+        var renderItems = function(list) {
+            return '<ul class="blocked-list">' +
+                list.map(function(d) {
                     return '<li class="blocked-item"><span class="blocked-dot"></span>' + d + '</li>';
-                }).join('') + '</ul>' + sessionNote;
+                }).join('') + '</ul>';
+        };
+
+        var html = '';
+        if (blocked.length === 0) {
+            html += '<div class="status-empty">✓ No domains currently blocked</div>';
+        } else if (userBlocked.length === 0) {
+            html += '<div class="status-empty">✓ No scheduled domains currently blocked</div>';
+        } else {
+            html += renderItems(userBlocked);
         }
+
+        if (dohBlocked.length > 0) {
+            html += '<details class="doh-details">' +
+                '<summary>' + dohBlocked.length + ' DoH/DoT endpoint' + (dohBlocked.length === 1 ? '' : 's') +
+                ' <span class="doh-summary-hint">(infrastructure — click to expand)</span>' +
+                '</summary>' +
+                renderItems(dohBlocked) +
+                '</details>';
+        }
+
+        contentEl.innerHTML = html + sessionNote;
 
         // Last evaluated
         if (data.last_evaluated) {


### PR DESCRIPTION
## Summary

Closes #97.

The currently-blocked list on the dashboard always included the entire `_doh` group when that rule was active (~11 endpoints by default: `dns.google`, `cloudflare-dns.com`, `dns.quad9.net`, etc.), drowning out the rule-driven blocks the user actually scheduled. This PR partitions the list client-side and tucks the DoH endpoints into a collapsed expander.

## What changed

`internal/web/static/index.html` only — pure client-side change, no Go touched.

- `loadStatus()` now partitions `data.blocked_domains` against `liveConfig.groups._doh`:
  - User-tracked sites render in the existing red `.blocked-list` (visually unchanged).
  - DoH/DoT endpoints render in a `<details>` expander beneath, collapsed by default, with summary text like `11 DoH/DoT endpoints (infrastructure — click to expand)`.
- New `.doh-details` styling: gray pill button with a 7×8 CSS-drawn triangle marker that rotates 90° on open. The triangle is sized to match the existing 7px red dot used in the blocked list so the two markers feel visually consistent.
- Three empty-state branches:
  - Nothing blocked → existing `✓ No domains currently blocked`.
  - Only DoH blocked (common with default config off-hours) → `✓ No scheduled domains currently blocked`, plus collapsed DoH expander.
  - User domains blocked → red list as today, plus collapsed DoH expander.
- Singular/plural handled (`1 DoH/DoT endpoint` vs `2 DoH/DoT endpoints`).

## Why this approach

- **Client-side filter, not a server change.** `/api/status` already returns the full blocked map; `/api/config` already exposes `groups._doh`. The dashboard has both before it renders, so no new API surface is needed.
- **`<details>` over a JS toggle.** Native disclosure widget — no state to manage, no event handlers, accessible by default.
- **Fail-open.** If a config has no `_doh` group at all (the user's working dev config didn't), `dohBlocked` is empty and the expander is omitted entirely. The list reverts to its previous behavior with no visible change.

## Gotchas

- The expander only appears when the config has a `_doh` group **and** a rule blocking it during the current window. Configs without `_doh` (or with `_doh` rules that aren't active right now) see no change.
- Domain match is exact-string. `dns.google` in `groups._doh` matches `dns.google` in `blocked_domains`; subdomains aren't normalized. This matches how the scheduler emits the keys, so it's correct, but worth flagging if anyone changes the scheduler's emission later.
- `liveConfig` is loaded *before* `loadStatus()` runs (line 898: `loadConfig().then(function() { loadStatus(); })`), so the partition has the DoH list available on first render.

## Test plan

- [x] `go test ./...` — all green
- [x] Verified end-to-end against a synthetic `_doh`-bearing config (`/tmp/df-test/config.json`) running `--local`: `/api/status` returned 13 blocks (2 user + 11 DoH), dashboard rendered the expander as expected.
- [x] Verified the no-`_doh` case: with the user's dev `config.json` (only `games`/`videos`/`social` groups), the expander correctly does not appear and the list renders as before.
- [x] Hard-refreshed in browser and confirmed the chevron triangle is now visible and matches the 7px red dot's footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)