### PR TITLE
fix(install): use bare `setup` subcommand instead of `--setup`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,6 @@ xattr -d com.apple.quarantine "$TMP" 2>/dev/null || true
 chmod +x "$TMP"
 
 echo "Installing..."
-sudo "$TMP" --setup
+sudo "$TMP" setup
 
 rm -f "$TMP"


### PR DESCRIPTION
## Summary
- The shipped `install.sh` invokes `sudo "$TMP" --setup`, but `cmd/app/main.go:365` only matches the bare `setup` subcommand.
- With the flag form, the binary falls through every subcommand handler and lands at the generic `service.Control(s, os.Args[1])` at `cmd/app/main.go:511`, which is not a valid kardianos/service action.
- Result: `log.Fatalf` writes to stderr, exits 1, and the install appears silent on stdout — no binary at `/usr/local/bin/sentinel`, no launchd service registered.

## Why this matters
This has been broken since PR #36 (the "simplify install/uninstall" refactor). Anyone running the documented one-liner `curl -fsSL …/install.sh | sudo bash` against v0.3.0 (or anything since #36) got a silent no-op. The install.sh published as a release asset is what `releases/latest/download/install.sh` serves, so this needs a fresh release tag after merge to take effect on the public installer.

README, Makefile, and the macOS CI harness all use the correct bare `sentinel setup`, so install.sh was the only outlier.

## Test plan
- [x] grep confirms `--setup` no longer appears anywhere in the repo
- [x] All other invocations (README, Makefile, `.github/workflows/macos-test.yml`) already use bare `setup`
- [ ] Post-merge: tag `v0.3.1`, wait for release workflow, then `curl -fsSL …/v0.3.1/install.sh | sudo bash` on a clean machine and verify `/usr/local/bin/sentinel` exists and the service is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)