### PR TITLE
ci(release): auto-generate release notes (no more empty release bodies)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,67 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
+  # ---------------------------------------------------------------------------
+  # Create the GitHub release first, with auto-generated notes.
+  #
+  # Why a dedicated job rather than letting softprops create the release
+  # opportunistically inside the matrix:
+  #   - softprops/action-gh-release does not read the annotated tag message,
+  #     and without `generate_release_notes: true` it ships an empty body.
+  #     v0.2.0 and v0.3.0 both went out with empty notes for this reason
+  #     (the body was filled in by hand post-release).
+  #   - The matrix below runs 3 build jobs in parallel + 1 install.sh job.
+  #     If notes generation ran inside the matrix, racing calls would
+  #     overwrite each other's body — same shape of bug as today.
+  #
+  # Solution: one job, ahead of the matrix, that creates the release with
+  # `gh release create --generate-notes`. The flag uses GitHub's built-in
+  # algorithm (the same one the "Generate release notes" button in the web
+  # UI uses) — produces a "What's Changed" section listing merged PRs and
+  # contributors since the previous tag.
+  #
+  # The matrix jobs then upload binaries to the already-existing release,
+  # so softprops never has to invent a body.
+  # ---------------------------------------------------------------------------
+  create-release:
+    name: Create release with auto-generated notes
+    runs-on: ubuntu-latest
+    outputs:
+      release_url: ${{ steps.release.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # --generate-notes needs prior tags to diff against
+
+      - name: Create or update release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: if the release already exists (e.g. a workflow re-run
+          # on the same tag), don't recreate it — just print the URL.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; skipping creation."
+            url=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json url -q .url)
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --generate-notes \
+              --verify-tag
+            url=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json url -q .url)
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Release URL: $url"
+
   build:
-    name: Build and Release
-    permissions:
-      contents: write
+    name: Build and upload binary
+    needs: create-release
     strategy:
       matrix:
         include:
@@ -30,7 +86,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -49,7 +105,7 @@ jobs:
         run: go test ./...
 
       - name: Upload Binary to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ matrix.output_name }}
         env:
@@ -57,14 +113,13 @@ jobs:
 
   release-installer:
     name: Attach install.sh to Release
-    permissions:
-      contents: write
+    needs: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Upload install.sh to Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: install.sh
         env:


### PR DESCRIPTION
v0.2.0 and v0.3.0 both shipped with empty release notes — I had to fill them in by hand right after each tag was pushed. This makes the workflow do it automatically.

## Root cause

\`\`\`yaml
# old: opportunistic release creation as a side effect of binary upload
- name: Upload Binary to Release
  uses: softprops/action-gh-release@v1
  with:
    files: \${{ matrix.output_name }}
\`\`\`

Two compounding issues:

1. **softprops doesn't read the annotated tag message.** \`git tag -a v0.3.0 -m \"…\"\` stores the message as git metadata; softprops creates the release with an empty body unless you pass it one explicitly.
2. **No \`generate_release_notes: true\` flag.** GitHub has a built-in notes generator — the same one the \"Generate release notes\" button uses in the web UI — but the workflow doesn't ask for it.
3. **Race risk if I'd just bolted it on.** The matrix runs 3 build jobs in parallel + 1 install.sh job. With \`generate_release_notes\` on each call, whichever finishes last would overwrite the body — same shape of bug as today.

## Fix

Split release creation off into a dedicated \`create-release\` job that runs first:

\`\`\`yaml
- name: Create or update release
  env:
    GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
    TAG: \${{ github.ref_name }}
  run: |
    if gh release view \"\$TAG\" --repo \"\$GITHUB_REPOSITORY\" >/dev/null 2>&1; then
      echo \"Release \$TAG already exists; skipping creation.\"
    else
      gh release create \"\$TAG\" \\
        --repo \"\$GITHUB_REPOSITORY\" \\
        --title \"\$TAG\" \\
        --generate-notes \\
        --verify-tag
    fi
\`\`\`

The matrix build jobs are now blocked by \`needs: create-release\`, so by the time they run softprops finds an existing release and just uploads its binary — no body-overwrite race.

## Properties

- **Auto-generated body**: GitHub's algorithm diffs from the previous tag, lists every merged PR with author, and groups by label if you use them. Same output as clicking \"Generate release notes\" in the web UI.
- **Idempotent**: re-running the workflow on the same tag (e.g. after a transient runner failure) detects the existing release and skips creation rather than erroring out.
- **\`--verify-tag\`**: the create step refuses to run if the tag doesn't actually exist on the repo, so a typo in \`ref_name\` fails loud instead of creating a release pointing at nothing.
- **Manual override still works**: \`gh release edit v0.x.x --notes ...\` still works for major releases where you want curated copy on top of (or instead of) the auto-generated list.

## Drive-by

Bumped \`actions/checkout@v3\` → \`@v4\` and \`softprops/action-gh-release@v1\` → \`@v2\` in the release-related steps. Both fix the Node 20 deprecation warning the runners have been annotating since GitHub announced the September 2026 removal. Kept the bump scoped to this workflow only.

## Test plan

- [x] \`actionlint\` clean.
- [ ] Next release (v0.3.1 or v0.4.0, whenever) should arrive with non-empty notes automatically. The v0.3.0 release is already fine — no re-trigger needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)