### PR TITLE
docs: fix hero section overflow on mobile; add favicon

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Sentinel — Your schedule. Enforced.">
   <meta property="og:description" content="OS-level productivity blocking for macOS and Windows. No extension to disable.">
   <meta property="og:type" content="website">
+  <link rel="icon" type="image/png" href="assets/img/logo2.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,7 @@
     <div class="glow-blob w-80 h-80 bg-indigo-500/10 bottom-24 -right-24"></div>
     <div class="glow-blob w-64 h-64 bg-sky-400/5 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
 
-    <div class="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-24 text-center">
+    <div class="relative w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-24 text-center">
       <!-- Logo -->
       <div class="flex justify-center mb-8">
         <img src="assets/img/logo2.png" alt="Sentinel" class="h-20 w-auto drop-shadow-[0_0_24px_rgba(56,189,248,0.3)]">
@@ -140,9 +140,9 @@
 
         <!-- macOS install one-liner -->
         <p class="text-xs text-slate-500">or install via Terminal on macOS:</p>
-        <div class="inline-flex items-center gap-3 bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-sm max-w-full">
+        <div class="flex items-center gap-3 bg-slate-900 border border-slate-700 rounded-xl px-4 py-3 text-sm w-full max-w-[40rem]">
           <span class="text-slate-500 shrink-0">$</span>
-          <code class="text-emerald-400 font-mono text-xs sm:text-sm truncate">curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh | sudo bash</code>
+          <code class="text-emerald-400 font-mono text-xs sm:text-sm flex-1 min-w-0 text-left truncate">curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh | sudo bash</code>
           <button x-data="{ copied: false }"
                   @click="navigator.clipboard.writeText('curl -fsSL https://github.com/vsangava/sentinel/releases/latest/download/install.sh | sudo bash'); copied = true; setTimeout(() => copied = false, 2000)"
                   class="shrink-0 text-slate-500 hover:text-slate-200 transition-colors ml-1"


### PR DESCRIPTION
## Summary

Two small fixes to `docs/index.html` (the public landing page) based on a mobile testing session:

1. **Hero section overflowing on narrow viewports.** The hero `<section>` uses `flex items-center` for vertical centering, which makes its child div content-sized rather than viewport-filling. Combined with the install one-liner using `inline-flex max-w-full` and a `<code class="truncate">` without `min-w-0`, the snippet's intrinsic min-content width (the full curl URL) propagated up the layout and pinned the hero's inner div at ~608px wide. On viewports below that, the section's `overflow-hidden` clipped content — the headline, badge, download CTA, and install snippet all appeared cut off on the right edge on mobile.
2. **Local `/favicon.ico` 404.** The page had no `<link rel="icon">`, so browsers fell back to `/favicon.ico`. GitHub Pages serves a default icon so it's invisible on the deployed site, but locally (e.g. `python -m http.server`) the 404 shows up in the request log.

## Changes

- `docs/index.html` hero inner div: `+ w-full` — makes the inner div fill the section width regardless of how flex sizes its child.
- `docs/index.html` install snippet (hero):
  - container: `inline-flex … max-w-full` → `flex w-full max-w-[40rem]`
  - code: `truncate` → `flex-1 min-w-0 text-left truncate` so the flex child can actually shrink below its content width and ellipsis the URL.
  - `max-w-[40rem]` (640px) matches the download section's effective max width (`max-w-2xl` parent at 672px minus `px-4` padding = 640px), so both install snippets now reduce in lockstep at every viewport.
- `docs/index.html` head: add `<link rel="icon" type="image/png" href="assets/img/logo2.png">` so the existing logo serves as the favicon.

## Gotchas / reviewer notes

- The fix targets a real-browser issue. Chrome headless ignores `--window-size` for the CSS viewport (always renders at ~500px CSS) so headless screenshots can't directly verify a 360px viewport — manual verification was done via the live page width math; please spot-check on a real phone or in Chrome DevTools device mode (iPhone SE, 360×640) to confirm the hero content fits without horizontal scroll.
- `max-w-[40rem]` is an arbitrary Tailwind value rather than a named token (`max-w-xl` = 576px, `max-w-2xl` = 672px — neither matches the download section's 640px effective width). Kept explicit to make the symmetry with the download snippet obvious.
- Favicon points at `logo2.png`, the only logo asset present. If a dedicated favicon (multi-size `.ico` or `.svg`) is added later, just update the `href`.
- No functional code changed — daemon, scheduler, enforcer, proxy untouched. Tests not affected.

## Test plan

- [ ] Open the landing page on a phone (or Chrome DevTools at 360×640): hero content fits, install snippet shows ellipsis instead of clipping.
- [ ] Resize browser from wide to narrow: hero install snippet width tracks the download-section install snippet at every breakpoint.
- [ ] Inspect browser network tab: favicon resolves to `assets/img/logo2.png`; no `/favicon.ico` 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)