### PR TITLE
feat: named configuration profiles (#50)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,8 @@ The interesting design decisions:
 - **Three interchangeable enforcement backends.** Blocking can be done by editing `/etc/hosts` (default), by running a local DNS proxy on `127.0.0.1:53`, or by combining the DNS proxy with a `pf` packet-filter anchor on macOS. The scheduler does not know which is in use; it talks to an `Enforcer` interface.
 - **Pure functions for the parts worth testing.** Rule evaluation, DNS-response building, hosts-line generation, and pf-anchor generation are pure functions of `(time, config, …)` with no side effects. This means the test suite covers the core behaviour without needing root, port 53, or system-file access.
 - **Diff-based activation.** The scheduler runs once a minute and computes the diff against the previous tick. The enforcer is given only `newlyBlocked` and `newlyUnblocked` lists, not the full set, so a steady-state minute is a no-op.
-- **Auto-reloading config.** Every tick reloads `config.json` from disk. There is no inotify/FSEvents listener — the 60-second window is the maximum staleness, and is good enough for human-edited rules.
+- **Auto-reloading config.** Every tick reloads the bootstrap (`sentinel.json`) and the active profile (`profiles/<active>.json`) from disk and merges them into the in-memory `Config`. There is no inotify/FSEvents listener — the 60-second window is the maximum staleness, and is good enough for human-edited rules.
+- **Named profiles.** Settings + the shared groups dictionary live in the bootstrap; rules are split into one file per profile (`default`, `work`, `study`, …). Switching profiles is a one-field write to the bootstrap that propagates on the next tick. Pause/Pomodoro stay bootstrap-level so they're never reset by a switch.
 - **Dashboard embedded in the binary.** Static HTML/CSS/JS is bundled via `go:embed`, so a single binary is the entire deliverable.
 
 ### Tech stack
@@ -48,8 +49,10 @@ The interesting design decisions:
 
 ```
                                  ┌─────────────────────────────┐
-                                 │  config.json (auto-reloaded │
-                                 │  every minute from disk)    │
+                                 │  sentinel.json (bootstrap) +│
+                                 │  profiles/<active>.json     │
+                                 │  (auto-reloaded every minute│
+                                 │  and merged in-memory)      │
                                  └──────────────┬──────────────┘
                                                 │
                                                 ▼
@@ -95,6 +98,10 @@ The interesting design decisions:
    │  • GET/POST /api/pf-preview    (auth)                           │
    │  • POST /api/pause             (auth)                           │
    │  • DELETE /api/pause           (auth)                           │
+   │  • GET /api/profiles           (auth) list profiles + active    │
+   │  • POST /api/profiles          (auth) create (clone_from opt.)  │
+   │  • DELETE /api/profiles/{name} (auth) delete (404/409 guarded)  │
+   │  • POST /api/profile/switch    (auth) change active profile     │
    │  • Embedded static dashboard (Status / Test / Manage tabs)      │
    └─────────────────────────────────────────────────────────────────┘
 ```
@@ -502,17 +509,17 @@ The web UI's `/api/pf-preview` endpoint calls `pf.GeneratePreview(domains, dnsSe
 
 ## 8. Configuration
 
-`internal/config/config.go`. Single global `AppConfig` guarded by an `RWMutex`. All access goes through `GetConfig()` (returns a value copy) and `LoadConfig()` / `SaveConfig()` (file I/O under exclusive lock).
+`internal/config/config.go`. Single global `AppConfig` guarded by an `RWMutex`. All access goes through `GetConfig()` (returns a value copy) and `LoadConfig()` / `SaveConfig()` (file I/O under exclusive lock). On-disk format is split into a bootstrap file plus one file per profile; see [File location](#file-location). The in-memory `Config` below is the *merged* view — keeping it identical to the pre-profiles shape lets every downstream package (scheduler, proxy, enforcer) ignore the split entirely.
 
-### Schema
+### Schema (in-memory, post-merge)
 
 ```go
 type Config struct {
-    Settings Settings            `json:"settings"`
-    Groups   map[string][]string `json:"groups"`
-    Rules    []Rule              `json:"rules"`
-    Pause    *PauseWindow        `json:"pause,omitempty"`
-    Pomodoro *PomodoroSession    `json:"pomodoro,omitempty"`
+    Settings Settings            // from sentinel.json
+    Groups   map[string][]string // from sentinel.json
+    Rules    []Rule              // from profiles/<active>.json
+    Pause    *PauseWindow        // from sentinel.json
+    Pomodoro *PomodoroSession    // from sentinel.json
 }
 
 type Settings struct {
@@ -558,27 +565,57 @@ A rule used to carry a single `Domain` string, which meant blocking five gaming 
 
 ### File location
 
-| OS | Path |
-|---|---|
-| macOS | `/Library/Application Support/Sentinel/config.json` |
-| Windows | `%PROGRAMDATA%\Sentinel\config.json` |
-| Linux | `/etc/distractionsfree/config.json` |
-| `UseLocalConfig=true` | `./config.json` |
+The on-disk format is split into a **bootstrap** file plus one file per **profile**:
+
+| OS | Bootstrap (`sentinel.json`) | Profiles directory |
+|---|---|---|
+| macOS | `/Library/Application Support/Sentinel/sentinel.json` | `/Library/Application Support/Sentinel/profiles/<name>.json` |
+| Windows | `%PROGRAMDATA%\Sentinel\sentinel.json` | `%PROGRAMDATA%\Sentinel\profiles\<name>.json` |
+| Linux | `/etc/distractionsfree/sentinel.json` | `/etc/distractionsfree/profiles/<name>.json` |
+| `UseLocalConfig=true` | `./sentinel.json` | `./profiles/<name>.json` |
 
 `UseLocalConfig` is a package-level boolean set by `--local`, `--test-web`, and `--test-query` so they can run against a working-directory config without touching system paths.
 
+`BootstrapFile` carries everything except rules — `Settings`, `Groups`, `Pause`, `Pomodoro`, and `ActiveProfile string`. `ProfileFile` carries `Rules []Rule`. `LoadConfig()` reads both and merges them into the in-memory `Config` struct (which keeps the original pre-profiles shape, so the scheduler/proxy/enforcer don't see this split). `SaveConfig()` does the inverse — it splits in-memory state back into bootstrap + active profile and writes both files atomically (CreateTemp + Rename) so the scheduler tick reading mid-write never sees a truncated file.
+
+The split is deliberate:
+
+- **Groups stay in the bootstrap** so they're reusable across profiles. Profile-specific blocking is expressed by adding a finer-grained group to the dictionary, not by overriding inside the profile.
+- **Pause / Pomodoro stay in the bootstrap** because they're runtime state — switching profiles mid-Pomodoro must not break the work-phase lock, and a pause should outlive a profile change.
+- **Auth token stays in the bootstrap** so a profile switch never invalidates the dashboard's stored credentials.
+
+### Profiles
+
+Profile-related public functions in `internal/config/profiles.go`:
+
+- `ListProfiles() ([]string, error)` — returns sorted profile names from `profiles/*.json`
+- `ProfileExists(name) (bool, error)`
+- `CreateProfile(name, cloneFrom string) error` — `cloneFrom == ""` → empty rule set
+- `DeleteProfile(name) error` — refuses to delete the active profile or `default`
+- `SwitchProfile(name) error` — writes new `ActiveProfile` to the bootstrap, then `LoadConfig()` to refresh in-memory state
+- `ReplaceFullConfig(cfg Config) error` — used by `POST /api/config/update` to accept the merged shape and route it back to bootstrap + active profile, preserving the auth token
+- `ValidateProfileName(name) error` — `^[a-z0-9][a-z0-9_-]{0,31}$`; reserved: `sentinel`, `bootstrap`, `config`
+- `ActiveProfile() string` — the name whose rules currently populate `AppConfig.Rules`
+
+`SwitchProfile` propagates with the same 60-second latency as every other config change because the scheduler tick already ends with `LoadConfig()`.
+
 ### Bootstrap
 
-On first run, if the config file doesn't exist, `LoadConfig()` writes a default config:
+On first run, if `sentinel.json` doesn't exist, `LoadConfig()` writes a default install — bootstrap + `profiles/default.json` — using the embedded `default_config.json`:
 
 - `primary_dns: "8.8.8.8:53"`, `backup_dns: "1.1.1.1:53"`
 - `enforcement_mode: "hosts"`
 - `dns_failure_mode: "open"`
 - `enable_foreground_tracking: false`
 - A randomly generated 32-character hex `auth_token`
-- Two seed groups — `games` (roblox/epic/steam/fortnite/minecraft) and `social` (discord/facebook/instagram/tiktok/snapchat/reddit) — each bound by an active rule to the school window (09:00–15:00 weekdays) plus a nightly window (21:30–23:59 every day).
+- `active_profile: "default"`
+- Two seed groups — `games` (roblox/epic/steam/fortnite/minecraft) and `social` (discord/facebook/instagram/tiktok/snapchat/reddit) — each bound by an active rule (in `profiles/default.json`) to the school window (09:00–15:00 weekdays) plus a nightly window (21:30–23:59 every day).
 
-If an existing config has a missing `auth_token`, one is generated and the file is rewritten. This is the only field auto-modified on load.
+If an existing bootstrap has a missing `auth_token`, one is generated and the file is rewritten. This is the only field auto-modified on load.
+
+### Legacy migration
+
+Pre-profiles installs have a single `config.json`. On the first `LoadConfig()` after upgrading, `migrateLegacyConfigIfNeeded()` splits it: `Settings`/`Groups`/`Pause`/`Pomodoro` go into `sentinel.json`, `Rules` go into `profiles/default.json`, `active_profile` is set to `"default"`, and the original is renamed to `config.json.bak` as a safety net. Idempotent — re-running it does nothing once the new layout is in place. If `active_profile` ever points at a missing file (e.g., a `default.json` deleted manually), `LoadConfig()` falls back to `default`, recreating an empty profile if needed, and logs a warning rather than crashing.
 
 ### Reload cadence
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ No. The scheduler's 1-minute ticker is a regular Go timer — it doesn't issue p
 - [Install](#install)
 - [The web dashboard](#the-web-dashboard)
 - [Configuration](#configuration)
+- [Profiles](#profiles)
 - [Pause & resume](#pause--resume)
 - [Focus sessions (Pomodoro)](#focus-sessions-pomodoro)
 - [Enforcement modes](#enforcement-modes)
@@ -192,17 +193,19 @@ The PIN is a friction layer — a moment of pause before making changes — not 
 
 ## Configuration
 
-The daemon reads its configuration from a single JSON file:
+Configuration lives in two places on disk: a **bootstrap file** that holds settings, the shared groups dictionary, pause/pomodoro state, and the active-profile pointer; and one or more **profile files** that hold only the rules. This split lets you swap between named rule sets (Work, Study, Weekend, …) without re-saving everything else. See [Profiles](#profiles) for the full feature.
 
-| OS | Path |
-|---|---|
-| macOS (service) | `/Library/Application Support/Sentinel/config.json` |
-| Windows (service) | `%PROGRAMDATA%\Sentinel\config.json` |
-| Any (`--local`) | `./config.json` (working directory) |
+| OS | Bootstrap | Profiles |
+|---|---|---|
+| macOS (service)   | `/Library/Application Support/Sentinel/sentinel.json` | `/Library/Application Support/Sentinel/profiles/<name>.json` |
+| Windows (service) | `%PROGRAMDATA%\Sentinel\sentinel.json`                | `%PROGRAMDATA%\Sentinel\profiles\<name>.json`                |
+| Any (`--local`)   | `./sentinel.json`                                     | `./profiles/<name>.json`                                     |
 
-The file is created with defaults on first launch. The scheduler reloads it every minute — live edits take effect on the next tick, no restart required.
+Both files are created with defaults on first launch. The scheduler reloads from disk every minute — live edits take effect on the next tick, no restart required. **Migration**: if you're upgrading from a pre-profiles install, your existing `config.json` is split into the bootstrap + a `profiles/default.json` automatically on first run, and the original is renamed to `config.json.bak` as a safety net.
 
 ### Example config
+
+The bootstrap (`sentinel.json`) holds everything except rules:
 
 ```json
 {
@@ -220,6 +223,14 @@ The file is created with defaults on first launch. The scheduler reloads it ever
     "social": ["facebook.com", "fbcdn.net", "facebook.net", "instagram.com", "cdninstagram.com", "tiktok.com", "tiktokv.com", "tiktokcdn.com", "..."],
     "_doh":   ["dns.google", "cloudflare-dns.com", "mozilla.cloudflare-dns.com", "one.one.one.one", "..."]
   },
+  "active_profile": "default"
+}
+```
+
+A profile file (`profiles/default.json`) holds only the rules:
+
+```json
+{
   "rules": [
     {
       "group": "games",
@@ -281,6 +292,70 @@ The `_doh` group is **active by default in strict mode**. It contains common DNS
 - **`rules[].daily_quota_minutes`** *(optional)* — cap how many minutes per calendar day the group is accessible. Once this limit is reached the group is blocked for the rest of the day, regardless of the scheduled window. `0` or omitted means no quota. **Requires `dns` or `strict` enforcement mode** — usage is tracked at the DNS proxy layer and is not available in `hosts` mode. Browsers in their default configuration are unaffected. The edge case: if a browser has a **specific DoH provider manually configured** (Chrome set to "With Google" / "With Cloudflare"; Firefox "DNS over HTTPS" set to a provider), it bypasses `127.0.0.1:53` and those queries are not counted. Leaving browser DNS on automatic (the default) avoids this.
 - **`rules[].schedules`** — keyed by weekday (`"Monday"` … `"Sunday"`). Each value is an array of `{start, end}` slots in `HH:MM` 24-hour format. Domains are blocked when the current time falls in `[start, end)`.
 - **`pause`** *(optional)* — `{"until": "<RFC3339 timestamp>"}`. All blocking suspended until that time. Cleared automatically when the timestamp passes.
+
+---
+
+## Profiles
+
+A **profile** is a named set of rules. Sentinel ships with one (`default`); you can save more (`work`, `study`, `weekend`, …) and switch between them. Settings, the shared groups dictionary, and runtime state (pause/pomodoro) live in the bootstrap and are *not* per-profile, so a switch only swaps the schedule — it doesn't reset your DNS config, your auth token, or break a Pomodoro work-phase lock.
+
+### How files are laid out
+
+```
+$CONFIG_DIR/
+├── sentinel.json              # bootstrap: settings, groups, pause, pomodoro,
+│                              # auth_token, "active_profile": "default"
+└── profiles/
+    ├── default.json           # rules only
+    ├── work.json              # rules only
+    └── study.json             # rules only
+```
+
+Each profile file is just `{"rules": [ … ]}` — same `Rule` shape as before. Group references (`"group": "social"`) resolve against the shared groups dictionary in the bootstrap, so to add profile-specific blocking you generally define a finer-grained group (e.g., `youtube_only` separate from `videos`) rather than overriding inside the profile.
+
+### Switching profiles
+
+From the dashboard, the header has a profile dropdown that's visible on every tab. Picking a different profile POSTs to `/api/profile/switch` and the daemon picks up the new active profile on its next 1-minute scheduler tick. The dropdown is auto-disabled during a Pomodoro work session (HTTP 423) so you can't unlock yourself out of focus mode by switching to an empty profile.
+
+From the CLI:
+
+```bash
+# List profiles, '*' marks the active one
+sudo sentinel --list-profiles
+
+# Switch to a different profile (root needed because this writes the system bootstrap)
+sudo sentinel --set-profile work
+```
+
+### Creating, cloning, and deleting profiles
+
+The **Manage** tab has a "Profiles" section (gated by the same PIN that protects rule edits). Type a name, optionally pick a profile to clone from, hit Create. To delete a profile, switch away from it first — the active profile cannot be deleted, and `default` is permanently undeletable.
+
+Or via the API directly:
+
+```bash
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r '.settings.auth_token')
+
+# Create a "work" profile cloned from default
+curl -X POST http://localhost:8040/api/profiles \
+  -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"work","clone_from":"default"}'
+
+# Switch active profile
+curl -X POST http://localhost:8040/api/profile/switch \
+  -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"work"}'
+
+# Delete an inactive profile
+curl -X DELETE http://localhost:8040/api/profiles/work \
+  -H "X-Auth-Token: $TOKEN"
+```
+
+Profile names must match `^[a-z0-9][a-z0-9_-]{0,31}$` (lowercase, dashes/underscores, max 32 chars). The names `sentinel`, `bootstrap`, and `config` are reserved.
+
+### Migration from older installs
+
+If you're upgrading from a version that used a single `config.json`, Sentinel migrates automatically the first time the new daemon boots: `Settings`, `Groups`, `Pause`, and `Pomodoro` go into `sentinel.json`; `Rules` go into `profiles/default.json`; the old file is renamed to `config.json.bak` so a botched migration is recoverable. The migration is idempotent — re-running it does nothing once the new layout is in place.
 
 ---
 
@@ -417,8 +492,10 @@ sudo sentinel clean [--yes]     # forensic uninstall
 | `status` | sudo | Print whether the service is running | — |
 | `run` | sudo | Run as if launched by the service supervisor (foreground) | — |
 | `clean [--yes]` | sudo | Undo every system change; use before deleting the binary | [Uninstall](#uninstall--cleanup) |
-| `--local` | none | Run the daemon in the foreground using `./config.json` | [Test utilities](#test-utilities) |
+| `--local` | none | Run the daemon in the foreground using `./sentinel.json` + `./profiles/` | [Test utilities](#test-utilities) |
 | `--set-mode <mode>` | sudo | Set `enforcement_mode` in config and exit (modes: `hosts`, `dns`, `strict`) | [Switching modes](#switching-modes) |
+| `--set-profile <name>` | sudo | Switch the active profile and exit; the daemon picks it up within 60s | [Profiles](#profiles) |
+| `--list-profiles` | sudo | Print every saved profile, marking the active one with `*` | [Profiles](#profiles) |
 | `--test-query "<YYYY-MM-DD HH:MM>" <domain>` | none | Check whether a domain would be blocked at a specific time | [Test utilities](#test-utilities) |
 | `--test-web` | none | Start the dashboard standalone without installing the service | [Test utilities](#test-utilities) |
 | `--test-applescript` | none | Generate and optionally run the tab-closing AppleScript (macOS) | [Test utilities](#test-utilities) |

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -121,7 +121,7 @@ If the block isn't there during a scheduled window, the scheduler hasn't fired (
 If the block *is* there but the site loads anyway:
 
 - Your browser or app may have cached the DNS resolution. Try a private window, or restart the app.
-- The site may be served from a CDN domain not covered by the static prefix list (`""`, `www.`, `m.`, `mobile.`, `app.`). Add the relevant subdomain to the relevant group in `config.json`.
+- The site may be served from a CDN domain not covered by the static prefix list (`""`, `www.`, `m.`, `mobile.`, `app.`). Add the relevant subdomain to the relevant group in `sentinel.json` (groups are shared across profiles).
 
 To preview what *would* be written without root:
 
@@ -488,7 +488,7 @@ If launchd / Service Manager logs aren't useful, run the daemon in the foregroun
 sudo ./sentinel stop          # stop the service version
 sudo ./sentinel run           # run with the supervisor (foreground)
 # or, even simpler, no privileges needed for hosts-mode rule evaluation:
-./sentinel --local            # uses ./config.json
+./sentinel --local            # uses ./sentinel.json + ./profiles/
 ```
 
 `--local` is a fast way to validate that the rules and scheduler logic work — it skips system paths and won't install anything.
@@ -544,12 +544,12 @@ Always use `sudo ./sentinel stop && sudo ./sentinel start` — not raw `launchct
 Three flags exist exactly so you can test the daemon's core logic without privileges, without binding port 53, and without modifying the system.
 
 ```bash
-# Will youtube.com be blocked at this specific time per current ./config.json?
+# Will youtube.com be blocked at this specific time per current ./sentinel.json + active profile?
 ./sentinel --test-query "2024-04-01 10:30" youtube.com
 # Output includes: applicable rules, would-block status, and a real DNS response
 # from upstream so you can verify what the upstream resolver returns.
 
-# Run the full dashboard against ./config.json (no service install, no system changes).
+# Run the full dashboard against ./sentinel.json (no service install, no system changes).
 # All endpoints work, including hosts-preview and pf-preview.
 ./sentinel --test-web
 # → http://localhost:8040
@@ -558,7 +558,7 @@ Three flags exist exactly so you can test the daemon's core logic without privil
 ./sentinel --test-applescript
 ```
 
-`--test-query` and `--test-web` use `./config.json` in the working directory rather than the system path, so you can iterate on groups and rules without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new group shapes or schedule timings.
+`--test-query` and `--test-web` use `./sentinel.json` (+ `./profiles/<active>.json`) in the working directory rather than the system path, so you can iterate on groups, rules, and profiles without touching the live config. `make build` followed by `--test-web` is the fastest dev loop for trying out new group shapes or schedule timings.
 
 ---
 
@@ -646,8 +646,8 @@ Sentinel needs to own port 53 to intercept queries. The other service must move 
 ```bash
 # Open the web UI and change primary_dns to 127.0.0.1:5300
 open http://localhost:8040
-# — or edit config.json directly —
-sudo nano /Library/Application\ Support/Sentinel/config.json
+# — or edit sentinel.json directly (settings live in the bootstrap, not in profile files) —
+sudo nano /Library/Application\ Support/Sentinel/sentinel.json
 # set "primary_dns": "127.0.0.1:5300"
 ```
 
@@ -658,7 +658,7 @@ You can also set a backup in case your local resolver is down:
 "backup_dns":  "8.8.8.8:53"
 ```
 
-> **Note:** If your `primary_dns` was still at the factory default (`8.8.8.8:53`) when Sentinel first started in `dns` or `strict` mode, Sentinel auto-detected your previous system DNS and saved it automatically. In that case this step may already be done — check the web UI or config.json before editing.
+> **Note:** If your `primary_dns` was still at the factory default (`8.8.8.8:53`) when Sentinel first started in `dns` or `strict` mode, Sentinel auto-detected your previous system DNS and saved it automatically. In that case this step may already be done — check the web UI or `sentinel.json` before editing.
 
 **Step 3 — Restart Sentinel.**
 
@@ -670,7 +670,7 @@ Sentinel now owns port 53 (blocking distracting sites by returning `0.0.0.0`) an
 
 #### What happens if Sentinel crashes or is killed?
 
-In `dns`/`strict` mode the OS sends all DNS through Sentinel. If it stops unexpectedly, behaviour depends on `dns_failure_mode` in `config.json`:
+In `dns`/`strict` mode the OS sends all DNS through Sentinel. If it stops unexpectedly, behaviour depends on `dns_failure_mode` in `sentinel.json`:
 
 | `dns_failure_mode` | Sentinel down | Sentinel restarted by launchd |
 |--------------------|--------------|-------------------------------|
@@ -684,7 +684,7 @@ In `dns`/`strict` mode the OS sends all DNS through Sentinel. If it stops unexpe
 To change the setting:
 
 ```bash
-sudo nano /Library/Application\ Support/Sentinel/config.json
+sudo nano /Library/Application\ Support/Sentinel/sentinel.json
 # set "dns_failure_mode": "closed"
 sudo sentinel restart
 ```
@@ -732,24 +732,63 @@ curl -H "X-Auth-Token: $TOKEN" http://localhost:8040/api/status
 
 ### Config edits aren't taking effect
 
-The scheduler reloads `config.json` once per minute. Wait 60 seconds.
+The scheduler reloads the bootstrap (`sentinel.json`) and the active profile (`profiles/<active>.json`) once per minute. Wait 60 seconds.
 
 If they're still not applied:
 
 ```bash
 # Validate JSON
-python3 -m json.tool < /Library/Application\ Support/Sentinel/config.json
+python3 -m json.tool < /Library/Application\ Support/Sentinel/sentinel.json
+python3 -m json.tool < /Library/Application\ Support/Sentinel/profiles/$(jq -r .active_profile /Library/Application\ Support/Sentinel/sentinel.json).json
 
 # Check the daemon's logs for parse errors
 log show --predicate 'process == "sentinel"' --last 5m | grep -i config
 ```
 
-If the file is malformed, the daemon logs a warning and keeps using the previous in-memory copy — your changes won't apply until you fix the JSON.
+If either file is malformed, the daemon logs a warning and keeps using the previous in-memory copy — your changes won't apply until you fix the JSON.
 
 You can also force a reload by hitting `GET /api/config` (which calls `LoadConfig()`):
 
 ```bash
 curl -s http://localhost:8040/api/config > /dev/null
+```
+
+### Active profile points at a missing file
+
+**Symptom:** Logs show `config: active profile "<name>" missing on disk, falling back to "default"`.
+
+**Cause:** `sentinel.json` has `active_profile` set to a name whose file isn't in `profiles/`. Most often happens when a profile file was deleted manually, or when a `sentinel --set-profile` was run against a fresh config dir before the profile existed.
+
+**Fix:** the daemon already self-heals — it falls back to `default`, recreating an empty `profiles/default.json` if necessary, and continues running. To pick the profile you actually wanted:
+
+```bash
+sudo sentinel --list-profiles      # confirm what's on disk
+sudo sentinel --set-profile <name>  # switch to one that exists
+```
+
+### `profile name "X" invalid` from --set-profile or the API
+
+Profile names must match `^[a-z0-9][a-z0-9_-]{0,31}$` — lowercase ASCII, digits, dashes, and underscores only, max 32 chars, no leading dash/underscore. The names `sentinel`, `bootstrap`, and `config` are reserved (would collide with bootstrap or legacy filenames in the same directory). Rename to something that fits the pattern.
+
+### Profile delete returns 409 (`cannot delete the active profile`)
+
+You can't delete the profile you're currently using, and `default` is permanently undeletable. Switch to a different profile first, then delete:
+
+```bash
+sudo sentinel --set-profile default
+TOKEN=$(curl -s http://localhost:8040/api/config | jq -r .settings.auth_token)
+curl -X DELETE http://localhost:8040/api/profiles/work -H "X-Auth-Token: $TOKEN"
+```
+
+### Migration from a pre-profiles install
+
+The first time the new daemon boots against an old `config.json`, it splits the file into `sentinel.json` + `profiles/default.json` and renames the original to `config.json.bak`. Idempotent — it's a no-op once the new layout exists. If you want to roll back to the old binary, restore the `.bak`:
+
+```bash
+sudo systemctl stop sentinel        # or: sudo launchctl unload .../sentinel.plist
+sudo mv /Library/Application\ Support/Sentinel/config.json.bak \
+        /Library/Application\ Support/Sentinel/config.json
+sudo rm -rf /Library/Application\ Support/Sentinel/{sentinel.json,profiles}
 ```
 
 ### `pf anchor setup failed` in logs (strict mode)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -386,6 +386,50 @@ func main() {
 		return
 	}
 
+	// --set-profile changes the active profile and exits. The running daemon
+	// (if any) picks up the new active profile on its next 1-minute scheduler
+	// tick, same as --set-mode.
+	// Usage: sudo ./sentinel --set-profile work
+	if len(os.Args) > 1 && os.Args[1] == "--set-profile" {
+		if len(os.Args) < 3 {
+			log.Fatalf("Usage: %s --set-profile <name>\n", os.Args[0])
+		}
+		name := os.Args[2]
+		if err := config.LoadConfig(); err != nil {
+			log.Fatalf("Failed to load config: %v", err)
+		}
+		if err := config.SwitchProfile(name); err != nil {
+			available, _ := config.ListProfiles()
+			log.Fatalf("Failed to switch profile: %v\nAvailable profiles: %v", err, available)
+		}
+		log.Printf("Active profile set to %q. The daemon will apply within 60 seconds.", name)
+		return
+	}
+
+	// --list-profiles prints every saved profile, marking the active one.
+	if len(os.Args) > 1 && os.Args[1] == "--list-profiles" {
+		if err := config.LoadConfig(); err != nil {
+			log.Fatalf("Failed to load config: %v", err)
+		}
+		names, err := config.ListProfiles()
+		if err != nil {
+			log.Fatalf("Failed to list profiles: %v", err)
+		}
+		active := config.ActiveProfile()
+		if len(names) == 0 {
+			fmt.Println("(no profiles found — first run will create the default)")
+			return
+		}
+		for _, n := range names {
+			marker := "  "
+			if n == active {
+				marker = "* "
+			}
+			fmt.Printf("%s%s\n", marker, n)
+		}
+		return
+	}
+
 	prg := &program{}
 	s, err := service.New(prg, svcConfig)
 	if err != nil {

--- a/docs/index.html
+++ b/docs/index.html
@@ -302,6 +302,15 @@
           <p class="text-slate-400 text-sm leading-relaxed">Start a 25/5 work-and-break session from the dashboard. During work, every active rule is forced on regardless of schedule and pause is locked out. Notifications fire at each phase boundary.</p>
         </div>
 
+        <!-- Feature: Named profiles -->
+        <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
+          <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
+            <svg class="w-5 h-5 text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+          </div>
+          <h3 class="text-white font-semibold mb-2">Named profiles</h3>
+          <p class="text-slate-400 text-sm leading-relaxed">Save different rule sets for Work, Study, Weekend — switch from the header dropdown or <code class="text-sky-400">sentinel --set-profile</code>. Settings, groups, and pause/Pomodoro state stay shared, so a switch only changes the schedule.</p>
+        </div>
+
         <!-- Feature: Clean uninstall -->
         <div class="bg-[#161616] border border-slate-800 rounded-2xl p-6 hover:border-sky-500/40 transition-colors">
           <div class="w-10 h-10 rounded-xl bg-sky-500/10 flex items-center justify-center mb-4">
@@ -589,6 +598,10 @@
           {
             q: `Is there a built-in Pomodoro / focus-session timer?`,
             a: `Yes. Open the dashboard's Status tab, set a work and break duration (defaults 25 / 5 minutes; up to 120 / 60), and click Start Focus Session. During the work phase every active rule is forced on regardless of its schedule, and pause is locked out — you can't edit your way out until the work phase ends. Notifications fire at each phase boundary, the session survives sleep and daemon restart, and it clears itself when the break finishes. It's the inverse of pause: pause forces blocking off, focus sessions force blocking on.`
+          },
+          {
+            q: `Can I have different rules for work vs. weekend?`,
+            a: `Yes — that's what profiles are for. Save one set of rules as "work", another as "weekend", then switch between them from the header dropdown in the dashboard or with sudo sentinel --set-profile <name>. Settings, the shared groups dictionary, and pause/Pomodoro state live outside profiles, so a switch never resets your DNS config or breaks an active focus session. Switches propagate within 60 seconds (the same scheduler tick everything else rides on).`
           },
           {
             q: `How do I uninstall?`,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -116,16 +117,30 @@ var (
 	// so parallel test packages don't race on the repo-rooted ./config.json
 	// (and don't reformat it as a side effect).
 	ConfigDirOverride string
+	// activeProfile is the name of the profile whose rules currently populate
+	// AppConfig.Rules. Held under mu like AppConfig.
+	activeProfile string
 )
 
-func GetConfigFilePath() (string, error) {
+// ActiveProfile returns the name of the profile whose rules currently populate
+// the in-memory Config.
+func ActiveProfile() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return activeProfile
+}
+
+// EnsureConfigDir creates the OS-specific config directory if it does not
+// already exist. Callers do not need this for normal Load/Save flows — the
+// helpers in this package create directories on demand — but it is exposed
+// for tests and one-shot CLI tools that want to fail fast on a permissions
+// problem.
+func EnsureConfigDir() error {
 	dir := configDir()
-	if dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return "", err
-		}
+	if dir == "." {
+		return nil
 	}
-	return filepath.Join(dir, "config.json"), nil
+	return os.MkdirAll(dir, 0755)
 }
 
 // configDir resolves the directory that should hold config.json.
@@ -155,34 +170,232 @@ func generateToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// LoadConfig reads the on-disk bootstrap + active profile and merges them
+// into the in-memory AppConfig. On a fresh install (neither file present) it
+// seeds the defaults. Legacy single-file config.json deployments are migrated
+// transparently on first call; the legacy file is renamed to config.json.bak.
+//
+// Auth tokens are generated and persisted on first run so the dashboard has a
+// stable bearer token from boot.
 func LoadConfig() error {
-	path, err := GetConfigFilePath()
-	if err != nil {
+	if err := EnsureConfigDir(); err != nil {
 		return err
 	}
+	if _, err := migrateLegacyConfigIfNeeded(); err != nil {
+		return fmt.Errorf("legacy config migration: %w", err)
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 
-	data, err := os.ReadFile(path)
+	boot, err := loadBootstrap()
 	if err != nil {
 		if os.IsNotExist(err) {
-			return saveDefaultConfig(path)
+			return seedDefaultsLocked()
 		}
 		return err
 	}
-	if err := json.Unmarshal(data, &AppConfig); err != nil {
-		return err
-	}
-	if AppConfig.Settings.AuthToken == "" {
+
+	tokenWasGenerated := false
+	if boot.Settings.AuthToken == "" {
 		token, err := generateToken()
 		if err != nil {
 			return err
 		}
-		AppConfig.Settings.AuthToken = token
-		updated, _ := json.MarshalIndent(AppConfig, "", "  ")
-		os.WriteFile(path, updated, 0644)
+		boot.Settings.AuthToken = token
+		tokenWasGenerated = true
+	}
+	if boot.ActiveProfile == "" {
+		boot.ActiveProfile = DefaultProfileName
+	}
+
+	prof, err := loadProfile(boot.ActiveProfile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// Active profile points at a missing file. Fall back to "default";
+		// if that's also missing, write an empty profile so the daemon stays
+		// up and the user can recover via the dashboard.
+		log.Printf("config: active profile %q missing on disk, falling back to %q",
+			boot.ActiveProfile, DefaultProfileName)
+		boot.ActiveProfile = DefaultProfileName
+		prof, err = loadProfile(DefaultProfileName)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			prof = ProfileFile{Rules: nil}
+			if err := saveProfile(DefaultProfileName, prof); err != nil {
+				return err
+			}
+		}
+		if err := saveBootstrap(boot); err != nil {
+			return err
+		}
+	} else if tokenWasGenerated {
+		if err := saveBootstrap(boot); err != nil {
+			return err
+		}
+	}
+
+	AppConfig = mergeBootstrapAndProfile(boot, prof)
+	activeProfile = boot.ActiveProfile
+	return nil
+}
+
+// mergeBootstrapAndProfile produces the in-memory Config consumed by the
+// scheduler/proxy/enforcer. Keeping this view identical to the pre-profiles
+// shape lets every downstream package stay untouched.
+func mergeBootstrapAndProfile(b BootstrapFile, p ProfileFile) Config {
+	return Config{
+		Settings: b.Settings,
+		Groups:   b.Groups,
+		Rules:    p.Rules,
+		Pause:    b.Pause,
+		Pomodoro: b.Pomodoro,
+	}
+}
+
+// splitConfigForDisk is the inverse of mergeBootstrapAndProfile. It also
+// records which profile name to write to.
+func splitConfigForDisk(c Config, activeProfile string) (BootstrapFile, ProfileFile) {
+	if activeProfile == "" {
+		activeProfile = DefaultProfileName
+	}
+	return BootstrapFile{
+			Settings:      c.Settings,
+			Groups:        c.Groups,
+			Pause:         c.Pause,
+			Pomodoro:      c.Pomodoro,
+			ActiveProfile: activeProfile,
+		}, ProfileFile{
+			Rules: c.Rules,
+		}
+}
+
+// ListProfiles returns the names of every profile on disk, sorted.
+func ListProfiles() ([]string, error) {
+	return listProfiles()
+}
+
+// ProfileExists reports whether profiles/<name>.json exists.
+func ProfileExists(name string) (bool, error) {
+	if err := ValidateProfileName(name); err != nil {
+		return false, err
+	}
+	_, err := os.Stat(profilePath(name))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// CreateProfile writes profiles/<name>.json. If cloneFrom is non-empty, the
+// new profile copies its rules from the named profile; otherwise it starts
+// with an empty rule set. Returns an error if the name is invalid, the
+// profile already exists, or cloneFrom is set but missing.
+func CreateProfile(name, cloneFrom string) error {
+	if err := ValidateProfileName(name); err != nil {
+		return err
+	}
+	exists, err := ProfileExists(name)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return fmt.Errorf("profile %q already exists", name)
+	}
+
+	var prof ProfileFile
+	if cloneFrom != "" {
+		if err := ValidateProfileName(cloneFrom); err != nil {
+			return fmt.Errorf("clone_from: %w", err)
+		}
+		src, err := loadProfile(cloneFrom)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("clone_from profile %q does not exist", cloneFrom)
+			}
+			return err
+		}
+		prof = src
+	}
+	return saveProfile(name, prof)
+}
+
+// DeleteProfile removes profiles/<name>.json. Returns an error if name is
+// invalid, the profile does not exist, or the profile is currently active.
+func DeleteProfile(name string) error {
+	if err := ValidateProfileName(name); err != nil {
+		return err
+	}
+	if name == ActiveProfile() {
+		return fmt.Errorf("cannot delete active profile %q", name)
+	}
+	if name == DefaultProfileName {
+		return fmt.Errorf("cannot delete the default profile")
+	}
+	if err := os.Remove(profilePath(name)); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("profile %q does not exist", name)
+		}
+		return err
 	}
 	return nil
+}
+
+// SwitchProfile changes the active profile in the bootstrap file, then
+// reloads the in-memory config so the next scheduler tick (or any reader)
+// sees the new rules. Returns an error if name is invalid or the profile
+// file does not exist.
+func SwitchProfile(name string) error {
+	if err := ValidateProfileName(name); err != nil {
+		return err
+	}
+	exists, err := ProfileExists(name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("profile %q does not exist", name)
+	}
+
+	boot, err := loadBootstrap()
+	if err != nil {
+		return err
+	}
+	boot.ActiveProfile = name
+	if err := saveBootstrap(boot); err != nil {
+		return err
+	}
+	return LoadConfig()
+}
+
+// ReplaceFullConfig accepts a merged Config (the legacy on-the-wire shape used
+// by /api/config/update) and writes it across the bootstrap + active profile
+// files. The auth token from the existing bootstrap is preserved — callers
+// cannot rotate it through this path. The active profile name is unchanged.
+func ReplaceFullConfig(cfg Config) error {
+	mu.Lock()
+	prof := activeProfile
+	if prof == "" {
+		prof = DefaultProfileName
+	}
+	cfg.Settings.AuthToken = AppConfig.Settings.AuthToken
+	mu.Unlock()
+
+	boot, profFile := splitConfigForDisk(cfg, prof)
+	if err := saveBootstrap(boot); err != nil {
+		return err
+	}
+	if err := saveProfile(prof, profFile); err != nil {
+		return err
+	}
+	return LoadConfig()
 }
 
 // SetEnforcementMode updates the in-memory enforcement mode.
@@ -250,32 +463,50 @@ func ClearPomodoro() {
 	AppConfig.Pomodoro = nil
 }
 
-// SaveConfig writes the current in-memory config to disk.
+// SaveConfig persists the in-memory AppConfig to disk by splitting it across
+// the bootstrap (sentinel.json) and the active profile file. Both writes are
+// atomic individually; the pair is not. A crash between the two leaves the
+// active profile pointing at the most recent rules — acceptable because the
+// scheduler reloads from disk every minute and re-converges.
 func SaveConfig() error {
-	path, err := GetConfigFilePath()
-	if err != nil {
-		return err
-	}
 	mu.RLock()
-	data, err := json.MarshalIndent(AppConfig, "", "  ")
+	cfg := AppConfig
+	prof := activeProfile
 	mu.RUnlock()
-	if err != nil {
+
+	if prof == "" {
+		prof = DefaultProfileName
+	}
+	boot, profFile := splitConfigForDisk(cfg, prof)
+	if err := saveBootstrap(boot); err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	return saveProfile(prof, profFile)
 }
 
-func saveDefaultConfig(path string) error {
-	if err := json.Unmarshal(defaultConfigBytes, &AppConfig); err != nil {
+// seedDefaultsLocked populates AppConfig from the embedded default config and
+// writes the bootstrap + default profile to disk. Caller must hold mu.
+func seedDefaultsLocked() error {
+	var seed Config
+	if err := json.Unmarshal(defaultConfigBytes, &seed); err != nil {
 		return err
 	}
 	token, err := generateToken()
 	if err != nil {
 		return err
 	}
-	AppConfig.Settings.AuthToken = token
-	data, _ := json.MarshalIndent(AppConfig, "", "  ")
-	return os.WriteFile(path, data, 0644)
+	seed.Settings.AuthToken = token
+
+	boot, prof := splitConfigForDisk(seed, DefaultProfileName)
+	if err := saveBootstrap(boot); err != nil {
+		return err
+	}
+	if err := saveProfile(DefaultProfileName, prof); err != nil {
+		return err
+	}
+	AppConfig = seed
+	activeProfile = DefaultProfileName
+	return nil
 }
 
 func GetConfig() Config {
@@ -289,22 +520,24 @@ const factoryPrimaryDNS = "8.8.8.8:53"
 // AutoSetPrimaryDNS updates primary_dns only when it still holds the factory
 // default. This lets the first dns/strict mode startup capture whatever DNS
 // the user had before Sentinel, without overwriting deliberate user settings.
+//
+// Settings live in the bootstrap, so this writes only sentinel.json.
 func AutoSetPrimaryDNS(server string) {
-	path, err := GetConfigFilePath()
-	if err != nil {
-		return
-	}
 	mu.Lock()
-	defer mu.Unlock()
 	if AppConfig.Settings.PrimaryDNS != factoryPrimaryDNS {
+		mu.Unlock()
 		return
 	}
 	AppConfig.Settings.PrimaryDNS = server
-	data, err := json.MarshalIndent(AppConfig, "", "  ")
-	if err != nil {
-		return
+	cfg := AppConfig
+	prof := activeProfile
+	mu.Unlock()
+
+	if prof == "" {
+		prof = DefaultProfileName
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	boot, _ := splitConfigForDisk(cfg, prof)
+	if err := saveBootstrap(boot); err != nil {
 		log.Printf("config: could not save auto-detected upstream DNS: %v", err)
 		return
 	}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// DefaultProfileName is the profile created on a fresh install and the fallback
+// when active_profile points at a missing file.
+const DefaultProfileName = "default"
+
+// profileNameRegex enforces a small, filesystem-safe name shape. The rules file
+// will be saved as <name>.json in profilesDir, so we keep names ASCII-lowercase,
+// short, and free of separator characters that would surprise users on case-
+// preserving-but-insensitive filesystems (APFS, NTFS).
+var profileNameRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,31}$`)
+
+// reservedProfileNames cannot be used because they would collide with bootstrap
+// or legacy filenames in the same directory.
+var reservedProfileNames = map[string]bool{
+	"sentinel":  true,
+	"bootstrap": true,
+	"config":    true,
+}
+
+// BootstrapFile is the on-disk shape of sentinel.json. It carries everything
+// that is *not* per-profile: the system settings (DNS, enforcement_mode, auth
+// token, foreground tracking), the shared groups dictionary, runtime state
+// (pause/pomodoro), and the name of the active profile.
+//
+// Groups are deliberately bootstrap-level so users can reuse the same domain
+// dictionary across profiles — a profile only differs in which groups are on
+// the schedule and when.
+type BootstrapFile struct {
+	Settings      Settings            `json:"settings"`
+	Groups        map[string][]string `json:"groups"`
+	Pause         *PauseWindow        `json:"pause,omitempty"`
+	Pomodoro      *PomodoroSession    `json:"pomodoro,omitempty"`
+	ActiveProfile string              `json:"active_profile"`
+}
+
+// ProfileFile is the on-disk shape of profiles/<name>.json. It only carries
+// the rules; settings and groups come from the bootstrap.
+type ProfileFile struct {
+	Rules []Rule `json:"rules"`
+}
+
+func bootstrapPath() string {
+	return filepath.Join(configDir(), "sentinel.json")
+}
+
+func profilesDir() string {
+	return filepath.Join(configDir(), "profiles")
+}
+
+func profilePath(name string) string {
+	return filepath.Join(profilesDir(), name+".json")
+}
+
+func legacyConfigPath() string {
+	return filepath.Join(configDir(), "config.json")
+}
+
+func legacyBackupPath() string {
+	return filepath.Join(configDir(), "config.json.bak")
+}
+
+// ValidateProfileName returns nil if name is a usable profile name.
+func ValidateProfileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name cannot be empty")
+	}
+	if reservedProfileNames[name] {
+		return fmt.Errorf("profile name %q is reserved", name)
+	}
+	if !profileNameRegex.MatchString(name) {
+		return fmt.Errorf("profile name %q invalid: must match %s", name, profileNameRegex.String())
+	}
+	return nil
+}
+
+// ensureProfilesDir creates the profiles/ subdirectory if it does not already exist.
+func ensureProfilesDir() error {
+	dir := profilesDir()
+	return os.MkdirAll(dir, 0755)
+}
+
+// loadBootstrap reads sentinel.json from disk. Caller must hold mu if it cares
+// about consistency with AppConfig — these helpers do not lock.
+func loadBootstrap() (BootstrapFile, error) {
+	var b BootstrapFile
+	data, err := os.ReadFile(bootstrapPath())
+	if err != nil {
+		return b, err
+	}
+	if err := json.Unmarshal(data, &b); err != nil {
+		return b, fmt.Errorf("parse sentinel.json: %w", err)
+	}
+	return b, nil
+}
+
+// saveBootstrap writes sentinel.json atomically (write-rename) so a partial
+// write cannot leave the file unparseable.
+func saveBootstrap(b BootstrapFile) error {
+	if err := os.MkdirAll(configDir(), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(bootstrapPath(), data)
+}
+
+// loadProfile reads profiles/<name>.json. Returns os.ErrNotExist if missing.
+func loadProfile(name string) (ProfileFile, error) {
+	var p ProfileFile
+	data, err := os.ReadFile(profilePath(name))
+	if err != nil {
+		return p, err
+	}
+	if err := json.Unmarshal(data, &p); err != nil {
+		return p, fmt.Errorf("parse profile %q: %w", name, err)
+	}
+	return p, nil
+}
+
+func saveProfile(name string, p ProfileFile) error {
+	if err := ensureProfilesDir(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(profilePath(name), data)
+}
+
+// listProfiles returns all profile names found on disk, sorted.
+func listProfiles() ([]string, error) {
+	entries, err := os.ReadDir(profilesDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(name, ".json"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// atomicWrite writes data to path via a temp file + rename so concurrent
+// readers (e.g. the scheduler tick reading mid-write) never see a truncated
+// file. Permissions match the original 0644 of os.WriteFile.
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// migrateLegacyConfigIfNeeded converts an old single-file config.json into the
+// new bootstrap+profile layout. Idempotent: a no-op once sentinel.json exists,
+// and a no-op when the legacy file is absent.
+//
+// On migration the legacy file is renamed to config.json.bak so a botched
+// migration is recoverable by a human operator.
+func migrateLegacyConfigIfNeeded() (bool, error) {
+	if _, err := os.Stat(bootstrapPath()); err == nil {
+		return false, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	legacy := legacyConfigPath()
+	data, err := os.ReadFile(legacy)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	var legacyCfg Config
+	if err := json.Unmarshal(data, &legacyCfg); err != nil {
+		return false, fmt.Errorf("parse legacy config.json: %w", err)
+	}
+
+	boot := BootstrapFile{
+		Settings:      legacyCfg.Settings,
+		Groups:        legacyCfg.Groups,
+		Pause:         legacyCfg.Pause,
+		Pomodoro:      legacyCfg.Pomodoro,
+		ActiveProfile: DefaultProfileName,
+	}
+	prof := ProfileFile{Rules: legacyCfg.Rules}
+
+	if err := saveBootstrap(boot); err != nil {
+		return false, err
+	}
+	if err := saveProfile(DefaultProfileName, prof); err != nil {
+		return false, err
+	}
+	if err := os.Rename(legacy, legacyBackupPath()); err != nil {
+		return false, fmt.Errorf("rename legacy config: %w", err)
+	}
+	return true, nil
+}

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -1,0 +1,345 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempDir routes config I/O at a fresh tempdir for the lifetime of the
+// test, restoring the prior override on cleanup. Tests that exercise on-disk
+// state should call this so they don't race against the package-level
+// AppConfig set up by other tests.
+func withTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	prevOverride := ConfigDirOverride
+	prevApp := AppConfig
+	prevActive := activeProfile
+	ConfigDirOverride = dir
+	t.Cleanup(func() {
+		ConfigDirOverride = prevOverride
+		AppConfig = prevApp
+		activeProfile = prevActive
+	})
+	return dir
+}
+
+func TestValidateProfileName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool // true = valid
+	}{
+		{"work", true},
+		{"work-mode", true},
+		{"study_2025", true},
+		{"a", true},
+		{"123work", true},
+		{"", false},
+		{"-leading-dash", false},
+		{"_leading-underscore", false},
+		{"UPPER", false},
+		{"has space", false},
+		{"has/slash", false},
+		{"sentinel", false},  // reserved
+		{"bootstrap", false}, // reserved
+		{"config", false},    // reserved
+	}
+	for _, c := range cases {
+		err := ValidateProfileName(c.name)
+		if (err == nil) != c.want {
+			t.Errorf("ValidateProfileName(%q) error=%v, want valid=%v", c.name, err, c.want)
+		}
+	}
+}
+
+func TestLoadConfig_FreshInstall_SeedsBootstrapAndDefaultProfile(t *testing.T) {
+	dir := withTempDir(t)
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Bootstrap and profile files should exist on disk.
+	if _, err := os.Stat(filepath.Join(dir, "sentinel.json")); err != nil {
+		t.Fatalf("sentinel.json not created: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "profiles", "default.json")); err != nil {
+		t.Fatalf("profiles/default.json not created: %v", err)
+	}
+
+	// Auth token should be generated.
+	cfg := GetConfig()
+	if cfg.Settings.AuthToken == "" {
+		t.Error("expected auth token to be generated on fresh install")
+	}
+	// Embedded default has rules — assert they were carried into AppConfig.
+	if len(cfg.Rules) == 0 {
+		t.Error("expected embedded default rules to populate Config.Rules")
+	}
+	// Active profile should be "default".
+	if got := ActiveProfile(); got != DefaultProfileName {
+		t.Errorf("ActiveProfile=%q, want %q", got, DefaultProfileName)
+	}
+}
+
+func TestLoadConfig_RoundTrip_PreservesAuthToken(t *testing.T) {
+	withTempDir(t)
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig 1: %v", err)
+	}
+	originalToken := GetConfig().Settings.AuthToken
+
+	// Reset in-memory state, force a re-read from disk.
+	AppConfig = Config{}
+	activeProfile = ""
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig 2: %v", err)
+	}
+	if GetConfig().Settings.AuthToken != originalToken {
+		t.Errorf("auth token changed across LoadConfig calls: was %q, now %q",
+			originalToken, GetConfig().Settings.AuthToken)
+	}
+}
+
+func TestLoadConfig_LegacyMigration_SplitsAndBacksUp(t *testing.T) {
+	dir := withTempDir(t)
+
+	// Write a legacy single-file config.json.
+	legacy := Config{
+		Settings: Settings{
+			PrimaryDNS:      "8.8.8.8:53",
+			BackupDNS:       "1.1.1.1:53",
+			AuthToken:       "preserved-token-xyz",
+			EnforcementMode: "strict",
+		},
+		Groups: map[string][]string{
+			"social": {"twitter.com", "instagram.com"},
+		},
+		Rules: []Rule{
+			{
+				Group:    "social",
+				IsActive: true,
+				Schedules: map[string][]TimeSlot{
+					"Monday": {{Start: "09:00", End: "12:00"}},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0644); err != nil {
+		t.Fatalf("seeding legacy file: %v", err)
+	}
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Legacy file should have been renamed to .bak.
+	if _, err := os.Stat(filepath.Join(dir, "config.json")); !os.IsNotExist(err) {
+		t.Error("expected legacy config.json to have been renamed away")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "config.json.bak")); err != nil {
+		t.Errorf("expected config.json.bak after migration: %v", err)
+	}
+
+	// In-memory config should match the legacy content.
+	cfg := GetConfig()
+	if cfg.Settings.AuthToken != "preserved-token-xyz" {
+		t.Errorf("auth_token not preserved: got %q", cfg.Settings.AuthToken)
+	}
+	if cfg.Settings.EnforcementMode != "strict" {
+		t.Errorf("enforcement_mode not preserved: got %q", cfg.Settings.EnforcementMode)
+	}
+	if len(cfg.Rules) != 1 || cfg.Rules[0].Group != "social" {
+		t.Errorf("rules not migrated correctly: %+v", cfg.Rules)
+	}
+	if got := ActiveProfile(); got != DefaultProfileName {
+		t.Errorf("ActiveProfile after migration=%q, want %q", got, DefaultProfileName)
+	}
+
+	// Re-running LoadConfig should be idempotent — no error, no state churn.
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("second LoadConfig (idempotency): %v", err)
+	}
+}
+
+func TestSwitchProfile_RoundTrip(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Create a "work" profile that overrides the default rules.
+	if err := CreateProfile("work", ""); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	// Write distinguishable rules into the new profile.
+	if err := saveProfile("work", ProfileFile{
+		Rules: []Rule{{Group: "videos", IsActive: true, Schedules: map[string][]TimeSlot{
+			"Monday": {{Start: "10:00", End: "11:00"}},
+		}}},
+	}); err != nil {
+		t.Fatalf("saveProfile: %v", err)
+	}
+
+	if err := SwitchProfile("work"); err != nil {
+		t.Fatalf("SwitchProfile: %v", err)
+	}
+
+	cfg := GetConfig()
+	if got := ActiveProfile(); got != "work" {
+		t.Errorf("ActiveProfile=%q after switch, want %q", got, "work")
+	}
+	if len(cfg.Rules) != 1 || cfg.Rules[0].Group != "videos" {
+		t.Errorf("expected work rules after switch, got %+v", cfg.Rules)
+	}
+
+	// Auth token should still be intact (lives in bootstrap).
+	if cfg.Settings.AuthToken == "" {
+		t.Error("auth token wiped by profile switch")
+	}
+}
+
+func TestSwitchProfile_MissingProfile_Errors(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := SwitchProfile("nope"); err == nil {
+		t.Error("expected error switching to nonexistent profile")
+	}
+}
+
+func TestSwitchProfile_InvalidName_Errors(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := SwitchProfile("BAD NAME"); err == nil {
+		t.Error("expected validation error for invalid profile name")
+	}
+}
+
+func TestCreateProfile_Clone(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if err := CreateProfile("study", DefaultProfileName); err != nil {
+		t.Fatalf("CreateProfile clone: %v", err)
+	}
+	src, err := loadProfile(DefaultProfileName)
+	if err != nil {
+		t.Fatalf("loadProfile default: %v", err)
+	}
+	clone, err := loadProfile("study")
+	if err != nil {
+		t.Fatalf("loadProfile study: %v", err)
+	}
+	if len(src.Rules) != len(clone.Rules) {
+		t.Errorf("clone rule count mismatch: src=%d clone=%d",
+			len(src.Rules), len(clone.Rules))
+	}
+}
+
+func TestCreateProfile_Duplicate_Errors(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := CreateProfile("dup", ""); err != nil {
+		t.Fatalf("first CreateProfile: %v", err)
+	}
+	if err := CreateProfile("dup", ""); err == nil {
+		t.Error("expected error on duplicate CreateProfile")
+	}
+}
+
+func TestDeleteProfile_Active_Errors(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := DeleteProfile(DefaultProfileName); err == nil {
+		t.Error("expected error deleting default/active profile")
+	}
+}
+
+func TestDeleteProfile_Inactive_OK(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := CreateProfile("temp", ""); err != nil {
+		t.Fatalf("CreateProfile: %v", err)
+	}
+	if err := DeleteProfile("temp"); err != nil {
+		t.Fatalf("DeleteProfile: %v", err)
+	}
+	exists, err := ProfileExists("temp")
+	if err != nil {
+		t.Fatalf("ProfileExists: %v", err)
+	}
+	if exists {
+		t.Error("expected profile file removed after DeleteProfile")
+	}
+}
+
+func TestLoadConfig_MissingActiveProfile_FallsBackToDefault(t *testing.T) {
+	dir := withTempDir(t)
+
+	// Hand-author a bootstrap that points at a profile that won't exist.
+	boot := BootstrapFile{
+		Settings: Settings{
+			PrimaryDNS: "8.8.8.8:53",
+			AuthToken:  "test-token",
+		},
+		Groups:        map[string][]string{"social": {"twitter.com"}},
+		ActiveProfile: "ghost",
+	}
+	bootData, _ := json.MarshalIndent(boot, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, "sentinel.json"), bootData, 0644); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got := ActiveProfile(); got != DefaultProfileName {
+		t.Errorf("ActiveProfile=%q, want fallback %q", got, DefaultProfileName)
+	}
+	// Auth token should be preserved across the fallback.
+	if cfg := GetConfig(); cfg.Settings.AuthToken != "test-token" {
+		t.Errorf("auth token lost on fallback: got %q", cfg.Settings.AuthToken)
+	}
+}
+
+func TestListProfiles_Sorted(t *testing.T) {
+	withTempDir(t)
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	for _, n := range []string{"zebra", "alpha", "mango"} {
+		if err := CreateProfile(n, ""); err != nil {
+			t.Fatalf("CreateProfile %q: %v", n, err)
+		}
+	}
+	got, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	want := []string{"alpha", "default", "mango", "zebra"}
+	if len(got) != len(want) {
+		t.Fatalf("ListProfiles len=%d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Errorf("ListProfiles[%d]=%q, want %q", i, got[i], name)
+		}
+	}
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -189,6 +189,7 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		"last_evaluated":   lastEval,
 		"enforcement_mode": cfg.Settings.GetEnforcementMode(),
 		"paused":           cfg.IsPaused(now),
+		"active_profile":   config.ActiveProfile(),
 	}
 	if cfg.Pause != nil {
 		resp["paused_until"] = cfg.Pause.Until.Format(time.RFC3339)
@@ -352,6 +353,154 @@ func PomodoroStopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// profilesCollectionRouter dispatches /api/profiles to the right handler by
+// HTTP method: GET → list, POST → create.
+func profilesCollectionRouter(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		ProfilesListHandler(w, r)
+	case http.MethodPost:
+		ProfilesCreateHandler(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// profilesItemRouter dispatches /api/profiles/{name}. Only DELETE is meaningful
+// today; GET/PATCH could be added later for inspect/rename.
+func profilesItemRouter(w http.ResponseWriter, r *http.Request) {
+	const prefix = "/api/profiles/"
+	name := r.URL.Path[len(prefix):]
+	if name == "" || name == "/" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	switch r.Method {
+	case http.MethodDelete:
+		ProfilesDeleteHandler(w, r, name)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+// ProfilesListHandler returns the names of every profile on disk plus the
+// active profile name. GET only.
+func ProfilesListHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	names, err := config.ListProfiles()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "failed to list profiles: " + err.Error()})
+		return
+	}
+	if names == nil {
+		names = []string{}
+	}
+	json.NewEncoder(w).Encode(map[string]any{
+		"active":   config.ActiveProfile(),
+		"profiles": names,
+	})
+}
+
+// ProfilesCreateHandler creates a new profile.
+// Body: {"name": "<name>", "clone_from": "<src>" (optional)}
+// 400 on validation error, 409 if the profile already exists, 500 on I/O.
+func ProfilesCreateHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var body struct {
+		Name      string `json:"name"`
+		CloneFrom string `json:"clone_from"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if err := config.ValidateProfileName(body.Name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	exists, err := config.ProfileExists(body.Name)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	if exists {
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": "profile already exists"})
+		return
+	}
+	if err := config.CreateProfile(body.Name, body.CloneFrom); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "name": body.Name})
+}
+
+// ProfilesDeleteHandler deletes a profile by name.
+// Path: /api/profiles/{name}. 400 on validation, 404 missing, 409 if active,
+// 500 on I/O.
+func ProfilesDeleteHandler(w http.ResponseWriter, r *http.Request, name string) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := config.ValidateProfileName(name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	exists, err := config.ProfileExists(name)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	if !exists {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "profile not found"})
+		return
+	}
+	if name == config.ActiveProfile() {
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": "cannot delete the active profile"})
+		return
+	}
+	if err := config.DeleteProfile(name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "name": name})
+}
+
+// ProfileSwitchHandler atomically changes the active profile and reloads the
+// in-memory config. Body: {"name": "<name>"}. Locked during a Pomodoro work
+// phase (HTTP 423) to mirror /api/pomodoro DELETE and /api/config/update.
+func ProfileSwitchHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if config.GetConfig().IsLockedByPomodoro(time.Now()) {
+		w.WriteHeader(http.StatusLocked)
+		json.NewEncoder(w).Encode(map[string]string{"error": "profile changes are locked during a Pomodoro work session"})
+		return
+	}
+	if err := config.SwitchProfile(body.Name); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "active": body.Name})
 }
 
 // resolveConfig extracts a config from the request body if present, otherwise reloads
@@ -720,6 +869,15 @@ func StartWebServer() {
 	}))
 	mux.HandleFunc("/api/events", authMiddleware(EventsHandler))
 	mux.HandleFunc("/api/usage", authMiddleware(UsageHandler))
+	mux.HandleFunc("/api/profiles", authMiddleware(profilesCollectionRouter))
+	mux.HandleFunc("/api/profiles/", authMiddleware(profilesItemRouter))
+	mux.HandleFunc("/api/profile/switch", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		ProfileSwitchHandler(w, r)
+	}))
 
 	log.Println("Web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {
@@ -773,6 +931,15 @@ func StartTestWebServer() {
 	}))
 	mux.HandleFunc("/api/events", authMiddleware(EventsHandler))
 	mux.HandleFunc("/api/usage", authMiddleware(UsageHandler))
+	mux.HandleFunc("/api/profiles", authMiddleware(profilesCollectionRouter))
+	mux.HandleFunc("/api/profiles/", authMiddleware(profilesItemRouter))
+	mux.HandleFunc("/api/profile/switch", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		ProfileSwitchHandler(w, r)
+	}))
 
 	log.Println("Test web server starting on http://localhost:8040")
 	if err := http.ListenAndServe("127.0.0.1:8040", mux); err != nil {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -151,13 +150,6 @@ func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path, err := config.GetConfigFilePath()
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "cannot resolve config path: " + err.Error()})
-		return
-	}
-
 	// Preserve the existing auth token — callers cannot replace it via this endpoint.
 	existing := config.GetConfig()
 	if existing.IsLockedByPomodoro(time.Now()) {
@@ -165,17 +157,12 @@ func UpdateConfigHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"error": "config changes are locked during a Pomodoro work session"})
 		return
 	}
-	cfg.Settings.AuthToken = existing.Settings.AuthToken
 
-	data, _ := json.MarshalIndent(cfg, "", "  ")
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// ReplaceFullConfig splits the merged Config across sentinel.json + the
+	// active profile file and reloads in-memory state.
+	if err := config.ReplaceFullConfig(cfg); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{"error": "failed to write config: " + err.Error()})
-		return
-	}
-	if err := config.LoadConfig(); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "config written but reload failed: " + err.Error()})
 		return
 	}
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -666,3 +666,150 @@ func TestUpdateConfigHandler_LockedDuringWork_Returns423(t *testing.T) {
 		t.Errorf("expected 423, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// ── Profile management tests ──────────────────────────────────────────────────
+
+func TestProfilesList_ReturnsActiveAndProfiles(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	req := authRequest("GET", "/api/profiles", nil)
+	rr := httptest.NewRecorder()
+	ProfilesListHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp["active"] == nil {
+		t.Errorf("expected active field, got %v", resp)
+	}
+	if _, ok := resp["profiles"].([]any); !ok {
+		t.Errorf("expected profiles array, got %v", resp["profiles"])
+	}
+}
+
+func TestProfilesCreate_NewProfile_201(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = config.DeleteProfile("alpha") })
+
+	body, _ := json.Marshal(map[string]string{"name": "alpha"})
+	req := authRequest("POST", "/api/profiles", body)
+	rr := httptest.NewRecorder()
+	ProfilesCreateHandler(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfilesCreate_DuplicateName_409(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	t.Cleanup(func() { _ = config.DeleteProfile("dupe") })
+	if err := config.CreateProfile("dupe", ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"name": "dupe"})
+	req := authRequest("POST", "/api/profiles", body)
+	rr := httptest.NewRecorder()
+	ProfilesCreateHandler(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfilesCreate_InvalidName_400(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	body, _ := json.Marshal(map[string]string{"name": "Has Spaces"})
+	req := authRequest("POST", "/api/profiles", body)
+	rr := httptest.NewRecorder()
+	ProfilesCreateHandler(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfilesDelete_Active_409(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	req := authRequest("DELETE", "/api/profiles/"+config.ActiveProfile(), nil)
+	rr := httptest.NewRecorder()
+	ProfilesDeleteHandler(rr, req, config.ActiveProfile())
+	if rr.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfilesDelete_Missing_404(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	req := authRequest("DELETE", "/api/profiles/ghost", nil)
+	rr := httptest.NewRecorder()
+	ProfilesDeleteHandler(rr, req, "ghost")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfileSwitch_ChangesActive(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := config.CreateProfile("beta", ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.SwitchProfile(config.DefaultProfileName)
+		_ = config.DeleteProfile("beta")
+	})
+
+	body, _ := json.Marshal(map[string]string{"name": "beta"})
+	req := authRequest("POST", "/api/profile/switch", body)
+	rr := httptest.NewRecorder()
+	ProfileSwitchHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if config.ActiveProfile() != "beta" {
+		t.Errorf("active profile not updated: got %q", config.ActiveProfile())
+	}
+}
+
+func TestProfileSwitch_LockedDuringWork_423(t *testing.T) {
+	setWorkPhase(t)
+	if err := config.CreateProfile("locked-target", ""); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = config.DeleteProfile("locked-target")
+	})
+
+	body, _ := json.Marshal(map[string]string{"name": "locked-target"})
+	req := authRequest("POST", "/api/profile/switch", body)
+	rr := httptest.NewRecorder()
+	ProfileSwitchHandler(rr, req)
+	if rr.Code != http.StatusLocked {
+		t.Errorf("expected 423, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestProfileSwitch_MissingProfile_400(t *testing.T) {
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	body, _ := json.Marshal(map[string]string{"name": "nope"})
+	req := authRequest("POST", "/api/profile/switch", body)
+	rr := httptest.NewRecorder()
+	ProfileSwitchHandler(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -504,23 +504,44 @@ func authRequest(method, path string, body []byte) *http.Request {
 
 func setWorkPhase(t *testing.T) {
 	t.Helper()
-	t.Cleanup(func() { config.AppConfig.Pomodoro = nil })
+	// Bootstrap AppConfig from disk (so Settings, Groups, AuthToken, active
+	// profile are all populated) before mutating Pomodoro. Without this, a
+	// subsequent SaveConfig would persist a half-initialized config.
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("setWorkPhase: LoadConfig failed: %v", err)
+	}
+	t.Cleanup(func() {
+		config.ClearPomodoro()
+		_ = config.SaveConfig()
+	})
 	config.AppConfig.Pomodoro = &config.PomodoroSession{
 		Phase:        "work",
 		PhaseEndsAt:  time.Now().Add(10 * time.Minute),
 		WorkMinutes:  25,
 		BreakMinutes: 5,
 	}
+	if err := config.SaveConfig(); err != nil {
+		t.Fatalf("setWorkPhase: SaveConfig failed: %v", err)
+	}
 }
 
 func setBreakPhase(t *testing.T) {
 	t.Helper()
-	t.Cleanup(func() { config.AppConfig.Pomodoro = nil })
+	if err := config.LoadConfig(); err != nil {
+		t.Fatalf("setBreakPhase: LoadConfig failed: %v", err)
+	}
+	t.Cleanup(func() {
+		config.ClearPomodoro()
+		_ = config.SaveConfig()
+	})
 	config.AppConfig.Pomodoro = &config.PomodoroSession{
 		Phase:        "break",
 		PhaseEndsAt:  time.Now().Add(5 * time.Minute),
 		WorkMinutes:  25,
 		BreakMinutes: 5,
+	}
+	if err := config.SaveConfig(); err != nil {
+		t.Fatalf("setBreakPhase: SaveConfig failed: %v", err)
 	}
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -37,7 +37,6 @@
         .app-header h1 { font-size: 20px; font-weight: 700; letter-spacing: -0.3px; }
         .app-header p  { font-size: 12px; opacity: 0.75; margin-top: 3px; }
         .app-header .version-pill {
-            margin-left: auto;
             font-size: 11px;
             font-weight: 600;
             padding: 4px 10px;
@@ -47,6 +46,88 @@
             letter-spacing: 0.3px;
             font-variant-numeric: tabular-nums;
             white-space: nowrap;
+        }
+        .app-header .header-spacer { flex: 1; }
+        .profile-switcher {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.92);
+            letter-spacing: 0.2px;
+        }
+        .profile-switcher label {
+            text-transform: uppercase;
+            font-size: 10px;
+            letter-spacing: 0.6px;
+            opacity: 0.75;
+        }
+        .profile-switcher select {
+            background: rgba(255, 255, 255, 0.18);
+            color: rgba(255, 255, 255, 0.95);
+            border: 1px solid rgba(255, 255, 255, 0.28);
+            border-radius: 12px;
+            padding: 4px 24px 4px 10px;
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            outline: none;
+            appearance: none;
+            background-image:
+                linear-gradient(45deg, transparent 50%, rgba(255,255,255,0.85) 50%),
+                linear-gradient(135deg, rgba(255,255,255,0.85) 50%, transparent 50%);
+            background-position:
+                calc(100% - 11px) 50%,
+                calc(100% - 7px) 50%;
+            background-size: 4px 4px, 4px 4px;
+            background-repeat: no-repeat;
+        }
+        .profile-switcher select:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
+        .profile-switcher select option { color: #212529; }
+        .profile-toast {
+            position: fixed;
+            top: 16px;
+            right: 16px;
+            background: #198754;
+            color: white;
+            padding: 10px 16px;
+            border-radius: 8px;
+            font-size: 13px;
+            font-weight: 600;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.18);
+            opacity: 0;
+            transform: translateY(-8px);
+            transition: opacity 0.2s, transform 0.2s;
+            pointer-events: none;
+            z-index: 1000;
+        }
+        .profile-toast.visible { opacity: 1; transform: translateY(0); }
+        .profile-toast.error { background: #dc3545; }
+
+        /* Profile management section in Manage tab */
+        .profile-list { display: flex; flex-direction: column; gap: 6px; margin: 8px 0 12px; }
+        .profile-row {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 8px 12px; border: 1px solid #e9ecef; border-radius: 6px;
+            background: #fafafa; font-size: 13px;
+        }
+        .profile-row.active { border-color: #667eea; background: #f3f4ff; font-weight: 600; }
+        .profile-row .profile-meta {
+            font-size: 11px; color: #6c757d; font-weight: 500;
+        }
+        .profile-row .profile-actions { display: flex; gap: 6px; }
+        .profile-create-row {
+            display: flex; gap: 8px; align-items: center; margin-top: 8px;
+            flex-wrap: wrap;
+        }
+        .profile-create-row input,
+        .profile-create-row select {
+            font-size: 13px; padding: 6px 10px; border: 1px solid #ced4da;
+            border-radius: 6px;
         }
 
         /* Tabs */
@@ -637,8 +718,14 @@
             <h1>Sentinel</h1>
             <p>Schedule-based focus enforcement</p>
         </div>
+        <div class="header-spacer"></div>
+        <div class="profile-switcher" id="profileSwitcher" hidden>
+            <label for="profileDropdown">Profile</label>
+            <select id="profileDropdown" onchange="handleProfileSwitch(this.value)" title="Active blocking profile"></select>
+        </div>
         <span id="versionPill" class="version-pill" title="Running version" hidden></span>
     </div>
+    <div id="profileToast" class="profile-toast" role="status" aria-live="polite"></div>
 
     <div class="tabs">
         <button class="tab-button active" onclick="switchTab('status')">Status</button>
@@ -658,6 +745,7 @@
                 <button class="btn-sm btn-success" onclick="loadStatus()">↻ Refresh</button>
             </div>
             <div id="modeBadge"></div>
+            <div id="profileBadge" style="margin-top:6px;"></div>
             <div id="pauseBanner"></div>
             <div id="statusContent"><p style="color:#adb5bd;font-size:13px;">Loading…</p></div>
             <div class="status-meta" id="statusMeta"></div>
@@ -844,6 +932,22 @@
                 <div id="managePauseContent"><p style="color:#adb5bd;font-size:13px;">Loading…</p></div>
                 <div id="managePauseMsg"></div>
             </div>
+
+            <hr class="section-divider">
+
+            <div class="section">
+                <div class="section-title">Profiles</div>
+                <p style="font-size:12px;color:#6c757d;margin:0 0 10px;">
+                    Each profile is its own set of <em>rules</em>; settings, groups, and pause/pomodoro state are shared. Editing the textarea above writes to the active profile.
+                </p>
+                <div id="manageProfileList" class="profile-list"></div>
+                <div class="profile-create-row">
+                    <input type="text" id="newProfileName" placeholder="profile-name" maxlength="32">
+                    <select id="cloneFromProfile" title="Clone rules from"></select>
+                    <button onclick="createProfile()">Create profile</button>
+                </div>
+                <div id="manageProfileMsg" style="margin-top:8px;"></div>
+            </div>
         </div>
     </div>
 
@@ -924,12 +1028,19 @@ var EXAMPLE_CONFIG = {
     ]
 };
 
+// ── State for profiles ────────────────────────────────────────────────────────
+var profileList   = [];
+var activeProfile = '';
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 window.onload = function() {
     setupPinBoxes();
     setDefaultTestTime();
     loadVersion();
-    loadConfig().then(function() { loadStatus(); });
+    loadConfig().then(function() {
+        loadProfiles();
+        loadStatus();
+    });
 };
 
 async function loadVersion() {
@@ -967,6 +1078,177 @@ async function loadConfig() {
         testConfig = EXAMPLE_CONFIG;
     }
 }
+
+// ── Profiles ──────────────────────────────────────────────────────────────────
+async function loadProfiles() {
+    if (!authToken) return;
+    try {
+        var res = await fetch('/api/profiles', {
+            headers: {'X-Auth-Token': authToken}
+        });
+        if (!res.ok) return;
+        var data = await res.json();
+        profileList   = data.profiles || [];
+        activeProfile = data.active   || '';
+        renderProfileSwitcher();
+        renderManageProfiles();
+    } catch (e) {
+        // Non-fatal — the rest of the dashboard still works without profiles.
+    }
+}
+
+function renderProfileSwitcher() {
+    var wrap = document.getElementById('profileSwitcher');
+    var sel  = document.getElementById('profileDropdown');
+    if (!wrap || !sel) return;
+    if (!profileList.length) {
+        wrap.hidden = true;
+        return;
+    }
+    var html = '';
+    for (var i = 0; i < profileList.length; i++) {
+        var name = profileList[i];
+        var selected = (name === activeProfile) ? ' selected' : '';
+        html += '<option value="' + escapeHtml(name) + '"' + selected + '>' +
+                escapeHtml(name) + '</option>';
+    }
+    sel.innerHTML = html;
+    wrap.hidden = false;
+
+    var badge = document.getElementById('profileBadge');
+    if (badge) {
+        if (activeProfile) {
+            badge.innerHTML =
+                '<span class="mode-badge hosts" style="background:#e9ecef;color:#495057;">' +
+                '⚑ Profile: ' + escapeHtml(activeProfile) + '</span>';
+        } else {
+            badge.innerHTML = '';
+        }
+    }
+}
+
+function setProfileSwitcherDisabled(disabled, reason) {
+    var sel = document.getElementById('profileDropdown');
+    if (!sel) return;
+    sel.disabled = !!disabled;
+    sel.title = disabled ? (reason || 'Disabled') : 'Active blocking profile';
+}
+
+async function handleProfileSwitch(name) {
+    if (!name || name === activeProfile) return;
+    try {
+        var res = await fetch('/api/profile/switch', {
+            method:  'POST',
+            headers: {'X-Auth-Token': authToken, 'Content-Type': 'application/json'},
+            body:    JSON.stringify({name: name})
+        });
+        var data = await res.json();
+        if (!res.ok) {
+            showProfileToast(data.error || 'Failed to switch profile', true);
+            // Revert dropdown to the still-active profile.
+            var sel = document.getElementById('profileDropdown');
+            if (sel) sel.value = activeProfile;
+            return;
+        }
+        activeProfile = name;
+        showProfileToast('Switched to "' + name + '" — applies within 60s');
+        await loadConfig();
+        await loadProfiles();
+        loadStatus();
+    } catch (e) {
+        showProfileToast('Error: ' + e.message, true);
+    }
+}
+
+function showProfileToast(msg, isError) {
+    var t = document.getElementById('profileToast');
+    if (!t) return;
+    t.textContent = msg;
+    t.classList.toggle('error', !!isError);
+    t.classList.add('visible');
+    clearTimeout(showProfileToast._timer);
+    showProfileToast._timer = setTimeout(function() {
+        t.classList.remove('visible');
+    }, 3500);
+}
+
+function renderManageProfiles() {
+    var listEl = document.getElementById('manageProfileList');
+    var cloneEl = document.getElementById('cloneFromProfile');
+    if (!listEl || !cloneEl) return;
+
+    if (!profileList.length) {
+        listEl.innerHTML = '<p style="color:#adb5bd;font-size:13px;">No profiles loaded.</p>';
+        cloneEl.innerHTML = '<option value="">empty (no clone)</option>';
+        return;
+    }
+
+    var rows = profileList.map(function(name) {
+        var isActive = (name === activeProfile);
+        var actions  = isActive
+            ? '<span class="profile-meta">Active</span>'
+            : '<button class="btn-sm btn-success" onclick="handleProfileSwitch(\'' + escapeJs(name) + '\')">Activate</button>' +
+              ' <button class="btn-sm" style="background:#dc3545;color:white;" onclick="deleteProfile(\'' + escapeJs(name) + '\')">Delete</button>';
+        return '<div class="profile-row' + (isActive ? ' active' : '') + '">' +
+               '<span>' + escapeHtml(name) + '</span>' +
+               '<span class="profile-actions">' + actions + '</span>' +
+               '</div>';
+    }).join('');
+    listEl.innerHTML = rows;
+
+    var cloneOpts = '<option value="">empty (no clone)</option>' +
+        profileList.map(function(name) {
+            return '<option value="' + escapeHtml(name) + '">clone from ' + escapeHtml(name) + '</option>';
+        }).join('');
+    cloneEl.innerHTML = cloneOpts;
+}
+
+async function createProfile() {
+    var nameEl  = document.getElementById('newProfileName');
+    var cloneEl = document.getElementById('cloneFromProfile');
+    var name    = (nameEl.value || '').trim();
+    if (!name) { showBanner('manageProfileMsg', 'error', 'Enter a profile name'); return; }
+    var body = {name: name};
+    if (cloneEl.value) body.clone_from = cloneEl.value;
+    try {
+        var res = await fetch('/api/profiles', {
+            method:  'POST',
+            headers: {'X-Auth-Token': authToken, 'Content-Type': 'application/json'},
+            body:    JSON.stringify(body)
+        });
+        var data = await res.json();
+        if (!res.ok) {
+            showBanner('manageProfileMsg', 'error', data.error || 'Create failed');
+            return;
+        }
+        showBanner('manageProfileMsg', 'success', 'Profile "' + name + '" created');
+        nameEl.value = '';
+        await loadProfiles();
+    } catch (e) {
+        showBanner('manageProfileMsg', 'error', 'Error: ' + e.message);
+    }
+}
+
+async function deleteProfile(name) {
+    if (!confirm('Delete profile "' + name + '"? This cannot be undone.')) return;
+    try {
+        var res = await fetch('/api/profiles/' + encodeURIComponent(name), {
+            method:  'DELETE',
+            headers: {'X-Auth-Token': authToken}
+        });
+        var data = await res.json();
+        if (!res.ok) {
+            showBanner('manageProfileMsg', 'error', data.error || 'Delete failed');
+            return;
+        }
+        showBanner('manageProfileMsg', 'success', 'Profile "' + name + '" deleted');
+        await loadProfiles();
+    } catch (e) {
+        showBanner('manageProfileMsg', 'error', 'Error: ' + e.message);
+    }
+}
+
+function escapeJs(s) { return String(s).replace(/'/g, "\\'"); }
 
 function populateModeSelector(cfg) {
     var current = (cfg && cfg.settings && cfg.settings.enforcement_mode) || 'hosts';
@@ -1247,6 +1529,17 @@ async function loadStatus() {
         if (manageUnlocked) renderManagePause(data);
 
         renderPomodoroPanel(data.pomodoro || null);
+
+        // Profile dropdown — refresh active profile, disable during work-phase lock.
+        if (data.active_profile && data.active_profile !== activeProfile) {
+            activeProfile = data.active_profile;
+            renderProfileSwitcher();
+            renderManageProfiles();
+        }
+        setProfileSwitcherDisabled(
+            !!(data.pomodoro && data.pomodoro.locked),
+            'Profile switching is locked during a Pomodoro work session'
+        );
 
     } catch(e) {
         contentEl.innerHTML = '<div class="banner error">Error: ' + e.message + '</div>';


### PR DESCRIPTION
## Summary

Closes #50. Sentinel now supports **named configuration profiles** — pre-saved sets of blocking rules a user can flip between via the dashboard or `sudo sentinel --set-profile <name>`. Settings, the shared groups dictionary, and pause/Pomodoro state stay common across profiles, so a switch only swaps the schedule.

The feature shipped as six independently-reviewed commits, each ticking one box on issue #50's tracker comment. Squash-merge will collapse them; the per-group commit messages contain the design rationale if you want to read it commit-by-commit before merging.

## What changed

**Storage (commit `955f0e2`).** Disk layout split:
```
$CONFIG_DIR/
├── sentinel.json              # settings, groups, pause, pomodoro, auth_token, active_profile
└── profiles/
    ├── default.json           # rules only
    └── <name>.json
```
- `LoadConfig` / `SaveConfig` merge / split between the two files; the in-memory `Config` struct is unchanged so the scheduler, proxy, and enforcer don't see the refactor.
- Legacy `config.json` deployments migrate transparently on first boot — split into the new files, original renamed to `config.json.bak`. Idempotent.
- Atomic write (CreateTemp + Rename) on both files so the per-tick reader never sees a truncated write.
- New public API: `ListProfiles`, `ProfileExists`, `CreateProfile(name, cloneFrom)`, `DeleteProfile`, `SwitchProfile`, `ReplaceFullConfig`, `ActiveProfile`, `ValidateProfileName`.
- Profile names: `^[a-z0-9][a-z0-9_-]{0,31}$`; reserved: `sentinel`, `bootstrap`, `config`.

**Profile management API (commit `534ecb5`).**
- `GET    /api/profiles` → `{ "active": "...", "profiles": ["default", ...] }`
- `POST   /api/profiles` body `{name, clone_from?}` → 201 / 400 / 409
- `DELETE /api/profiles/{name}` → 200 / 400 / 404 / 409 (active-profile guard, default permanently undeletable)
- `POST   /api/profile/switch` body `{name}` → 200 / 400 / 423 (Pomodoro work-phase locks switching, mirroring `/api/pomodoro` DELETE and `/api/config/update`)
- `/api/status` now includes `active_profile`.
- Routes registered in both `StartWebServer` and `StartTestWebServer` so `--test-web` exercises the full surface.

**CLI (commit `37c9021`).**
- `sudo sentinel --set-profile <name>` — load → switch → save → exit; daemon picks up within 60 s on the next scheduler tick (no IPC, file-based propagation, identical to `--set-mode`). Fails fast and lists available profiles on bad name.
- `sudo sentinel --list-profiles` — prints names with `*` next to the active one.

**Dashboard UI (commit `0e9d744`).**
- Profile dropdown lives in the header (visible across all tabs); change handler POSTs to `/api/profile/switch`, shows a toast (`Switched to <name> — applies within 60s`), refreshes status.
- Dropdown auto-disabled while a Pomodoro work session is active — same affordance as the Pause button.
- Manage tab gets a Profiles section (gated by `manageUnlocked`): list with Activate / Delete buttons, Create form with name input + optional clone-from dropdown.
- Status tab gets a `⚑ Profile: <name>` badge under the enforcement-mode badge.

**Documentation (commit `84ae866`).**
- README — new Profiles section + ToC entry + CLI-flag table additions; Configuration table + example config rewritten to show the bootstrap + profile split.
- DESIGN.md — data-flow diagram, web-server endpoint inventory, §8 file-location table, new "Profiles" + "Legacy migration" subsections; the in-memory `Config` schema callout now flags it as the merged shape.
- `docs/index.html` — new "Named profiles" feature card and a FAQ entry on different rules for work vs. weekend.
- TROUBLESHOOTING — entries for active-profile-missing self-heal, invalid-name regex, active-profile-delete 409, pre-profiles rollback recipe; inline path/file references updated where the field lives in the bootstrap.
- Session-log entry intentionally not in this commit; per project convention it lands on PR merge once we know the release tag.

## Why this design

User direction was **shared groups across profiles** — most users want different schedules, not different domain dictionaries. Splitting the bootstrap from per-profile files makes that natural: groups stay in one place, profiles are tiny ($\\approx$ rules-only), and a profile switch is a one-field write to the bootstrap (`active_profile`). Pause and Pomodoro stay bootstrap-level on purpose: switching profiles mid-Pomodoro must not break the work-phase lock, and an active pause should outlive a profile change.

Auth token also stays in the bootstrap so a profile switch never invalidates the dashboard's stored credentials.

## Gotchas / things to look at during review

- **`UpdateConfigHandler` lost its direct `os.WriteFile`.** The legacy code path used `config.GetConfigFilePath()` to write the merged config to one file; the new code routes through `config.ReplaceFullConfig` which preserves the auth token, splits across bootstrap + active profile, and reloads. Public `GetConfigFilePath` is gone (replaced by `EnsureConfigDir` for callers that just need the dir to exist).
- **`setWorkPhase` / `setBreakPhase` test helpers were rewritten.** They previously relied on `json.Unmarshal` leaving `Pomodoro` untouched when the disk file didn't have it — a quirk of the old single-file load path. The new helpers `LoadConfig` first to bootstrap state cleanly, then mutate + `SaveConfig`, with a cleanup that `ClearPomodoro` + saves. This matches every other handler's flow and is robust to the new clean `AppConfig` assignment in `LoadConfig`.
- **Migration is one-shot.** If you've already upgraded once and want to roll back to the old binary, restore `config.json.bak` and delete `sentinel.json` + `profiles/`. The TROUBLESHOOTING.md "Migration from a pre-profiles install" section has the exact incantation.
- **CLI flags require root.** `--set-profile` and `--list-profiles` write/read the system bootstrap and require sudo on a service-installed machine, identical to `--set-mode`. There's no `--local` modifier today; for local-mode iteration, use `--test-web` instead.
- **No per-profile setting overrides.** A profile only carries rules; settings, groups, and runtime state are bootstrap-wide. To get profile-specific blocking, define a finer-grained group in the shared dictionary (e.g., `youtube_only` separate from `videos`). Profile-level group overrides could be added later if the need surfaces.
- **Default profile is permanently undeletable.** Pragmatic choice — it's the migration target and the auto-fallback when `active_profile` points at a missing file. Renaming isn't supported either; clone + switch + delete the old one is the workflow.

## Test plan

- [x] Full `go test ./...` green across all packages (config, web, scheduler, proxy, enforcer, pf, testcli, cleanup).
- [x] 21 new config-package unit tests — fresh install, legacy migration round-trip, auth-token preservation, missing-active-profile fallback, switch-round-trip, name validation including reserved names, list-sorted, create-clone, create-duplicate-error, delete-active-error, delete-inactive-ok.
- [x] 9 new web-handler tests — list, create-201, create-409, create-400, delete-409 active, delete-404 missing, switch-200, switch-423-locked-during-work-phase, switch-400-missing.
- [x] `make build-all` produces darwin-arm64, darwin-amd64, and windows-amd64 binaries cleanly.
- [x] End-to-end smoke against `--test-web` in a tempdir with a seeded legacy `config.json`: migration produces the expected layout + `config.json.bak`; create-with-clone, duplicate-409, invalid-name-400, reserved-name-400; switch reflected in `/api/status` `active_profile`; active-profile delete blocked with 409; Pomodoro work-phase blocks switch with 423 and the right error message; expired Pomodoro on disk → reload via `GET /api/config` → switch unlocks.

## Deferred / follow-up

- Session-log entry will be appended on merge (per CLAUDE.md convention).
- Per-profile setting / group overrides — only if a real need surfaces; none today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)