### PR TITLE
refactor(scheduler): extract ForegroundProbe interface (#94)

### DIFF
--- a/internal/scheduler/foreground.go
+++ b/internal/scheduler/foreground.go
@@ -33,13 +33,27 @@ var supportedForegroundBrowsers = []string{
 
 // ForegroundProbeResult is the parsed output of one probe invocation.
 //
-//   - App is the macOS frontmost application name (e.g. "Google Chrome").
-//   - URL is the active tab URL when App is a supported browser; "" otherwise.
+//   - App is the frontmost application name (e.g. "Google Chrome"). On
+//     Windows this is the supported-browser name we mapped the foreground
+//     process to, or "" if the foreground app isn't a tracked browser.
+//   - URL is the active tab URL/host when App is a supported browser; ""
+//     otherwise. May be a bare host (no scheme) on platforms that can't read
+//     the full URL — extractHost tolerates that.
 //   - IdleSeconds is how long the user has been idle (no keyboard/mouse input).
+//
+// The zero value (App == "") means "nothing to record this tick" — no GUI
+// session, non-browser frontmost, or an unsupported platform.
 type ForegroundProbeResult struct {
 	App         string
 	URL         string
 	IdleSeconds int
+}
+
+// ForegroundProbe is the per-tick foreground sampler. Each OS provides its own
+// implementation; tests substitute a stub. Probe returns the zero
+// ForegroundProbeResult (not an error) when there's nothing to record.
+type ForegroundProbe interface {
+	Probe() (ForegroundProbeResult, error)
 }
 
 // ForegroundProbeGenerator interface so tests can swap in a deterministic
@@ -115,14 +129,29 @@ func SetForegroundProbeGenerator(g ForegroundProbeGenerator) {
 	foregroundProbeGenerator = g
 }
 
-// runForegroundProbe is the production probe runner — executes the generated
-// AppleScript and returns its stdout. Replaceable in tests.
-var runForegroundProbe = func() (string, error) {
+// macOSForegroundProbe runs the generated AppleScript via osascript and parses
+// its stdout. On non-darwin it's a no-op (returns the zero result) so this
+// stays the package default until a platform-specific probe replaces it.
+type macOSForegroundProbe struct{}
+
+func (macOSForegroundProbe) Probe() (ForegroundProbeResult, error) {
 	if runtime.GOOS != "darwin" {
-		return "", nil
+		return ForegroundProbeResult{}, nil
 	}
-	return runOsaScriptCapture(foregroundProbeGenerator.GenerateForegroundProbeScript())
+	out, err := runOsaScriptCapture(foregroundProbeGenerator.GenerateForegroundProbeScript())
+	if err != nil {
+		return ForegroundProbeResult{}, err
+	}
+	if strings.TrimSpace(out) == "" {
+		// No GUI session (e.g. running headless): nothing to record.
+		return ForegroundProbeResult{}, nil
+	}
+	return parseForegroundProbeOutput(out)
 }
+
+// foregroundProbe is the active per-tick sampler. Replaceable in tests; a
+// later change wires in a Windows implementation behind build tags.
+var foregroundProbe ForegroundProbe = macOSForegroundProbe{}
 
 // parseForegroundProbeOutput parses the tab-separated probe output.
 // Trailing whitespace from AppleScript is tolerated; an empty/missing URL
@@ -215,30 +244,23 @@ func isSupportedBrowser(name string) bool {
 	return false
 }
 
-// recordForegroundTick is the per-tick gate: probe → parse → filter → emit one
-// usage event when every condition passes. Returns ok=false (no event to
-// append) on any miss, with no error logged — these are normal cases (no
-// browser frontmost, idle, off-list domain).
+// recordForegroundTick is the per-tick gate: probe → filter → emit one usage
+// event when every condition passes. Returns ok=false (no event to append) on
+// any miss, with no error logged — these are normal cases (no browser
+// frontmost, idle, off-list domain).
 //
 // groupLookup is the shared domain→group map already built each tick by the
 // scheduler; reusing it avoids walking cfg.Groups again here.
-func recordForegroundTick(t time.Time, cfg config.Config, runProbe func() (string, error), groupLookup map[string]string) (proxy.UsageEvent, bool, error) {
-	out, err := runProbe()
-	if err != nil {
-		return proxy.UsageEvent{}, false, err
-	}
-	if strings.TrimSpace(out) == "" {
-		// Non-darwin / no GUI session: probe is a no-op, no event to record.
-		return proxy.UsageEvent{}, false, nil
-	}
-
-	res, err := parseForegroundProbeOutput(out)
+func recordForegroundTick(t time.Time, cfg config.Config, probe ForegroundProbe, groupLookup map[string]string) (proxy.UsageEvent, bool, error) {
+	res, err := probe.Probe()
 	if err != nil {
 		return proxy.UsageEvent{}, false, err
 	}
 	if res.IdleSeconds >= foregroundIdleCutoffSeconds {
 		return proxy.UsageEvent{}, false, nil
 	}
+	// Zero-value result (App == "") and non-browser frontmost both land here:
+	// nothing to record.
 	if !isSupportedBrowser(res.App) {
 		return proxy.UsageEvent{}, false, nil
 	}

--- a/internal/scheduler/foreground_test.go
+++ b/internal/scheduler/foreground_test.go
@@ -10,14 +10,32 @@ import (
 	"github.com/vsangava/sentinel/internal/proxy"
 )
 
-// withForegroundProbeStub swaps runForegroundProbe with a stub that returns the
-// given output (and optional error). Restores the original on test cleanup so
-// parallel tests don't leak state into each other.
+// stubForegroundProbe implements ForegroundProbe from a raw probe-output string
+// so existing test fixtures (tab-separated "app\turl\tidle" lines) keep
+// working — and the parse path stays exercised through recordForegroundTick.
+type stubForegroundProbe struct {
+	out string
+	err error
+}
+
+func (s stubForegroundProbe) Probe() (ForegroundProbeResult, error) {
+	if s.err != nil {
+		return ForegroundProbeResult{}, s.err
+	}
+	if strings.TrimSpace(s.out) == "" {
+		return ForegroundProbeResult{}, nil
+	}
+	return parseForegroundProbeOutput(s.out)
+}
+
+// withForegroundProbeStub swaps the package foregroundProbe with a stub built
+// from the given output (and optional error). Restores the original on test
+// cleanup so parallel tests don't leak state into each other.
 func withForegroundProbeStub(t *testing.T, out string, runErr error) {
 	t.Helper()
-	orig := runForegroundProbe
-	runForegroundProbe = func() (string, error) { return out, runErr }
-	t.Cleanup(func() { runForegroundProbe = orig })
+	orig := foregroundProbe
+	foregroundProbe = stubForegroundProbe{out: out, err: runErr}
+	t.Cleanup(func() { foregroundProbe = orig })
 }
 
 // trackedCfg builds a minimal config covering the tracked-domain branches.
@@ -161,7 +179,7 @@ func TestRecordForegroundTick_HappyPath(t *testing.T) {
 	cfg := trackedCfg()
 	gl := BuildGroupLookup(cfg)
 
-	event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, gl)
+	event, ok, err := recordForegroundTick(now, cfg, foregroundProbe, gl)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -186,7 +204,7 @@ func TestRecordForegroundTick_IdleAboveCutoff(t *testing.T) {
 	withForegroundProbeStub(t, "Google Chrome\thttps://youtube.com\t120", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -199,7 +217,7 @@ func TestRecordForegroundTick_NonBrowserApp(t *testing.T) {
 	withForegroundProbeStub(t, "Slack\t\t0", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -212,7 +230,7 @@ func TestRecordForegroundTick_DomainNotInGroups(t *testing.T) {
 	withForegroundProbeStub(t, "Safari\thttps://example.com/article\t0", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -227,7 +245,7 @@ func TestRecordForegroundTick_DohDomainExcluded(t *testing.T) {
 	withForegroundProbeStub(t, "Google Chrome\thttps://dns.google/\t0", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -242,7 +260,7 @@ func TestRecordForegroundTick_EmptyProbeOutputIsNoOp(t *testing.T) {
 	withForegroundProbeStub(t, "", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Errorf("expected no error on empty probe output, got %v", err)
 	}
@@ -256,7 +274,7 @@ func TestRecordForegroundTick_ProbeError(t *testing.T) {
 	withForegroundProbeStub(t, "", stubErr)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err == nil {
 		t.Error("expected probe error to propagate")
 	}
@@ -270,7 +288,7 @@ func TestRecordForegroundTick_StripsWWW(t *testing.T) {
 	withForegroundProbeStub(t, "Google Chrome\thttps://www.youtube.com/\t0", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	event, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil || !ok {
 		t.Fatalf("expected event, got ok=%v err=%v", ok, err)
 	}
@@ -285,7 +303,7 @@ func TestRecordForegroundTick_BlankURLForBrowser(t *testing.T) {
 	withForegroundProbeStub(t, "Google Chrome\tchrome://newtab/\t0", nil)
 	now := time.Date(2026, 5, 6, 14, 30, 0, 0, time.UTC)
 	cfg := trackedCfg()
-	_, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, BuildGroupLookup(cfg))
+	_, ok, err := recordForegroundTick(now, cfg, foregroundProbe, BuildGroupLookup(cfg))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -557,7 +557,7 @@ func evaluateRules() {
 	// works under hosts/dns/strict alike, and is the only per-domain time signal
 	// available in hosts mode (no DNS proxy → no DNS-bucket usage events).
 	if cfg.Settings.EnableForegroundTracking {
-		event, ok, err := recordForegroundTick(now, cfg, runForegroundProbe, gl)
+		event, ok, err := recordForegroundTick(now, cfg, foregroundProbe, gl)
 		if err != nil {
 			log.Printf("scheduler: foreground probe: %v", err)
 		} else if ok {


### PR DESCRIPTION
## What

Introduces a `ForegroundProbe` interface (`Probe() (ForegroundProbeResult, error)`) in `internal/scheduler/foreground.go` and moves the "run the probe and parse its output" responsibility behind it. `macOSForegroundProbe` is the implementation (runs the AppleScript via `osascript`, parses stdout); on non-darwin it returns the zero `ForegroundProbeResult` — the same no-op behaviour as before.

- `recordForegroundTick` now takes a `ForegroundProbe` instead of a `func() (string, error)`, and no longer parses — it just filters and emits.
- The package-level `runForegroundProbe` func var is replaced by `var foregroundProbe ForegroundProbe = macOSForegroundProbe{}`.
- The test stub is now a `ForegroundProbe` that parses fixture strings via the existing `parseForegroundProbeOutput`, so every existing test fixture (`"Google Chrome\thttps://...\t0"`) and the parse-path coverage carry over unchanged.

## Why

Issue #94 wants a Windows foreground probe. The old shape entangled the probe runner, the AppleScript generator, and the parsing — all macOS-specific. This is the seam a Windows implementation plugs into. Part of #94 (Phase A); follow-up PRs add the Windows window-title probe and then the UIA address-bar probe.

## Gotchas

- **No behaviour change.** `make test` is green; `make build-all` cross-compiles clean (darwin arm64/amd64, windows amd64).
- The empty-stdout / no-GUI-session case (which `recordForegroundTick` used to detect by checking for empty output before parsing) now lives inside `macOSForegroundProbe.Probe()` — it returns the zero result rather than letting `parseForegroundProbeOutput("")` error.
- `ForegroundProbeResult{App: ""}` is the "nothing to record" sentinel; it falls through the existing `!isSupportedBrowser` gate, so no new branch was needed in `recordForegroundTick`.

## Test plan

- [x] `make test`
- [x] `make build-all`
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)