### PR TITLE
fix(install): use direct asset URL instead of API scraping

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,20 +14,12 @@ case "$ARCH" in
   *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
 esac
 
-echo "Fetching latest release info..."
-URL=$(curl -fsSL https://api.github.com/repos/vsangava/sentinel/releases/latest \
-  | grep browser_download_url \
-  | grep "\"$BINARY\"" \
-  | cut -d'"' -f4)
-
-if [[ -z "$URL" ]]; then
-  echo "Could not find a release asset for $BINARY. Check https://github.com/vsangava/sentinel/releases/latest"
-  exit 1
-fi
-
 echo "Downloading $BINARY..."
 TMP=$(mktemp)
-curl -fsSL -o "$TMP" "$URL"
+# GitHub's /releases/latest/download/<asset> redirects to the latest release's
+# asset URL — no API call, no JSON parsing, no rate-limit concerns. Use -fSL
+# (not -fsSL) so transfer errors and progress are visible if anything fails.
+curl -fSL -o "$TMP" "https://github.com/vsangava/sentinel/releases/latest/download/$BINARY"
 
 # Remove Gatekeeper quarantine flag (no-op if not set).
 xattr -d com.apple.quarantine "$TMP" 2>/dev/null || true


### PR DESCRIPTION
## Summary
The install.sh asset-URL pipeline has been broken since PR #36 — confirmed today by running it under `bash -x` against v0.3.1.

```bash
URL=$(curl ... /releases/latest \
  | grep browser_download_url \
  | grep "\"$BINARY\"" \
  | cut -d'"' -f4)
```

The second grep looks for `"sentinel-macos-arm64"` (quotes on **both** sides), but the JSON line is:

```
"browser_download_url": "https://.../sentinel-macos-arm64"
```

— the asset name has only a *trailing* quote, never a leading one. The grep matches nothing, `$URL` comes out empty, and `set -euo pipefail` kills the script silently **before** the `[[ -z "$URL" ]]` error check can run. The public installer has been a quiet no-op the entire v0.1.x–v0.3.1 line.

Secondary problem: even on the happy path the script hit the 60/hour unauthenticated GitHub API rate limit. Anyone running it after some `gh` activity could exhaust their limit and break their own install.

## Fix
Drop the API entirely. `https://github.com/<owner>/<repo>/releases/latest/download/<asset>` is a stable GitHub redirect to the latest release's asset — no auth, no rate limit, no JSON parsing. Also dropped `-s` from the binary download so transfer errors and progress are visible; silent-failure-by-default was the load-bearing reason this took two PRs to find.

## Why this comes after #129
PR #129 fixed `--setup` → `setup` in the same script. That fix is still correct — without it, even a successful download would have run `sudo "$TMP" --setup` and failed at the binary level. The two bugs compounded: the API bug fired first and killed the script before the `--setup` bug could surface. With this PR, both layers are now correct.

## Test plan
- [x] `bash -x install.sh` traces cleanly through download, chmod, xattr, and reaches `sudo "$TMP" setup` (only blocked by sudo's TTY requirement in a non-interactive shell)
- [x] `curl -fsI https://github.com/vsangava/sentinel/releases/latest/download/sentinel-macos-arm64` returns a 302 to the v0.3.1 asset
- [ ] Post-merge: tag `v0.3.2`, then `curl -fsSL …/v0.3.2/install.sh | sudo bash` end-to-end on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)