### PR TITLE
docs: correct macOS plist filename + launchctl label

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -926,7 +926,7 @@ Sentinel is **not** a security tool. It's a friction tool against your own futur
 
 ### macOS
 
-- Service framework: `launchd`. Setup runs as root, so `kardianos/service` writes a system-wide LaunchDaemon plist to `/Library/LaunchDaemons/com.github.sentinel.plist`. With kardianos's defaults (`KeepAlive=true`), launchd starts the daemon at boot and respawns it on crash — meaning it's already running before any user logs in.
+- Service framework: `launchd`. Setup runs as root, so `kardianos/service` writes a system-wide LaunchDaemon plist to `/Library/LaunchDaemons/Sentinel.plist` (label `Sentinel`, derived from `svcConfig.Name`). With kardianos's defaults (`KeepAlive=true`), launchd starts the daemon at boot and respawns it on crash — meaning it's already running before any user logs in.
 - `osascript` is invoked as the console user (resolved via `stat -f %Su /dev/console`) so notifications appear in the user's UI session and AppleScript can talk to Chrome/Safari. Running `osascript` as root produces a notification nobody can see.
 - `networksetup` is the only supported way to set system DNS — there's no clean API.
 - `dscacheutil -flushcache` + `killall -HUP mDNSResponder` is the canonical cache-flush incantation. Both are needed.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -478,11 +478,11 @@ log show --predicate 'process == "sentinel"' --last 1h
 log show --predicate 'process == "sentinel"' --last 1h | grep -E "scheduler|hosts|dns"
 ```
 
-Setup runs as root, so `kardianos/service` installs a system-wide LaunchDaemon plist at `/Library/LaunchDaemons/com.github.sentinel.plist` (not a per-user LaunchAgent — the daemon needs to bind port 53 and modify `/etc/hosts`):
+Setup runs as root, so `kardianos/service` installs a system-wide LaunchDaemon plist at `/Library/LaunchDaemons/Sentinel.plist` (not a per-user LaunchAgent — the daemon needs to bind port 53 and modify `/etc/hosts`):
 
 ```bash
-sudo cat /Library/LaunchDaemons/com.github.sentinel.plist
-sudo launchctl print system/com.github.sentinel
+sudo cat /Library/LaunchDaemons/Sentinel.plist
+sudo launchctl print system/Sentinel
 ```
 
 ### Windows
@@ -515,7 +515,7 @@ The normal happy path is `sudo ./sentinel install && sudo ./sentinel start`. If 
 ```bash
 sudo ./sentinel install
 # Verify on macOS:
-sudo ls -la /Library/LaunchDaemons/com.github.sentinel.plist
+sudo ls -la /Library/LaunchDaemons/Sentinel.plist
 sudo launchctl list | grep sentinel
 ```
 
@@ -540,7 +540,7 @@ sudo ./sentinel stop
 ```bash
 sudo ./sentinel uninstall
 # Verify:
-sudo ls /Library/LaunchDaemons/com.github.sentinel.plist  # should be gone
+sudo ls /Library/LaunchDaemons/Sentinel.plist  # should be gone
 sudo launchctl list | grep sentinel                       # should be empty
 ```
 
@@ -712,8 +712,8 @@ sudo ./sentinel install
 If `uninstall` claims it isn't installed, the plist is dangling:
 
 ```bash
-sudo launchctl unload /Library/LaunchDaemons/com.github.sentinel.plist
-sudo rm /Library/LaunchDaemons/com.github.sentinel.plist
+sudo launchctl unload /Library/LaunchDaemons/Sentinel.plist
+sudo rm /Library/LaunchDaemons/Sentinel.plist
 sudo ./sentinel install
 ```
 
@@ -728,7 +728,7 @@ If `stop` hangs or fails, force it:
 
 ```bash
 sudo pkill -f "sentinel"
-sudo launchctl unload /Library/LaunchDaemons/com.github.sentinel.plist
+sudo launchctl unload /Library/LaunchDaemons/Sentinel.plist
 sudo ./sentinel uninstall
 ```
 


### PR DESCRIPTION
The macOS test harness from [#124](https://github.com/vsangava/sentinel/issues/124) ([PR #126](https://github.com/vsangava/sentinel/pull/126)) running on a real \`macos-latest\` runner revealed that TROUBLESHOOTING.md and DESIGN.md have been wrong about the launchd plist path for a while.

## Discrepancy

Docs claim:
\`\`\`
/Library/LaunchDaemons/com.github.sentinel.plist
sudo launchctl print system/com.github.sentinel
\`\`\`

Actual on a real install:
\`\`\`
/Library/LaunchDaemons/Sentinel.plist
sudo launchctl print system/Sentinel
\`\`\`

The CI run output confirms it:
\`\`\`
[OK] plist: /Library/LaunchDaemons/Sentinel.plist
plist Program: /usr/local/bin/sentinel
    path = /Library/LaunchDaemons/Sentinel.plist
    program = /usr/local/bin/sentinel
\`\`\`

## Why this happened

\`kardianos/service\` derives the plist filename (and the launchctl label) directly from \`svcConfig.Name\` — no reverse-domain prefix is prepended. In \`cmd/app/main.go\`:

\`\`\`go
var svcConfig = &service.Config{
    Name:        \"Sentinel\",
    DisplayName: \"Sentinel DNS Proxy\",
    ...
}
\`\`\`

→ plist filename = \`Sentinel.plist\`, label = \`Sentinel\`.

The \`com.github.sentinel\` form was probably a holdover from an earlier rename pass or copy-pasted from a different project's convention.

## Changes

- \`TROUBLESHOOTING.md\` — 8 path references + 1 \`launchctl print\` invocation corrected
- \`DESIGN.md\` — macOS bullet in §15 corrected, and the new wording calls out that the label is derived from \`svcConfig.Name\` so future readers know where it comes from

\`session-log.md\` still contains the old names in historical entries (the May 10 and May 15 sessions both reference them) — those are intentionally not edited, since they're time-stamped records of what was claimed at the time. The future-tense docs are authoritative going forward.

## Test plan

- [x] \`grep -rn 'com\\.github\\.sentinel' --include='*.md' --include='*.html' --include='*.go' --include='*.yml'\` returns no matches outside session-log.md.
- [ ] After merge, re-run the macOS test harness to confirm no docs-derived commands in the workflow stop working (none reference the old form — the harness already globs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)