### PR TITLE
docs: correct launchd plist path (LaunchDaemon, not LaunchAgent)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -869,7 +869,7 @@ Sentinel is **not** a security tool. It's a friction tool against your own futur
 
 ### macOS
 
-- Service framework: `launchd`. The `kardianos/service` library writes a plist to `~/Library/LaunchAgents/com.github.sentinel.plist` (or system equivalent depending on install context).
+- Service framework: `launchd`. Setup runs as root, so `kardianos/service` writes a system-wide LaunchDaemon plist to `/Library/LaunchDaemons/com.github.sentinel.plist`. With kardianos's defaults (`KeepAlive=true`), launchd starts the daemon at boot and respawns it on crash — meaning it's already running before any user logs in.
 - `osascript` is invoked as the console user (resolved via `stat -f %Su /dev/console`) so notifications appear in the user's UI session and AppleScript can talk to Chrome/Safari. Running `osascript` as root produces a notification nobody can see.
 - `networksetup` is the only supported way to set system DNS — there's no clean API.
 - `dscacheutil -flushcache` + `killall -HUP mDNSResponder` is the canonical cache-flush incantation. Both are needed.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -465,11 +465,11 @@ log show --predicate 'process == "sentinel"' --last 1h
 log show --predicate 'process == "sentinel"' --last 1h | grep -E "scheduler|hosts|dns"
 ```
 
-If the service was installed via `kardianos/service` defaults, the launchd plist is at `~/Library/LaunchAgents/com.github.sentinel.plist`:
+Setup runs as root, so `kardianos/service` installs a system-wide LaunchDaemon plist at `/Library/LaunchDaemons/com.github.sentinel.plist` (not a per-user LaunchAgent — the daemon needs to bind port 53 and modify `/etc/hosts`):
 
 ```bash
-cat ~/Library/LaunchAgents/com.github.sentinel.plist
-launchctl print system/com.github.sentinel
+sudo cat /Library/LaunchDaemons/com.github.sentinel.plist
+sudo launchctl print system/com.github.sentinel
 ```
 
 ### Windows
@@ -502,8 +502,8 @@ The normal happy path is `sudo ./sentinel install && sudo ./sentinel start`. If 
 ```bash
 sudo ./sentinel install
 # Verify on macOS:
-ls -la ~/Library/LaunchAgents/com.github.sentinel.plist
-launchctl list | grep sentinel
+sudo ls -la /Library/LaunchDaemons/com.github.sentinel.plist
+sudo launchctl list | grep sentinel
 ```
 
 ```bash
@@ -527,8 +527,8 @@ sudo ./sentinel stop
 ```bash
 sudo ./sentinel uninstall
 # Verify:
-ls ~/Library/LaunchAgents/com.github.sentinel.plist  # should be gone
-launchctl list | grep sentinel                       # should be empty
+sudo ls /Library/LaunchDaemons/com.github.sentinel.plist  # should be gone
+sudo launchctl list | grep sentinel                       # should be empty
 ```
 
 #### Restarting after a binary update
@@ -699,8 +699,8 @@ sudo ./sentinel install
 If `uninstall` claims it isn't installed, the plist is dangling:
 
 ```bash
-launchctl unload ~/Library/LaunchAgents/com.github.sentinel.plist
-rm ~/Library/LaunchAgents/com.github.sentinel.plist
+sudo launchctl unload /Library/LaunchDaemons/com.github.sentinel.plist
+sudo rm /Library/LaunchDaemons/com.github.sentinel.plist
 sudo ./sentinel install
 ```
 
@@ -715,7 +715,7 @@ If `stop` hangs or fails, force it:
 
 ```bash
 sudo pkill -f "sentinel"
-launchctl unload ~/Library/LaunchAgents/com.github.sentinel.plist
+sudo launchctl unload /Library/LaunchDaemons/com.github.sentinel.plist
 sudo ./sentinel uninstall
 ```
 


### PR DESCRIPTION
## Summary

- `DESIGN.md` and `TROUBLESHOOTING.md` claimed the launchd plist lives at `~/Library/LaunchAgents/com.github.sentinel.plist`. It doesn't. Setup runs as root (`cmd/app/main.go:170`), and `kardianos/service` with `UserService=false` (its default) installs to `/Library/LaunchDaemons/com.github.sentinel.plist` (`service_darwin.go:104–112`). That's why the same code block could write `cat ~/Library/LaunchAgents/...` on one line and `launchctl print system/com.github.sentinel` on the next — the launchctl command was always targeting the `system/` domain.
- Updated the path everywhere it appeared (DESIGN.md §15, TROUBLESHOOTING.md §5 / §6 / §13) and added `sudo` where `/Library/LaunchDaemons` requires it.
- Surfaced in #56's review: the LaunchDaemon lifecycle (boot-time start, `KeepAlive=true`) is also what made that issue's "startup notification" proposal infeasible, so DESIGN.md §15 now spells out that the daemon is already running before any user logs in.

## Gotchas

- Docs only — no code, no tests, no behaviour change.
- `launchctl unload` is still listed (rather than the newer `bootout`) to keep parity with the rest of the doc, which leans on `unload`/`load` throughout. Worth a separate sweep if we want to modernize.

## Test plan

- [x] `grep -n LaunchAgents TROUBLESHOOTING.md DESIGN.md README.md` returns no matches.
- [ ] Reviewer spot-checks the diff reads cleanly in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)